### PR TITLE
feat: 增强 builtin fetcher — robots.txt 合规 + 分页 + 大小保护

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,8 @@ souwen = "souwen.cli:app"
 tls = ["curl-cffi>=0.14.0"]
 # 网页内容抓取（trafilatura 提取 + Markdown 转换）
 web = ["trafilatura>=1.0"]
+# robots.txt 合规解析（builtin fetcher 可选启用）
+robots = ["protego>=0.3.0"]
 # Crawl4AI 无头浏览器抓取（基于 Playwright，适合 JS 重度页面）
 crawl4ai = ["crawl4ai>=0.4.0"]
 # newspaper4k 新闻文章提取（作者/日期/关键词/摘要）

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -17,3 +17,5 @@ fastapi>=0.111
 uvicorn[standard]>=0.29
 # MCP 集成
 mcp>=1.0
+# robots.txt 合规解析（builtin fetcher 可选启用）
+protego>=0.3.0

--- a/src/souwen/config.py
+++ b/src/souwen/config.py
@@ -254,6 +254,7 @@ class SouWenConfig(BaseModel):
     timeout: int = 30
     max_retries: int = 3
     data_dir: str = "~/.local/share/souwen"
+    respect_robots_txt: bool = False  # 是否遵守目标站点 robots.txt（builtin fetcher 使用）
 
     # ===== HTTP 后端 =====
     # 全局默认 HTTP 后端:auto(自动选择)| curl_cffi | httpx

--- a/src/souwen/models.py
+++ b/src/souwen/models.py
@@ -338,6 +338,8 @@ class FetchResult(BaseModel):
     title: str = ""
     content: str = ""  # 提取的正文（优先 markdown）
     content_format: Literal["markdown", "text", "html"] = "markdown"
+    content_truncated: bool = False  # 内容是否因 max_length 被截断
+    next_start_index: int | None = None  # 续读起点（仅在截断时设置）
     source: str = ""  # 提供者标识: jina_reader / tavily / firecrawl / exa / builtin
     snippet: str = ""  # 截断的摘要（前 500 字）
     published_date: str | None = None

--- a/src/souwen/web/builtin.py
+++ b/src/souwen/web/builtin.py
@@ -32,6 +32,7 @@
     - souwen.models: FetchResult, FetchResponse 数据模型
     - trafilatura（可选）: HTML 正文提取 + Markdown 转换
     - html2text（可选）: HTML→Markdown 回退方案
+    - protego（可选）: robots.txt 解析（启用 respect_robots_txt 时使用）
 """
 
 from __future__ import annotations
@@ -40,7 +41,7 @@ import asyncio
 import logging
 import re
 from typing import Any
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 from souwen.models import FetchResponse, FetchResult
 from souwen.scraper.base import BaseScraper
@@ -50,6 +51,7 @@ logger = logging.getLogger("souwen.web.builtin")
 # 可选依赖探测
 _HAS_TRAFILATURA = False
 _HAS_HTML2TEXT = False
+_HAS_PROTEGO = False
 
 try:
     import trafilatura  # noqa: F401
@@ -64,6 +66,17 @@ try:
     _HAS_HTML2TEXT = True
 except ImportError:
     pass
+
+try:
+    import protego  # noqa: F401
+
+    _HAS_PROTEGO = True
+except ImportError:
+    pass
+
+
+# robots.txt 校验使用的固定 User-Agent
+_ROBOTS_USER_AGENT = "SouWen/1.0 (+https://github.com/BlueSkyXN/SouWen)"
 
 
 _CJK_PATTERN = r"[\u4e00-\u9fff\u3400-\u4dbf\uf900-\ufaff\u3040-\u30ff\u31f0-\u31ff\uac00-\ud7af]"
@@ -203,17 +216,80 @@ class BuiltinFetcherClient(BaseScraper):
     ENGINE_NAME = "builtin_fetch"
     PROVIDER_NAME = "builtin"
     MAX_REDIRECTS = 5
+    MAX_RESPONSE_SIZE = 10 * 1024 * 1024  # 10 MiB 响应体大小上限，防 OOM
     _REDIRECT_CODES = frozenset({301, 302, 303, 307, 308})
 
-    def __init__(self) -> None:
+    def __init__(self, respect_robots_txt: bool = False) -> None:
         super().__init__(
             min_delay=0,
             max_delay=0.3,
             max_retries=2,
             follow_redirects=False,
         )
+        self.respect_robots_txt = respect_robots_txt
+        # robots.txt 缓存：{ "scheme://host[:port]": Protego | None }
+        # None 表示该域 robots.txt 拉取失败 / 不存在 → 视为允许
+        self._robots_cache: dict[str, Any] = {}
 
-    async def fetch(self, url: str, timeout: float = 30.0) -> FetchResult:
+    async def _check_robots(self, url: str) -> tuple[bool, str]:
+        """检查目标 URL 是否被该域的 robots.txt 允许
+
+        若 protego 未安装或抓取 robots.txt 失败，按"允许"处理（fail-open）。
+        缓存按 scheme+netloc 维度，避免针对同域多 URL 重复抓取。
+
+        Args:
+            url: 待检查的 URL
+
+        Returns:
+            (allowed, reason)：allowed=False 时 reason 给出拒绝原因
+        """
+        if not self.respect_robots_txt:
+            return True, ""
+        if not _HAS_PROTEGO:
+            logger.debug("protego 未安装，跳过 robots.txt 检查")
+            return True, ""
+
+        parsed = urlparse(url)
+        if not parsed.scheme or not parsed.netloc:
+            return True, ""
+        origin = f"{parsed.scheme}://{parsed.netloc}"
+
+        if origin not in self._robots_cache:
+            robots_url = f"{origin}/robots.txt"
+            try:
+                resp = await self._fetch(robots_url, headers={"User-Agent": _ROBOTS_USER_AGENT})
+                if 200 <= resp.status_code < 300 and resp.text:
+                    from protego import Protego
+
+                    self._robots_cache[origin] = Protego.parse(resp.text)
+                else:
+                    self._robots_cache[origin] = None
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("robots.txt 抓取失败 %s: %s", robots_url, exc)
+                self._robots_cache[origin] = None
+
+        parser = self._robots_cache.get(origin)
+        if parser is None:
+            return True, ""
+
+        try:
+            allowed = parser.can_fetch(url, _ROBOTS_USER_AGENT)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("robots.txt 解析异常 %s: %s", url, exc)
+            return True, ""
+
+        if not allowed:
+            return False, f"robots.txt 拒绝抓取（UA={_ROBOTS_USER_AGENT}）"
+        return True, ""
+
+    async def fetch(
+        self,
+        url: str,
+        timeout: float = 30.0,
+        start_index: int = 0,
+        max_length: int | None = None,
+        respect_robots_txt: bool | None = None,
+    ) -> FetchResult:
         """抓取单个 URL 的内容
 
         手动跟踪重定向并在每一跳校验 SSRF，防止攻击者通过 302 跳转
@@ -222,12 +298,42 @@ class BuiltinFetcherClient(BaseScraper):
         Args:
             url: 目标网页 URL
             timeout: 超时秒数（预留，实际由 BaseScraper 的重试机制控制）
+            start_index: 内容起始切片位置（用于分页续读）
+            max_length: 内容最大长度，超出则截断并设置 next_start_index
+            respect_robots_txt: 覆盖实例级 ``respect_robots_txt`` 设置（仅作用本次调用）
 
         Returns:
             FetchResult 包含提取的正文内容
         """
+        # 临时覆盖实例级配置
+        prev_robots = self.respect_robots_txt
+        if respect_robots_txt is not None:
+            self.respect_robots_txt = respect_robots_txt
+        try:
+            return await self._fetch_impl(url, start_index=start_index, max_length=max_length)
+        finally:
+            self.respect_robots_txt = prev_robots
+
+    async def _fetch_impl(
+        self,
+        url: str,
+        start_index: int = 0,
+        max_length: int | None = None,
+    ) -> FetchResult:
         try:
             from souwen.web.fetch import validate_fetch_url
+
+            # robots.txt 合规检查（在任何重定向 / 抓取之前）
+            allowed, reason = await self._check_robots(url)
+            if not allowed:
+                logger.info("robots.txt 拒绝: %s (%s)", url, reason)
+                return FetchResult(
+                    url=url,
+                    final_url=url,
+                    source=self.PROVIDER_NAME,
+                    error=reason,
+                    raw={"provider": "builtin", "blocked_by_robots": True},
+                )
 
             # 手动重定向循环 — 每一跳做 SSRF 校验
             current_url = url
@@ -276,7 +382,61 @@ class BuiltinFetcherClient(BaseScraper):
                 )
 
             final_url = current_url
+
+            # 大小保护一：响应头声明的 Content-Length
+            content_length_header = resp.headers.get("content-length") or resp.headers.get(
+                "Content-Length"
+            )
+            if content_length_header:
+                try:
+                    declared_size = int(content_length_header)
+                except (TypeError, ValueError):
+                    declared_size = -1
+                if declared_size > self.MAX_RESPONSE_SIZE:
+                    logger.warning(
+                        "拒绝超大响应 url=%s declared=%d max=%d",
+                        url,
+                        declared_size,
+                        self.MAX_RESPONSE_SIZE,
+                    )
+                    return FetchResult(
+                        url=url,
+                        final_url=final_url,
+                        source=self.PROVIDER_NAME,
+                        error=(
+                            f"响应体过大: Content-Length={declared_size} "
+                            f"> 上限 {self.MAX_RESPONSE_SIZE}"
+                        ),
+                        raw={
+                            "provider": "builtin",
+                            "status_code": resp.status_code,
+                            "content_length": declared_size,
+                            "oversized": True,
+                        },
+                    )
+
             html = resp.text
+
+            # 大小保护二：实际正文长度（防御 Content-Length 缺失或撒谎）
+            if html and len(html) > self.MAX_RESPONSE_SIZE:
+                logger.warning(
+                    "拒绝超大响应 url=%s actual=%d max=%d",
+                    url,
+                    len(html),
+                    self.MAX_RESPONSE_SIZE,
+                )
+                return FetchResult(
+                    url=url,
+                    final_url=final_url,
+                    source=self.PROVIDER_NAME,
+                    error=(f"响应体过大: 实际 {len(html)} 字节 > 上限 {self.MAX_RESPONSE_SIZE}"),
+                    raw={
+                        "provider": "builtin",
+                        "status_code": resp.status_code,
+                        "content_length": len(html),
+                        "oversized": True,
+                    },
+                )
 
             if not html or len(html.strip()) < 100:
                 return FetchResult(
@@ -291,7 +451,7 @@ class BuiltinFetcherClient(BaseScraper):
             extracted = _extract_with_trafilatura(html, url)
             content = extracted["content"]
 
-            # 更好的内容验证：检查长度和词数
+            # 更好的内容验证：检查长度和词数（基于完整提取结果）
             MIN_CONTENT_LENGTH = 50
             MIN_WORD_COUNT = 10
             word_count = _count_words(content) if content else 0
@@ -310,14 +470,34 @@ class BuiltinFetcherClient(BaseScraper):
                     },
                 )
 
-            snippet = content[:500] if content else ""
+            # 分页切片：start_index / max_length
+            full_length = len(content)
+            sliced = content
+            content_truncated = False
+            next_start_index: int | None = None
+
+            if start_index < 0:
+                start_index = 0
+            if start_index >= full_length and full_length > 0:
+                sliced = ""
+            elif start_index > 0:
+                sliced = content[start_index:]
+
+            if max_length is not None and max_length >= 0 and len(sliced) > max_length:
+                sliced = sliced[:max_length]
+                content_truncated = True
+                next_start_index = start_index + max_length
+
+            snippet = sliced[:500] if sliced else ""
 
             return FetchResult(
                 url=url,
                 final_url=final_url,
                 title=extracted["title"],
-                content=content,
+                content=sliced,
                 content_format=extracted["content_format"],
+                content_truncated=content_truncated,
+                next_start_index=next_start_index,
                 source=self.PROVIDER_NAME,
                 snippet=snippet,
                 published_date=extracted["date"],
@@ -326,7 +506,10 @@ class BuiltinFetcherClient(BaseScraper):
                     "provider": "builtin",
                     "status_code": resp.status_code,
                     "content_length": len(html),
-                    "extracted_length": len(content),
+                    "extracted_length": full_length,
+                    "returned_length": len(sliced),
+                    "start_index": start_index,
+                    "max_length": max_length,
                     "word_count": word_count,
                     "description": extracted.get("description"),
                     "sitename": extracted.get("sitename"),

--- a/tests/test_web/test_builtin.py
+++ b/tests/test_web/test_builtin.py
@@ -380,3 +380,290 @@ class TestSSRFRedirectProtection:
         assert result.error is not None
         assert "SSRF" in result.error
         assert "10.0.0.1" in result.final_url
+
+
+_has_protego = False
+try:
+    import protego  # noqa: F401
+
+    _has_protego = True
+except ImportError:
+    pass
+
+requires_protego = pytest.mark.skipif(not _has_protego, reason="protego not installed")
+
+
+def _ok_html() -> str:
+    """生成一段足以通过最小内容校验的 HTML。"""
+    return (
+        "<html><head><title>P</title></head><body><article><p>"
+        + ("Pagination test content. " * 40)
+        + "</p></article></body></html>"
+    )
+
+
+class TestPagination:
+    """start_index / max_length 分页"""
+
+    @pytest.mark.asyncio
+    async def test_no_pagination_returns_full_content(self):
+        mock_resp = MagicMock()
+        mock_resp.text = _ok_html()
+        mock_resp.status_code = 200
+        mock_resp.headers = {}
+        mock_resp.url = "https://example.com/p"
+
+        with patch.object(BuiltinFetcherClient, "_fetch", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = mock_resp
+            async with BuiltinFetcherClient() as client:
+                result = await client.fetch("https://example.com/p")
+
+        assert result.error is None
+        assert result.content_truncated is False
+        assert result.next_start_index is None
+        assert len(result.content) > 0
+
+    @pytest.mark.asyncio
+    async def test_max_length_truncates_and_sets_next(self):
+        mock_resp = MagicMock()
+        mock_resp.text = _ok_html()
+        mock_resp.status_code = 200
+        mock_resp.headers = {}
+        mock_resp.url = "https://example.com/p"
+
+        with patch.object(BuiltinFetcherClient, "_fetch", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = mock_resp
+            async with BuiltinFetcherClient() as client:
+                full = await client.fetch("https://example.com/p")
+                truncated = await client.fetch("https://example.com/p", max_length=100)
+
+        assert truncated.error is None
+        assert truncated.content_truncated is True
+        assert truncated.next_start_index == 100
+        assert len(truncated.content) == 100
+        # snippet 来自切片后的内容，长度不超过 max_length
+        assert len(truncated.snippet) <= 100
+        # 切片是完整内容的前缀
+        assert full.content.startswith(truncated.content)
+
+    @pytest.mark.asyncio
+    async def test_start_index_slices_content(self):
+        mock_resp = MagicMock()
+        mock_resp.text = _ok_html()
+        mock_resp.status_code = 200
+        mock_resp.headers = {}
+        mock_resp.url = "https://example.com/p"
+
+        with patch.object(BuiltinFetcherClient, "_fetch", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = mock_resp
+            async with BuiltinFetcherClient() as client:
+                full = await client.fetch("https://example.com/p")
+                offset = await client.fetch("https://example.com/p", start_index=50)
+
+        assert offset.error is None
+        assert offset.content == full.content[50:]
+        # 未给 max_length 不应标记截断
+        assert offset.content_truncated is False
+        assert offset.next_start_index is None
+
+    @pytest.mark.asyncio
+    async def test_start_index_plus_max_length(self):
+        mock_resp = MagicMock()
+        mock_resp.text = _ok_html()
+        mock_resp.status_code = 200
+        mock_resp.headers = {}
+        mock_resp.url = "https://example.com/p"
+
+        with patch.object(BuiltinFetcherClient, "_fetch", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = mock_resp
+            async with BuiltinFetcherClient() as client:
+                page = await client.fetch("https://example.com/p", start_index=20, max_length=80)
+
+        assert page.error is None
+        assert len(page.content) == 80
+        assert page.content_truncated is True
+        assert page.next_start_index == 100
+
+
+class TestMaxResponseSize:
+    """MAX_RESPONSE_SIZE 防 OOM 保护"""
+
+    @pytest.mark.asyncio
+    async def test_oversized_content_length_header_rejected(self):
+        big = BuiltinFetcherClient.MAX_RESPONSE_SIZE + 1
+        mock_resp = MagicMock()
+        mock_resp.text = ""
+        mock_resp.status_code = 200
+        mock_resp.headers = {"content-length": str(big)}
+        mock_resp.url = "https://example.com/big"
+
+        with patch.object(BuiltinFetcherClient, "_fetch", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = mock_resp
+            async with BuiltinFetcherClient() as client:
+                result = await client.fetch("https://example.com/big")
+
+        assert result.error is not None
+        assert "过大" in result.error
+        assert result.raw.get("oversized") is True
+
+    @pytest.mark.asyncio
+    async def test_oversized_actual_body_rejected(self):
+        body = "x" * (BuiltinFetcherClient.MAX_RESPONSE_SIZE + 10)
+        mock_resp = MagicMock()
+        mock_resp.text = body
+        mock_resp.status_code = 200
+        mock_resp.headers = {}  # 没有 content-length
+        mock_resp.url = "https://example.com/big"
+
+        with patch.object(BuiltinFetcherClient, "_fetch", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = mock_resp
+            async with BuiltinFetcherClient() as client:
+                result = await client.fetch("https://example.com/big")
+
+        assert result.error is not None
+        assert "过大" in result.error
+        assert result.raw.get("oversized") is True
+
+    @pytest.mark.asyncio
+    async def test_normal_size_ok(self):
+        mock_resp = MagicMock()
+        mock_resp.text = _ok_html()
+        mock_resp.status_code = 200
+        mock_resp.headers = {"content-length": str(len(_ok_html()))}
+        mock_resp.url = "https://example.com/p"
+
+        with patch.object(BuiltinFetcherClient, "_fetch", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = mock_resp
+            async with BuiltinFetcherClient() as client:
+                result = await client.fetch("https://example.com/p")
+
+        assert result.error is None
+
+
+class TestRobotsTxt:
+    """robots.txt 可选合规"""
+
+    @pytest.mark.asyncio
+    async def test_disabled_by_default(self):
+        """默认不启用 → 不抓取 robots.txt，也不阻塞"""
+        mock_resp = MagicMock()
+        mock_resp.text = _ok_html()
+        mock_resp.status_code = 200
+        mock_resp.headers = {}
+        mock_resp.url = "https://example.com/p"
+
+        with patch.object(BuiltinFetcherClient, "_fetch", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = mock_resp
+            async with BuiltinFetcherClient() as client:
+                assert client.respect_robots_txt is False
+                result = await client.fetch("https://example.com/p")
+
+        assert result.error is None
+        # 仅一次抓取目标 URL，未额外请求 robots.txt
+        assert mock_fetch.call_count == 1
+
+    @requires_protego
+    @pytest.mark.asyncio
+    async def test_blocked_by_robots(self):
+        robots_resp = MagicMock()
+        robots_resp.text = "User-agent: *\nDisallow: /private/\n"
+        robots_resp.status_code = 200
+        robots_resp.headers = {}
+        robots_resp.url = "https://example.com/robots.txt"
+
+        with patch.object(BuiltinFetcherClient, "_fetch", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = robots_resp
+            async with BuiltinFetcherClient(respect_robots_txt=True) as client:
+                result = await client.fetch("https://example.com/private/secret")
+
+        assert result.error is not None
+        assert "robots.txt" in result.error
+        assert result.raw.get("blocked_by_robots") is True
+
+    @requires_protego
+    @pytest.mark.asyncio
+    async def test_allowed_by_robots(self):
+        robots_resp = MagicMock()
+        robots_resp.text = "User-agent: *\nDisallow: /private/\n"
+        robots_resp.status_code = 200
+        robots_resp.headers = {}
+        robots_resp.url = "https://example.com/robots.txt"
+
+        page_resp = MagicMock()
+        page_resp.text = _ok_html()
+        page_resp.status_code = 200
+        page_resp.headers = {}
+        page_resp.url = "https://example.com/public/p"
+
+        with patch.object(BuiltinFetcherClient, "_fetch", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.side_effect = [robots_resp, page_resp]
+            async with BuiltinFetcherClient(respect_robots_txt=True) as client:
+                result = await client.fetch("https://example.com/public/p")
+
+        assert result.error is None
+
+    @requires_protego
+    @pytest.mark.asyncio
+    async def test_robots_cached_per_domain(self):
+        """同域多 URL 只抓取一次 robots.txt"""
+        robots_resp = MagicMock()
+        robots_resp.text = "User-agent: *\nAllow: /\n"
+        robots_resp.status_code = 200
+        robots_resp.headers = {}
+        robots_resp.url = "https://example.com/robots.txt"
+
+        page_resp = MagicMock()
+        page_resp.text = _ok_html()
+        page_resp.status_code = 200
+        page_resp.headers = {}
+        page_resp.url = "https://example.com/x"
+
+        with patch.object(BuiltinFetcherClient, "_fetch", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.side_effect = [robots_resp, page_resp, page_resp]
+            async with BuiltinFetcherClient(respect_robots_txt=True) as client:
+                r1 = await client.fetch("https://example.com/a")
+                r2 = await client.fetch("https://example.com/b")
+
+        assert r1.error is None and r2.error is None
+        # 1 次 robots + 2 次正文 = 3 次
+        assert mock_fetch.call_count == 3
+
+    @requires_protego
+    @pytest.mark.asyncio
+    async def test_robots_fetch_failure_fail_open(self):
+        """robots.txt 抓取失败时按允许处理（fail-open）"""
+        page_resp = MagicMock()
+        page_resp.text = _ok_html()
+        page_resp.status_code = 200
+        page_resp.headers = {}
+        page_resp.url = "https://example.com/p"
+
+        async def side_effect(u, *args, **kwargs):
+            if u.endswith("/robots.txt"):
+                raise Exception("network down")
+            return page_resp
+
+        with patch.object(BuiltinFetcherClient, "_fetch", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.side_effect = side_effect
+            async with BuiltinFetcherClient(respect_robots_txt=True) as client:
+                result = await client.fetch("https://example.com/p")
+
+        assert result.error is None
+
+    @pytest.mark.asyncio
+    async def test_per_call_override(self):
+        """fetch() 的 respect_robots_txt 参数覆盖实例配置"""
+        mock_resp = MagicMock()
+        mock_resp.text = _ok_html()
+        mock_resp.status_code = 200
+        mock_resp.headers = {}
+        mock_resp.url = "https://example.com/p"
+
+        with patch.object(BuiltinFetcherClient, "_fetch", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = mock_resp
+            async with BuiltinFetcherClient(respect_robots_txt=False) as client:
+                result = await client.fetch("https://example.com/p", respect_robots_txt=False)
+                # 调用结束后实例配置应被还原
+                assert client.respect_robots_txt is False
+
+        assert result.error is None


### PR DESCRIPTION
## 概述

基于 MCP 参考 fetch 服务器对比分析结果，对 SouWen builtin fetcher 进行三项关键改进。

## 改进内容

### 1. robots.txt 可选合规 🤖

- 使用 `protego` 库解析 robots.txt（可选依赖）
- 新增配置项 `respect_robots_txt: bool = False`（默认关闭，不影响现有行为）
- 按域名缓存 robots.txt，避免重复请求
- User-Agent: `SouWen/1.0 (+https://github.com/BlueSkyXN/SouWen)`
- Fail-open 策略：protego 未安装或 robots.txt 获取失败时不阻断

### 2. start_index / max_length 分页 📄

- `fetch()` 新增 `start_index: int = 0` 和 `max_length: int | None = None` 参数
- `FetchResult` 新增字段：`content_truncated: bool` 和 `next_start_index: int | None`
- 内容切片后重新生成 snippet，确保一致性
- 适配 LLM 上下文窗口限制，支持大页面逐段读取

### 3. 最大响应大小保护 🛡️

- 新增 `MAX_RESPONSE_SIZE = 10 MiB` 常量
- 优先检查 Content-Length 头，超限直接拒绝（不读取 body）
- 兜底检查实际内容长度，双重防护
- 防止巨型页面导致 OOM 崩溃

## 修改文件

| 文件 | 变更 |
|------|------|
| `src/souwen/web/builtin.py` | 核心实现（robots 缓存、分页切片、大小检查） |
| `src/souwen/models.py` | FetchResult 新增 content_truncated / next_start_index |
| `src/souwen/config.py` | 新增 respect_robots_txt 配置项 |
| `pyproject.toml` | 新增 `[robots]` 可选依赖组 |
| `requirements-full.txt` | 添加 protego>=0.3.0 |
| `tests/test_web/test_builtin.py` | 新增 11 个测试（36 tests total） |

## 测试

- `pytest tests/test_web/test_builtin.py -v` → 36 passed ✅
- `ruff check` + `ruff format --check` → clean ✅
