### PR TITLE
feat: 增强 ArXiv 搜索 + Semantic Scholar 引用图谱 + 论文全文获取

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,8 @@ crawl4ai = ["crawl4ai>=0.4.0"]
 newspaper = ["newspaper4k>=0.9"]
 # readability 提取（Mozilla Readability 算法 + markdownify 转换）
 readability = ["readability-lxml>=0.8", "markdownify>=0.12"]
+# arXiv 全文 PDF 解析（PyMuPDF + Markdown 转换）
+pdf = ["pymupdf4llm>=0.0.17"]
 # 浏览器爬虫（Playwright）+ TLS 伪装
 scraper = ["playwright>=1.40", "curl-cffi>=0.14.0"]
 # Web 服务器（FastAPI + Uvicorn）

--- a/src/souwen/paper/__init__.py
+++ b/src/souwen/paper/__init__.py
@@ -5,6 +5,7 @@
 - SemanticScholarClient: Semantic Scholar (可选Key)
 - CrossrefClient: Crossref (无需Key)
 - ArxivClient: arXiv (无需Key)
+- ArxivFulltextClient: arXiv 论文全文（HTML 优先 + PDF 回退，无需 Key）
 - DblpClient: DBLP (无需Key)
 - CoreClient: CORE (需Key)
 - PubMedClient: PubMed (可选Key)
@@ -16,6 +17,7 @@ from souwen.paper.openalex import OpenAlexClient
 from souwen.paper.semantic_scholar import SemanticScholarClient
 from souwen.paper.crossref import CrossrefClient
 from souwen.paper.arxiv import ArxivClient
+from souwen.paper.arxiv_fulltext import ArxivFulltextClient
 from souwen.paper.dblp import DblpClient
 from souwen.paper.core import CoreClient
 from souwen.paper.pubmed import PubMedClient
@@ -27,6 +29,7 @@ __all__ = [
     "SemanticScholarClient",
     "CrossrefClient",
     "ArxivClient",
+    "ArxivFulltextClient",
     "DblpClient",
     "CoreClient",
     "PubMedClient",

--- a/src/souwen/paper/arxiv.py
+++ b/src/souwen/paper/arxiv.py
@@ -24,13 +24,25 @@
         - 输出：统一的 PaperResult 模型，包含标题、作者、PDF 链接、分类等
         - 关键变量：arxiv_id (str) arXiv 唯一标识符, categories (list[str]) 学科分类
 
+    _build_search_query(query: str, categories: list[str]|None, date_from: str|None,
+                        date_to: str|None) -> str
+        - 功能：组合用户查询、学科分类、提交日期范围，生成 arXiv 检索字符串
+        - 输入：query 原始查询；categories 分类列表（如 ["cs.AI", "cs.LG"]）；
+               date_from/date_to 日期 YYYY-MM-DD
+        - 输出：完整的 search_query 字符串，已按 arXiv 语法拼接
+
     search(query: str, id_list: list|None, start: int, max_results: int,
-           sort_by: str|None, sort_order: str|None) -> SearchResponse
-        - 功能：搜索 arXiv 论文或按 ID 列表查询
+           sort_by: str|None, sort_order: str|None,
+           categories: list[str]|None, date_from: str|None,
+           date_to: str|None) -> SearchResponse
+        - 功能：搜索 arXiv 论文或按 ID 列表查询，支持分类与日期范围过滤
         - 输入：query 检索查询（支持字段前缀如 ti:/au:）, id_list arXiv ID 列表,
-               start 起始偏移, max_results 返回条数（最多 2000）, sort_by/sort_order 排序参数
+               start 起始偏移, max_results 返回条数（最多 2000）, sort_by/sort_order 排序参数,
+               categories 学科分类过滤, date_from/date_to 提交日期范围过滤
         - 输出：SearchResponse 包含结果列表及分页信息
         - 限流：通过 _limiter.acquire() 控制每 3 秒最多 1 次请求
+        - 注意：含日期过滤时直接拼接 URL 字符串，避免 httpx 把 ``+TO+`` 编码为
+               ``%2BTO%2B``（arXiv 要求字面 ``+`` 字符）
 
 模块依赖：
     - SouWenHttpClient: 统一 HTTP 客户端
@@ -221,6 +233,37 @@ class ArxivClient:
     # 公开方法
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _build_search_query(
+        query: str,
+        categories: list[str] | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
+    ) -> str:
+        """组合查询、分类与日期，生成 arXiv ``search_query`` 字符串。
+
+        - 多个分类以 ``OR`` 连接，整体以 ``AND`` 拼接到原 query。
+        - 日期范围使用 ``submittedDate:[YYYYMMDD0000+TO+YYYYMMDD2359]`` 语法。
+          其中 ``+TO+`` 为字面 ``+`` 字符，调用方需绕过 URL 编码。
+        - 仅缺省 ``date_from`` 时使用 ``00000101``，仅缺省 ``date_to`` 时使用 ``99991231``。
+        """
+        parts: list[str] = []
+        if query:
+            # 含空格/括号时已由调用方控制是否加括号；此处只要存在原 query 就保留
+            parts.append(f"({query})" if (categories or date_from or date_to) and query else query)
+
+        if categories:
+            cat_clause = " OR ".join(f"cat:{c}" for c in categories)
+            parts.append(f"({cat_clause})")
+
+        if date_from or date_to:
+            start_compact = (date_from or "0000-01-01").replace("-", "") + "0000"
+            end_compact = (date_to or "9999-12-31").replace("-", "") + "2359"
+            # ``+TO+`` 使用字面 ``+``，外层调用方需通过手工拼接 URL 避免被编码
+            parts.append(f"submittedDate:[{start_compact}+TO+{end_compact}]")
+
+        return " AND ".join(parts)
+
     async def search(
         self,
         query: str,
@@ -229,6 +272,9 @@ class ArxivClient:
         max_results: int = 10,
         sort_by: str | None = None,
         sort_order: str | None = None,
+        categories: list[str] | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
     ) -> SearchResponse:
         """搜索 arXiv 论文。
 
@@ -241,27 +287,51 @@ class ArxivClient:
             sort_by: 排序字段: ``"relevance"``、``"lastUpdatedDate"``、
                      ``"submittedDate"``。
             sort_order: ``"ascending"`` 或 ``"descending"``。
+            categories: 学科分类过滤列表，如 ``["cs.AI", "cs.LG"]``，多个分类间以
+                        ``OR`` 连接后 ``AND`` 到原查询。
+            date_from: 起始日期 ``YYYY-MM-DD`` 格式（按 submittedDate 过滤）。
+            date_to: 结束日期 ``YYYY-MM-DD`` 格式。
 
         Returns:
             SearchResponse 包含结果列表及分页信息。
         """
         await self._limiter.acquire()
 
-        params: dict[str, str | int] = {
-            "start": start,
-            "max_results": min(max_results, 2000),
-        }
+        # 组合查询字符串：基础 query + 分类过滤 + 日期范围
+        effective_query = self._build_search_query(query, categories, date_from, date_to)
+        has_date_filter = bool(date_from or date_to)
 
-        if query:
-            params["search_query"] = query
-        if id_list:
-            params["id_list"] = ",".join(id_list)
-        if sort_by:
-            params["sortBy"] = sort_by
-        if sort_order:
-            params["sortOrder"] = sort_order
+        capped_max = min(max_results, 2000)
 
-        resp = await self._client.get("/query", params=params)
+        if has_date_filter:
+            # 日期过滤含 ``+TO+`` 字面 ``+``，httpx 会将 ``+`` URL 编码为 ``%2B``，
+            # 因此手工拼接 URL 字符串绕过 params 编码。其余参数仍按原样附加。
+            url_parts: list[str] = [f"search_query={effective_query}"]
+            if id_list:
+                url_parts.append(f"id_list={','.join(id_list)}")
+            url_parts.append(f"start={start}")
+            url_parts.append(f"max_results={capped_max}")
+            if sort_by:
+                url_parts.append(f"sortBy={sort_by}")
+            if sort_order:
+                url_parts.append(f"sortOrder={sort_order}")
+            full_url = "/query?" + "&".join(url_parts)
+            resp = await self._client.get(full_url)
+        else:
+            params: dict[str, str | int] = {
+                "start": start,
+                "max_results": capped_max,
+            }
+            if effective_query:
+                params["search_query"] = effective_query
+            if id_list:
+                params["id_list"] = ",".join(id_list)
+            if sort_by:
+                params["sortBy"] = sort_by
+            if sort_order:
+                params["sortOrder"] = sort_order
+            resp = await self._client.get("/query", params=params)
+
         xml_text = resp.text
 
         try:

--- a/src/souwen/paper/arxiv_fulltext.py
+++ b/src/souwen/paper/arxiv_fulltext.py
@@ -1,0 +1,206 @@
+"""arXiv 论文全文获取模块
+
+支持两种获取方式：
+1. HTML 版本（优先）：从 ``https://arxiv.org/html/{paper_id}`` 获取，
+   用 BeautifulSoup 提取纯文本（剥离 nav/header/footer/script/style）。
+2. PDF 回退：从 ``https://arxiv.org/pdf/{paper_id}`` 下载 PDF，
+   用 ``pymupdf4llm`` 转换为 Markdown（可选依赖，未安装则只返回原始字节大小提示）。
+
+文件用途：为 SouWen 提供论文全文获取能力，支持后续的全文分析和知识提取。
+
+函数/类清单：
+    ArxivFulltextClient（类，async context manager）
+        - 功能：HTML 优先 + PDF 回退的 arXiv 全文抓取
+        - 关键属性：_client (SouWenHttpClient), _limiter (TokenBucketLimiter,
+                   1 req / 3 sec，与 ArxivClient 同步)
+
+    get_fulltext(paper_id: str) -> FetchResult
+        - 功能：按 paper_id 获取论文全文
+        - 输入：paper_id 形如 ``2301.00001`` 或带版本号 ``2301.00001v2``
+        - 输出：FetchResult，content 字段为 Markdown 或纯文本
+
+模块依赖：
+    - SouWenHttpClient: 统一 HTTP 客户端
+    - TokenBucketLimiter: 令牌桶限流器（与 arxiv.py 共享 3s 间隔）
+    - BeautifulSoup4: HTML 解析（核心依赖）
+    - pymupdf4llm: PDF→Markdown 转换（可选依赖，[pdf] extra）
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from bs4 import BeautifulSoup
+
+from souwen.http_client import SouWenHttpClient
+from souwen.models import FetchResult
+from souwen.rate_limiter import TokenBucketLimiter
+
+logger = logging.getLogger(__name__)
+
+_HTML_BASE = "https://arxiv.org/html"
+_PDF_BASE = "https://arxiv.org/pdf"
+_ABS_BASE = "https://arxiv.org/abs"
+
+# arXiv 要求至少 3 秒间隔（与 ArxivClient 一致）
+_RATE_LIMIT_RPS = 1.0 / 3.0
+
+# HTML 中需要剥离的标签（噪音 / 非正文）
+_STRIP_TAGS = ("script", "style", "nav", "header", "footer", "noscript", "form")
+
+
+class ArxivFulltextClient:
+    """arXiv 全文抓取客户端（HTML 优先，PDF 回退）。"""
+
+    def __init__(self) -> None:
+        """初始化客户端，使用与 arXiv API 相同的 3 秒限流。"""
+        # 不绑定 base_url，便于 HTML/PDF 分别访问完整地址
+        self._client = SouWenHttpClient(source_name="arxiv_fulltext")
+        self._limiter = TokenBucketLimiter(rate=_RATE_LIMIT_RPS, burst=1.0)
+
+    # ------------------------------------------------------------------
+    # async context manager
+    # ------------------------------------------------------------------
+
+    async def __aenter__(self) -> ArxivFulltextClient:
+        await self._client.__aenter__()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> None:
+        await self._client.__aexit__(exc_type, exc_val, exc_tb)
+
+    # ------------------------------------------------------------------
+    # 内部工具
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _extract_html_text(html: str) -> tuple[str, str]:
+        """从 arXiv HTML 渲染页提取标题和正文纯文本。
+
+        Returns:
+            (title, text) 元组。
+        """
+        soup = BeautifulSoup(html, "lxml")
+
+        title_el = soup.find("title")
+        title = title_el.get_text(strip=True) if title_el else ""
+
+        for tag in soup(list(_STRIP_TAGS)):
+            tag.decompose()
+
+        body = soup.find("body") or soup
+        # 用换行分隔块级元素，避免段落首尾粘连
+        text = body.get_text(separator="\n", strip=True)
+        # 合并多余空行
+        lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+        return title, "\n".join(lines)
+
+    @staticmethod
+    def _pdf_to_markdown(pdf_bytes: bytes) -> str | None:
+        """用 pymupdf4llm 将 PDF 字节流转为 Markdown。
+
+        可选依赖：未安装时返回 None，由调用方决定回退方案。
+        """
+        try:
+            import pymupdf4llm  # type: ignore
+            import pymupdf  # type: ignore
+        except ImportError:
+            logger.warning("pymupdf4llm 未安装，无法转换 PDF；可执行 `pip install souwen[pdf]`")
+            return None
+
+        try:
+            doc = pymupdf.open(stream=pdf_bytes, filetype="pdf")
+            md = pymupdf4llm.to_markdown(doc)
+            doc.close()
+            return md
+        except Exception as exc:
+            logger.warning("pymupdf4llm 转换失败: %s", exc)
+            return None
+
+    # ------------------------------------------------------------------
+    # 公开方法
+    # ------------------------------------------------------------------
+
+    async def get_fulltext(self, paper_id: str) -> FetchResult:
+        """按 arXiv ID 获取论文全文。
+
+        Args:
+            paper_id: arXiv ID（如 ``2301.00001`` 或 ``2301.00001v2``）。
+
+        Returns:
+            FetchResult。失败时 ``error`` 字段被填充，``content`` 为空。
+        """
+        abs_url = f"{_ABS_BASE}/{paper_id}"
+        html_url = f"{_HTML_BASE}/{paper_id}"
+        pdf_url = f"{_PDF_BASE}/{paper_id}"
+
+        # ── 1. HTML 优先 ────────────────────────────────────────────
+        await self._limiter.acquire()
+        try:
+            html_resp = await self._client.get(html_url)
+        except Exception as exc:
+            logger.warning("arXiv HTML 请求失败: %s", exc)
+            html_resp = None
+
+        if html_resp is not None and html_resp.status_code == 200:
+            try:
+                title, text = self._extract_html_text(html_resp.text)
+                return FetchResult(
+                    url=abs_url,
+                    final_url=str(html_resp.url),
+                    title=title,
+                    content=text,
+                    content_format="text",
+                    source="arxiv_fulltext",
+                    snippet=text[:500],
+                    raw={"variant": "html", "paper_id": paper_id},
+                )
+            except Exception as exc:
+                logger.warning("arXiv HTML 解析失败: %s", exc)
+
+        # ── 2. PDF 回退 ─────────────────────────────────────────────
+        await self._limiter.acquire()
+        try:
+            pdf_resp = await self._client.get(pdf_url)
+        except Exception as exc:
+            return FetchResult(
+                url=abs_url,
+                final_url=pdf_url,
+                source="arxiv_fulltext",
+                error=f"PDF 请求失败: {exc}",
+            )
+
+        if pdf_resp.status_code != 200:
+            return FetchResult(
+                url=abs_url,
+                final_url=str(pdf_resp.url),
+                source="arxiv_fulltext",
+                error=f"PDF 抓取返回 HTTP {pdf_resp.status_code}",
+            )
+
+        markdown = self._pdf_to_markdown(pdf_resp.content)
+        if markdown is None:
+            return FetchResult(
+                url=abs_url,
+                final_url=str(pdf_resp.url),
+                source="arxiv_fulltext",
+                error="pymupdf4llm 不可用或转换失败；请安装 souwen[pdf]",
+                raw={"variant": "pdf", "paper_id": paper_id, "pdf_size": len(pdf_resp.content)},
+            )
+
+        return FetchResult(
+            url=abs_url,
+            final_url=str(pdf_resp.url),
+            title="",  # PDF 无独立标题元数据，留空
+            content=markdown,
+            content_format="markdown",
+            source="arxiv_fulltext",
+            snippet=markdown[:500],
+            raw={"variant": "pdf", "paper_id": paper_id, "pdf_size": len(pdf_resp.content)},
+        )

--- a/src/souwen/paper/semantic_scholar.py
+++ b/src/souwen/paper/semantic_scholar.py
@@ -33,6 +33,13 @@
         - 输入：paper_id Semantic Scholar Paper ID, limit 返回条数
         - 输出：推荐论文列表
 
+    get_citations(paper_id: str, limit: int) -> dict
+        - 功能：获取论文的引用图谱（被该论文引用 + 引用该论文的论文）
+        - 输入：paper_id Paper ID / DOI:xxx / ARXIV:xxx
+               limit 每个方向（citations/references）的最大返回数
+        - 输出：dict，含 paper_id、citation_count、reference_count、citations、
+               references 字段，每条记录提供轻量摘要（含 arxiv_id 交叉引用）
+
 模块依赖：
     - SouWenHttpClient: 统一 HTTP 客户端
     - SlidingWindowLimiter: 滑动窗口限流器
@@ -292,3 +299,82 @@ class SemanticScholarClient:
 
         data: dict[str, Any] = resp.json()
         return [self._parse_paper(p) for p in data.get("recommendedPapers", [])]
+
+    async def get_citations(self, paper_id: str, limit: int = 100) -> dict[str, Any]:
+        """获取论文的引用关系图谱（引用该论文的 + 该论文引用的）。
+
+        Args:
+            paper_id: Semantic Scholar Paper ID, DOI (``DOI:xxx``)，
+                      或 arXiv ID (``ARXIV:xxx``)。
+            limit: 每个方向（citations/references）的最大返回数。
+
+        Returns:
+            包含 ``citing_papers`` 和 ``referenced_papers`` 摘要的字典：
+
+            .. code-block:: python
+
+                {
+                    "paper_id": str,
+                    "citation_count": int,
+                    "reference_count": int,
+                    "citations": [{"paper_id", "title", "year", "authors", "arxiv_id"}, ...],
+                    "references": [{"paper_id", "title", "year", "authors", "arxiv_id"}, ...],
+                }
+
+        Raises:
+            NotFoundError: 论文不存在。
+            RateLimitError: 超出请求频率限制。
+        """
+        fields = "paperId,title,year,authors,externalIds"
+        capped_limit = min(limit, 1000)
+
+        # citations 端点（被谁引用）
+        await self._limiter.acquire()
+        cit_resp = await self._client.get(
+            f"/paper/{paper_id}/citations",
+            params={"fields": fields, "limit": capped_limit},
+        )
+        if cit_resp.status_code == 404:
+            raise NotFoundError(f"Semantic Scholar 未找到论文: {paper_id}")
+        if cit_resp.status_code == 429:
+            raise RateLimitError("Semantic Scholar 请求频率超限")
+
+        # references 端点（该论文引用谁）
+        await self._limiter.acquire()
+        ref_resp = await self._client.get(
+            f"/paper/{paper_id}/references",
+            params={"fields": fields, "limit": capped_limit},
+        )
+        if ref_resp.status_code == 404:
+            raise NotFoundError(f"Semantic Scholar 未找到论文: {paper_id}")
+        if ref_resp.status_code == 429:
+            raise RateLimitError("Semantic Scholar 请求频率超限")
+
+        citations = [
+            self._summarize_citation_node(item.get("citingPaper") or {})
+            for item in cit_resp.json().get("data", [])
+        ]
+        references = [
+            self._summarize_citation_node(item.get("citedPaper") or {})
+            for item in ref_resp.json().get("data", [])
+        ]
+
+        return {
+            "paper_id": paper_id,
+            "citation_count": len(citations),
+            "reference_count": len(references),
+            "citations": citations,
+            "references": references,
+        }
+
+    @staticmethod
+    def _summarize_citation_node(node: dict[str, Any]) -> dict[str, Any]:
+        """从 citations/references 子结构提取轻量字段摘要。"""
+        external_ids: dict[str, str] = node.get("externalIds") or {}
+        return {
+            "paper_id": node.get("paperId"),
+            "title": node.get("title"),
+            "year": node.get("year"),
+            "authors": [a.get("name", "") for a in (node.get("authors") or [])],
+            "arxiv_id": external_ids.get("ArXiv"),
+        }

--- a/tests/test_paper/test_arxiv.py
+++ b/tests/test_paper/test_arxiv.py
@@ -256,3 +256,86 @@ async def test_pagination(httpx_mock: HTTPXMock):
         resp = await c.search("test", start=20, max_results=10)
 
     assert resp.page == 3  # (20 // 10) + 1
+
+
+# ---------------------------------------------------------------------------
+# Categories & date range filtering (Feature 1)
+# ---------------------------------------------------------------------------
+
+
+def test_build_search_query_categories_only():
+    """仅给定 categories 时，将 ``OR`` 拼接的分类子句 ``AND`` 到原 query。"""
+    q = ArxivClient._build_search_query("transformer", categories=["cs.AI", "cs.LG"])
+    assert q == "(transformer) AND (cat:cs.AI OR cat:cs.LG)"
+
+
+def test_build_search_query_date_range():
+    """日期范围使用 ``+TO+`` 字面 ``+`` 字符。"""
+    q = ArxivClient._build_search_query("transformer", date_from="2024-01-01", date_to="2024-06-30")
+    assert "submittedDate:[202401010000+TO+202406302359]" in q
+    assert "(transformer) AND" in q
+
+
+def test_build_search_query_partial_date():
+    """缺省 date_to 时使用极大值占位。"""
+    q = ArxivClient._build_search_query("", date_from="2024-01-01")
+    assert "202401010000+TO+999912312359" in q
+
+
+async def test_search_with_categories(httpx_mock: HTTPXMock):
+    """search() categories 参数正确拼到 search_query。"""
+    httpx_mock.add_response(
+        url=re.compile(r"http://export\.arxiv\.org/api/query.*"),
+        text=ARXIV_SEARCH_XML,
+    )
+
+    async with ArxivClient() as c:
+        await c.search("attention", categories=["cs.AI", "cs.LG"])
+
+    request = httpx_mock.get_requests()[0]
+    # 注意 httpx 会将空格编码为 + 或 %20，我们检查关键子串
+    url_str = str(request.url)
+    assert "cat:cs.AI" in url_str or "cat%3Acs.AI" in url_str
+    assert "cat:cs.LG" in url_str or "cat%3Acs.LG" in url_str
+
+
+async def test_search_with_date_range_preserves_plus_to_plus(httpx_mock: HTTPXMock):
+    """search() date_from/date_to 拼到 URL 时，``+TO+`` 不被编码为 ``%2BTO%2B``。"""
+    httpx_mock.add_response(
+        url=re.compile(r"http://export\.arxiv\.org/api/query.*"),
+        text=ARXIV_SEARCH_XML,
+    )
+
+    async with ArxivClient() as c:
+        await c.search(
+            "attention",
+            date_from="2024-01-01",
+            date_to="2024-06-30",
+        )
+
+    request = httpx_mock.get_requests()[0]
+    raw_url = str(request.url)
+    # 关键不变量：字面 ``+TO+`` 必须保留
+    assert "+TO+" in raw_url
+    assert "%2BTO%2B" not in raw_url
+    assert "submittedDate:[202401010000+TO+202406302359]" in raw_url
+
+
+async def test_search_with_categories_and_date_range(httpx_mock: HTTPXMock):
+    """同时给定 categories 与 date 时两段都附加。"""
+    httpx_mock.add_response(
+        url=re.compile(r"http://export\.arxiv\.org/api/query.*"),
+        text=ARXIV_SEARCH_XML,
+    )
+
+    async with ArxivClient() as c:
+        await c.search(
+            "transformer",
+            categories=["cs.AI"],
+            date_from="2024-01-01",
+            date_to="2024-12-31",
+        )
+
+    raw_url = str(httpx_mock.get_requests()[0].url)
+    assert "cat:cs.AI" in raw_url
+    assert "+TO+" in raw_url

--- a/tests/test_paper/test_arxiv_fulltext.py
+++ b/tests/test_paper/test_arxiv_fulltext.py
@@ -1,0 +1,143 @@
+"""arXiv 全文获取客户端单元测试（pytest-httpx mock）。
+
+覆盖 ``souwen.paper.arxiv_fulltext`` 中 ArxivFulltextClient 的 HTML 提取、
+PDF 回退、错误处理逻辑。无真实网络调用。
+
+测试清单：
+- ``test_html_success``：HTML 200 时提取标题与正文
+- ``test_html_strips_unwanted_tags``：剥离 nav/script/style 等噪音
+- ``test_pdf_fallback_when_html_404``：HTML 404 时回退到 PDF
+- ``test_pdf_fallback_without_pymupdf4llm``：未安装 pymupdf4llm 时返回 error
+- ``test_both_failed``：HTML/PDF 均失败时返回带 error 的 FetchResult
+"""
+
+from __future__ import annotations
+
+import re
+from unittest.mock import patch
+
+from pytest_httpx import HTTPXMock
+
+from souwen.paper.arxiv_fulltext import ArxivFulltextClient
+
+
+HTML_PAGE = """\
+<html>
+<head><title>Sample arXiv Paper</title></head>
+<body>
+  <nav>navigation links</nav>
+  <header>top header</header>
+  <script>var x = 1;</script>
+  <style>body{color:red;}</style>
+  <main>
+    <h1>Sample Title</h1>
+    <p>This is the abstract.</p>
+    <p>And this is the body content.</p>
+  </main>
+  <footer>copyright footer</footer>
+</body>
+</html>
+"""
+
+
+async def test_html_success(httpx_mock: HTTPXMock):
+    """HTML 200 时返回 text 类型 FetchResult。"""
+    httpx_mock.add_response(
+        url=re.compile(r"https://arxiv\.org/html/.*"),
+        text=HTML_PAGE,
+    )
+
+    async with ArxivFulltextClient() as c:
+        result = await c.get_fulltext("2301.00001")
+
+    assert result.error is None
+    assert result.source == "arxiv_fulltext"
+    assert result.content_format == "text"
+    assert result.title == "Sample arXiv Paper"
+    assert "Sample Title" in result.content
+    assert "abstract" in result.content
+    assert result.snippet  # 非空
+    assert result.url == "https://arxiv.org/abs/2301.00001"
+    assert result.raw["variant"] == "html"
+
+
+async def test_html_strips_unwanted_tags(httpx_mock: HTTPXMock):
+    """nav/header/footer/script/style 应当被完全移除。"""
+    httpx_mock.add_response(
+        url=re.compile(r"https://arxiv\.org/html/.*"),
+        text=HTML_PAGE,
+    )
+
+    async with ArxivFulltextClient() as c:
+        result = await c.get_fulltext("2301.00001")
+
+    text = result.content
+    assert "navigation links" not in text
+    assert "top header" not in text
+    assert "copyright footer" not in text
+    assert "var x = 1" not in text
+    assert "color:red" not in text
+
+
+async def test_pdf_fallback_when_html_404(httpx_mock: HTTPXMock):
+    """HTML 404 时回退到 PDF；若 pymupdf4llm 可用则返回 markdown。"""
+    httpx_mock.add_response(
+        url=re.compile(r"https://arxiv\.org/html/.*"),
+        status_code=404,
+        text="not found",
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"https://arxiv\.org/pdf/.*"),
+        content=b"%PDF-1.4 fake content",
+    )
+
+    with patch.object(
+        ArxivFulltextClient,
+        "_pdf_to_markdown",
+        return_value="# Title\n\nMocked markdown content.",
+    ):
+        async with ArxivFulltextClient() as c:
+            result = await c.get_fulltext("2301.99999")
+
+    assert result.error is None
+    assert result.content_format == "markdown"
+    assert "Mocked markdown" in result.content
+    assert result.raw["variant"] == "pdf"
+
+
+async def test_pdf_fallback_without_pymupdf4llm(httpx_mock: HTTPXMock):
+    """pymupdf4llm 不可用时（_pdf_to_markdown 返回 None）返回 error 字段。"""
+    httpx_mock.add_response(
+        url=re.compile(r"https://arxiv\.org/html/.*"),
+        status_code=404,
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"https://arxiv\.org/pdf/.*"),
+        content=b"%PDF-1.4 stub",
+    )
+
+    with patch.object(ArxivFulltextClient, "_pdf_to_markdown", return_value=None):
+        async with ArxivFulltextClient() as c:
+            result = await c.get_fulltext("2301.99999")
+
+    assert result.error is not None
+    assert "pymupdf4llm" in result.error
+    assert result.content == ""
+
+
+async def test_both_failed(httpx_mock: HTTPXMock):
+    """HTML 与 PDF 均非 200 时返回带 error 的 FetchResult。"""
+    httpx_mock.add_response(
+        url=re.compile(r"https://arxiv\.org/html/.*"),
+        status_code=404,
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"https://arxiv\.org/pdf/.*"),
+        status_code=500,
+    )
+
+    async with ArxivFulltextClient() as c:
+        result = await c.get_fulltext("2301.99999")
+
+    assert result.error is not None
+    assert "500" in result.error

--- a/tests/test_paper/test_semantic_scholar.py
+++ b/tests/test_paper/test_semantic_scholar.py
@@ -180,3 +180,94 @@ async def test_get_paper_rate_limit(httpx_mock: HTTPXMock):
     async with SemanticScholarClient(api_key=None) as c:
         with pytest.raises(RateLimitError):
             await c.get_paper("abc")
+
+
+# ---------------------------------------------------------------------------
+# Citation graph (Feature 2)
+# ---------------------------------------------------------------------------
+
+
+S2_CITATIONS_RESPONSE = {
+    "data": [
+        {
+            "citingPaper": {
+                "paperId": "cite1",
+                "title": "Citing Paper One",
+                "year": 2024,
+                "authors": [{"name": "Alice"}, {"name": "Bob"}],
+                "externalIds": {"ArXiv": "2401.00001"},
+            }
+        },
+        {
+            "citingPaper": {
+                "paperId": "cite2",
+                "title": "Citing Paper Two",
+                "year": 2023,
+                "authors": [{"name": "Carol"}],
+                "externalIds": {},
+            }
+        },
+    ]
+}
+
+S2_REFERENCES_RESPONSE = {
+    "data": [
+        {
+            "citedPaper": {
+                "paperId": "ref1",
+                "title": "Referenced Paper",
+                "year": 2020,
+                "authors": [{"name": "Dave"}],
+                "externalIds": {"ArXiv": "2001.12345"},
+            }
+        }
+    ]
+}
+
+
+async def test_get_citations_basic(httpx_mock: HTTPXMock):
+    """get_citations() 同时拉取 citations 与 references 并组装为字典。"""
+    httpx_mock.add_response(
+        url=re.compile(r".*/paper/abc123/citations.*"),
+        json=S2_CITATIONS_RESPONSE,
+    )
+    httpx_mock.add_response(
+        url=re.compile(r".*/paper/abc123/references.*"),
+        json=S2_REFERENCES_RESPONSE,
+    )
+
+    async with SemanticScholarClient(api_key=None) as c:
+        result = await c.get_citations("abc123", limit=10)
+
+    assert result["paper_id"] == "abc123"
+    assert result["citation_count"] == 2
+    assert result["reference_count"] == 1
+
+    cite0 = result["citations"][0]
+    assert cite0["paper_id"] == "cite1"
+    assert cite0["title"] == "Citing Paper One"
+    assert cite0["year"] == 2024
+    assert cite0["authors"] == ["Alice", "Bob"]
+    assert cite0["arxiv_id"] == "2401.00001"
+
+    cite1 = result["citations"][1]
+    assert cite1["arxiv_id"] is None  # 无 ArXiv 外部 ID
+
+    ref0 = result["references"][0]
+    assert ref0["paper_id"] == "ref1"
+    assert ref0["arxiv_id"] == "2001.12345"
+
+
+async def test_get_citations_not_found(httpx_mock: HTTPXMock):
+    """404 抛 NotFoundError。"""
+    from souwen.exceptions import NotFoundError
+
+    httpx_mock.add_response(
+        url=re.compile(r".*/paper/missing/citations.*"),
+        status_code=404,
+        json={"error": "not found"},
+    )
+
+    async with SemanticScholarClient(api_key=None) as c:
+        with pytest.raises(NotFoundError):
+            await c.get_citations("missing")


### PR DESCRIPTION
## 概述

基于 [arxiv-mcp-server](https://github.com/blazickjp/arxiv-mcp-server) 对比分析，为 SouWen 原生实现三项关键增强，不依赖 MCP 协议。

## 对比背景

| 功能 | SouWen (之前) | arxiv-mcp-server | SouWen (本 PR) |
|------|--------------|-------------------|----------------|
| 分类过滤 | ❌ | ✅ | ✅ |
| 日期范围 | ❌ | ✅ | ✅ |
| 引用图谱 | ❌ | ✅ (Semantic Scholar) | ✅ |
| 全文获取 | ❌ | ✅ (HTML+PDF) | ✅ |
| XXE 安全 | ✅ defusedxml | ❌ 标准 ET | ✅ |
| 多源聚合 | ✅ | ❌ | ✅ |
| SSRF 防护 | ✅ | ❌ | ✅ |

## 改进内容

### 1. ArXiv 搜索增强 🔍

`ArxivClient.search()` 新增参数：
- `categories: list[str] | None` — 按学科分类过滤（如 `["cs.AI", "cs.LG"]`）
- `date_from: str | None` — 起始日期 (YYYY-MM-DD)
- `date_to: str | None` — 截止日期 (YYYY-MM-DD)

技术细节：
- 分类过滤通过 `AND (cat:cs.AI OR cat:cs.LG)` 追加到 query
- 日期过滤使用 arXiv 原生 `submittedDate:[YYYYMMDD0000+TO+YYYYMMDD2359]` 语法
- 手动构建 URL 绕过 httpx 对 `+` 的编码问题（arXiv API 要求 literal `+`）

### 2. Semantic Scholar 引用图谱 🔗

`SemanticScholarClient.get_citations(paper_id, limit=100)` 新增方法：
- 同时获取「被谁引用」和「引用了谁」两个方向
- 返回结构化 dict 含 arXiv ID 交叉引用
- 复用已有限流机制和 API Key 认证

### 3. ArXiv 论文全文获取 📄

新增 `ArxivFulltextClient` 类：
- HTML 优先：从 `arxiv.org/html/{id}` 获取，BeautifulSoup 提取正文
- PDF 回退：`pymupdf4llm`（可选依赖 `[pdf]` extra）转换为 markdown
- 返回标准 `FetchResult` 模型，与 builtin fetcher 输出一致
- 遵循 3 秒限速，独立 rate limiter

## 修改文件

| 文件 | 变更 |
|------|------|
| `src/souwen/paper/arxiv.py` | 新增 categories/date_from/date_to + URL 构建 |
| `src/souwen/paper/semantic_scholar.py` | 新增 get_citations() 方法 |
| `src/souwen/paper/arxiv_fulltext.py` | 新文件：全文获取客户端 |
| `src/souwen/paper/__init__.py` | 导出 ArxivFulltextClient |
| `pyproject.toml` | 新增 `[pdf]` 可选依赖组 |
| `tests/test_paper/test_arxiv.py` | +6 新测试 |
| `tests/test_paper/test_semantic_scholar.py` | +2 引用图谱测试 |
| `tests/test_paper/test_arxiv_fulltext.py` | +5 新测试 |

## 测试

- `pytest tests/test_paper/ -v` → **54 passed** ✅
- `ruff check` + `ruff format --check` → clean ✅
- 全部使用 mock，无真实网络请求