### PR TITLE
feat(web/duckduckgo): 原生重写 DDG 搜索引擎 — 新增 News/Images/Videos + VQD + POST 分页

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## 🎯 简介
 
-SouWen（搜文）为 AI Agent 提供统一的学术论文、专利和网页搜索接口，整合 **62 个数据源**，归一化为 Pydantic v2 数据模型。
+SouWen（搜文）为 AI Agent 提供统一的学术论文、专利和网页搜索接口，整合 **65 个数据源**，归一化为 Pydantic v2 数据模型。
 
 - **8 论文源 + 8 专利源 + 22 搜索引擎** — 18 个零配置即用（5 论文 + 2 专利 + 9 爬虫 + 2 自建）
 - **统一数据模型** — `PaperResult` / `PatentResult` / `WebSearchResult`
@@ -156,7 +156,7 @@ asyncio.run(main())
 
 | 文档 | 内容 |
 |------|------|
-| [数据源详情](docs/data-sources.md) | 62 个数据源完整列表、分级说明 |
+| [数据源详情](docs/data-sources.md) | 65 个数据源完整列表、分级说明 |
 | [配置详解](docs/configuration.md) | 配置优先级、全部字段、代理池、YAML 格式 |
 | [架构设计](docs/architecture.md) | 数据流、基类模式、限流器、异常体系、项目结构 |
 | [外观定制](docs/appearance.md) | 皮肤、明暗模式、配色方案、自定义皮肤指南 |
@@ -170,7 +170,7 @@ asyncio.run(main())
 
 **专利**（8 源）：PatentsView、PQAI、EPO OPS、USPTO ODP、The Lens、CNIPA、PatSnap、Google Patents — 其中 2 个零配置
 
-**搜索引擎**（22 个）：9 个爬虫（DuckDuckGo、Yahoo、Brave 等）+ 10 个 API（Tavily、Exa、Metaso、Perplexity 等）+ 3 个自建实例（SearXNG、Whoogle、Websurfx）
+**搜索引擎**（25 个）：12 个爬虫（DuckDuckGo Web/News/Images/Videos、Yahoo、Brave 等）+ 10 个 API（Tavily、Exa、Metaso、Perplexity 等）+ 3 个自建实例（SearXNG、Whoogle、Websurfx）
 
 **中文技术社区**（3 个）：CSDN、稀土掘金（Juejin）、LinuxDo — 全部零配置
 

--- a/src/souwen/models.py
+++ b/src/souwen/models.py
@@ -140,6 +140,9 @@ class SourceType(str, Enum):
     GOOGLE_PATENTS = "google_patents"
     # 常规搜索引擎
     WEB_DUCKDUCKGO = "web_duckduckgo"
+    WEB_DDG_NEWS = "web_ddg_news"
+    WEB_DDG_IMAGES = "web_ddg_images"
+    WEB_DDG_VIDEOS = "web_ddg_videos"
     WEB_YAHOO = "web_yahoo"
     WEB_BRAVE = "web_brave"
     WEB_GOOGLE = "web_google"

--- a/src/souwen/scraper/base.py
+++ b/src/souwen/scraper/base.py
@@ -213,6 +213,7 @@ class BaseScraper:
         method: str = "GET",
         params: dict[str, Any] | None = None,
         headers: dict[str, str] | None = None,
+        data: dict[str, Any] | None = None,
     ) -> httpx.Response:
         """带重试和礼貌延迟的请求方法
 
@@ -224,6 +225,7 @@ class BaseScraper:
             method: HTTP 方法
             params: 查询参数
             headers: 额外请求头
+            data: POST 表单数据（application/x-www-form-urlencoded）
 
         Returns:
             httpx.Response（或 curl_cffi 兼容的响应对象）
@@ -245,7 +247,7 @@ class BaseScraper:
             await self._polite_delay()
 
             try:
-                resp = await self._do_request(method, url, params, request_headers)
+                resp = await self._do_request(method, url, params, request_headers, data=data)
 
                 if resp.status_code == 429:
                     # 被限流：退避系数翻倍（上限 16x），大幅增加后续请求间隔
@@ -286,6 +288,7 @@ class BaseScraper:
         url: str,
         params: dict[str, Any] | None,
         headers: dict[str, str],
+        data: dict[str, Any] | None = None,
     ) -> Any:
         """执行实际的 HTTP 请求 — curl_cffi 或 httpx 双引擎
 
@@ -297,6 +300,7 @@ class BaseScraper:
             url: 目标 URL
             params: 查询参数字典
             headers: 请求头字典（已包含浏览器指纹和频道自定义头）
+            data: POST 表单数据
 
         Returns:
             响应对象（curl_cffi.Response 或 httpx.Response）
@@ -311,10 +315,13 @@ class BaseScraper:
                 url,
                 params=params,
                 headers=headers,
+                data=data,
                 allow_redirects=self._follow_redirects,
             )
         elif self._httpx_client is not None:
             # httpx 回退路径
-            return await self._httpx_client.request(method, url, params=params, headers=headers)
+            return await self._httpx_client.request(
+                method, url, params=params, headers=headers, data=data
+            )
         else:
             raise RuntimeError("无可用 HTTP 客户端")

--- a/src/souwen/source_registry.py
+++ b/src/souwen/source_registry.py
@@ -144,7 +144,10 @@ _reg("patsnap", "patent", "official_api", "patsnap_api_key", description="PatSna
 _reg("google_patents", "patent", "scraper", None, description="Google Patents 爬虫")
 
 # ── 通用搜索 (general)：爬虫 ──────────────────────────────
-_reg("duckduckgo", "general", "scraper", None, description="DuckDuckGo HTML 搜索")
+_reg("duckduckgo", "general", "scraper", None, description="DuckDuckGo 网页搜索")
+_reg("duckduckgo_news", "general", "scraper", None, description="DuckDuckGo 新闻搜索")
+_reg("duckduckgo_images", "general", "scraper", None, description="DuckDuckGo 图片搜索")
+_reg("duckduckgo_videos", "general", "scraper", None, description="DuckDuckGo 视频搜索")
 _reg("yahoo", "general", "scraper", None, description="Yahoo 搜索")
 _reg("brave", "general", "scraper", None, description="Brave 搜索")
 _reg("google", "general", "scraper", None, description="Google 搜索")

--- a/src/souwen/web/__init__.py
+++ b/src/souwen/web/__init__.py
@@ -26,6 +26,9 @@ API 类（需 Key / 自建实例）：
 """
 
 from souwen.web.duckduckgo import DuckDuckGoClient
+from souwen.web.ddg_news import DuckDuckGoNewsClient
+from souwen.web.ddg_images import DuckDuckGoImagesClient, ImageSearchResult, ImageSearchResponse
+from souwen.web.ddg_videos import DuckDuckGoVideosClient, VideoSearchResult, VideoSearchResponse
 from souwen.web.yahoo import YahooClient
 from souwen.web.brave import BraveClient
 from souwen.web.google import GoogleClient
@@ -69,6 +72,13 @@ from souwen.web.fetch import fetch_content
 __all__ = [
     # 爬虫类（无需 Key）
     "DuckDuckGoClient",
+    "DuckDuckGoNewsClient",
+    "DuckDuckGoImagesClient",
+    "DuckDuckGoVideosClient",
+    "ImageSearchResult",
+    "ImageSearchResponse",
+    "VideoSearchResult",
+    "VideoSearchResponse",
     "YahooClient",
     "BraveClient",
     "GoogleClient",

--- a/src/souwen/web/ddg_images.py
+++ b/src/souwen/web/ddg_images.py
@@ -1,0 +1,140 @@
+"""DuckDuckGo 图片搜索
+
+通过 duckduckgo.com/i.js JSON 端点获取图片搜索结果。
+支持尺寸、颜色、类型、布局、许可证过滤。
+"""
+
+from __future__ import annotations
+
+import logging
+
+from pydantic import BaseModel
+
+from souwen.models import SourceType
+from souwen.web.ddg_json import DDGJsonClient
+from souwen.web.ddg_utils import build_filter_string, normalize_url
+
+logger = logging.getLogger("souwen.web.ddg_images")
+
+# safesearch 映射
+_SAFESEARCH_MAP = {"on": "1", "moderate": "1", "off": "-1"}
+
+
+class ImageSearchResult(BaseModel):
+    """图片搜索结果"""
+
+    source: SourceType = SourceType.WEB_DDG_IMAGES
+    title: str
+    url: str  # 来源页面 URL
+    image_url: str  # 原图直链
+    thumbnail_url: str = ""
+    width: int = 0
+    height: int = 0
+    image_source: str = ""  # 来源站点名
+    engine: str = "duckduckgo_images"
+
+
+class ImageSearchResponse(BaseModel):
+    """图片搜索响应"""
+
+    query: str
+    source: SourceType = SourceType.WEB_DDG_IMAGES
+    results: list[ImageSearchResult] = []
+    total_results: int = 0
+
+
+class DuckDuckGoImagesClient(DDGJsonClient):
+    """DuckDuckGo 图片搜索客户端
+
+    使用 i.js JSON 端点。支持尺寸/颜色/类型/布局/许可证过滤。
+    """
+
+    ENGINE_NAME = "duckduckgo_images"
+    _ENDPOINT = "/i.js"
+    _MAX_PAGES = 5
+
+    async def search(
+        self,
+        query: str,
+        max_results: int = 20,
+        region: str = "wt-wt",
+        safesearch: str = "moderate",
+        time_range: str | None = None,
+        size: str | None = None,
+        color: str | None = None,
+        type_image: str | None = None,
+        layout: str | None = None,
+        license_image: str | None = None,
+        max_pages: int | None = None,
+    ) -> ImageSearchResponse:
+        """搜索 DuckDuckGo 图片
+
+        Args:
+            query: 搜索关键词
+            max_results: 最大结果数
+            region: 区域代码
+            safesearch: "on"/"moderate"/"off"
+            time_range: "Day"/"Week"/"Month"/"Year"/None
+            size: "Small"/"Medium"/"Large"/"Wallpaper"/None
+            color: "color"/"Monochrome"/"Red"/etc./None
+            type_image: "photo"/"clipart"/"gif"/"transparent"/"line"/None
+            layout: "Square"/"Tall"/"Wide"/None
+            license_image: "any"/"Public"/"Share"/"ShareCommercially"/"Modify"/"ModifyCommercially"/None
+            max_pages: 最大分页数
+
+        Returns:
+            ImageSearchResponse 包含图片搜索结果
+        """
+        vqd = await self._get_vqd(query)
+        if not vqd:
+            return ImageSearchResponse(query=query)
+
+        # 构建过滤字符串
+        time_token = f"time:{time_range}" if time_range else ""
+        size_token = f"size:{size}" if size else ""
+        color_token = f"color:{color}" if color else ""
+        type_token = f"type:{type_image}" if type_image else ""
+        layout_token = f"layout:{layout}" if layout else ""
+        license_token = f"license:{license_image}" if license_image else ""
+        f_str = build_filter_string(
+            time_token, size_token, color_token, type_token, layout_token, license_token
+        )
+
+        params: dict[str, str] = {
+            "l": region,
+            "o": "json",
+            "q": query,
+            "vqd": vqd,
+            "f": f_str,
+            "p": _SAFESEARCH_MAP.get(safesearch, "1"),
+        }
+
+        raw_results = await self._paginated_search(query, params, max_results, max_pages)
+
+        results: list[ImageSearchResult] = []
+        seen_images: set[str] = set()
+
+        for row in raw_results:
+            image_url = normalize_url(row.get("image", ""))
+            if not image_url or image_url in seen_images:
+                continue
+            seen_images.add(image_url)
+
+            results.append(
+                ImageSearchResult(
+                    title=row.get("title", ""),
+                    url=normalize_url(row.get("url", "")),
+                    image_url=image_url,
+                    thumbnail_url=normalize_url(row.get("thumbnail", "")),
+                    width=int(row.get("width", 0) or 0),
+                    height=int(row.get("height", 0) or 0),
+                    image_source=row.get("source", ""),
+                )
+            )
+
+        logger.info("DDG Images 返回 %d 条结果 (query=%s)", len(results), query)
+        return ImageSearchResponse(
+            query=query,
+            results=results,
+            total_results=len(results),
+        )

--- a/src/souwen/web/ddg_json.py
+++ b/src/souwen/web/ddg_json.py
@@ -1,0 +1,122 @@
+"""DuckDuckGo JSON 搜索基类
+
+为 News/Images/Videos 提供共享的 VQD token 管理和 JSON 分页逻辑。
+所有 JSON 端点（i.js, news.js, v.js）共用同一模式：
+    1. 从首页获取 VQD token
+    2. GET 请求 JSON 端点，附带 VQD + 过滤参数
+    3. 通过响应中的 next URL 解析 s= 偏移实现分页
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from souwen.scraper.base import BaseScraper
+from souwen.web.ddg_utils import extract_vqd, parse_next_offset
+
+logger = logging.getLogger("souwen.web.ddg_json")
+
+
+class DDGJsonClient(BaseScraper):
+    """DDG JSON 端点搜索基类
+
+    子类需设置:
+        ENGINE_NAME: str
+        BASE_URL: str = "https://duckduckgo.com"
+        _ENDPOINT: str (如 "/i.js", "/news.js", "/v.js")
+        _MAX_PAGES: int = 5
+    """
+
+    BASE_URL = "https://duckduckgo.com"
+    _ENDPOINT: str = ""
+    _MAX_PAGES: int = 5
+
+    def __init__(self, **kwargs):
+        super().__init__(
+            min_delay=0.75,
+            max_delay=1.5,
+            max_retries=3,
+            follow_redirects=False,
+            **kwargs,
+        )
+
+    async def _get_vqd(self, keywords: str) -> str | None:
+        """从 DuckDuckGo 首页获取 VQD token（per-query）"""
+        try:
+            resp = await self._fetch(
+                "https://duckduckgo.com",
+                params={"q": keywords},
+                headers={"Referer": "https://duckduckgo.com/"},
+            )
+            if resp.status_code != 200:
+                logger.warning("VQD 获取失败: status=%d", resp.status_code)
+                return None
+            content = resp.content if hasattr(resp, "content") else resp.text.encode()
+            return extract_vqd(content, keywords)
+        except Exception as e:
+            logger.warning("VQD 获取异常: %s", e)
+            return None
+
+    async def _fetch_json_page(self, params: dict[str, str]) -> dict[str, Any] | None:
+        """请求 JSON 端点并返回解析后的字典"""
+        url = f"{self._resolved_base_url}{self._ENDPOINT}"
+        try:
+            resp = await self._fetch(
+                url,
+                params=params,
+                headers={"Referer": "https://duckduckgo.com/"},
+            )
+            if resp.status_code in (301, 302, 202, 403, 418, 429):
+                logger.warning("DDG JSON 反爬 status=%d", resp.status_code)
+                return None
+            if resp.status_code != 200:
+                return None
+            return resp.json()
+        except Exception as e:
+            logger.warning("DDG JSON 请求失败: %s", e)
+            return None
+
+    async def _paginated_search(
+        self,
+        keywords: str,
+        base_params: dict[str, str],
+        max_results: int,
+        max_pages: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """通用分页搜索循环
+
+        Args:
+            keywords: 搜索关键词
+            base_params: 基础请求参数（包含 vqd, q, l, o, p 等）
+            max_results: 最大结果数
+            max_pages: 最大页数
+
+        Returns:
+            原始结果字典列表
+        """
+        pages = max_pages or self._MAX_PAGES
+        all_results: list[dict[str, Any]] = []
+        params = dict(base_params)
+
+        for page in range(pages):
+            data = await self._fetch_json_page(params)
+            if data is None:
+                break
+
+            results = data.get("results")
+            if not results:
+                break
+
+            all_results.extend(results)
+            if len(all_results) >= max_results:
+                break
+
+            # 解析分页偏移
+            next_url = data.get("next")
+            offset = parse_next_offset(next_url)
+            if not offset:
+                break
+            params["s"] = offset
+
+        return all_results[:max_results]

--- a/src/souwen/web/ddg_news.py
+++ b/src/souwen/web/ddg_news.py
@@ -1,0 +1,125 @@
+"""DuckDuckGo 新闻搜索
+
+通过 duckduckgo.com/news.js JSON 端点获取新闻搜索结果。
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from souwen.models import SourceType, WebSearchResult, WebSearchResponse
+from souwen.web.ddg_json import DDGJsonClient
+from souwen.web.ddg_utils import normalize_text
+
+logger = logging.getLogger("souwen.web.ddg_news")
+
+# safesearch 映射 → DDG news.js 的 p 参数
+_SAFESEARCH_MAP = {"on": "1", "moderate": "-1", "off": "-2"}
+
+
+class DuckDuckGoNewsClient(DDGJsonClient):
+    """DuckDuckGo 新闻搜索客户端
+
+    使用 news.js JSON 端点，支持时间范围过滤和区域设置。
+    """
+
+    ENGINE_NAME = "duckduckgo_news"
+    _ENDPOINT = "/news.js"
+    _MAX_PAGES = 5
+
+    async def search(
+        self,
+        query: str,
+        max_results: int = 20,
+        region: str = "wt-wt",
+        safesearch: str = "moderate",
+        time_range: str | None = None,
+        max_pages: int | None = None,
+    ) -> WebSearchResponse:
+        """搜索 DuckDuckGo 新闻
+
+        Args:
+            query: 搜索关键词
+            max_results: 最大结果数
+            region: 区域代码
+            safesearch: "on"/"moderate"/"off"
+            time_range: "d"(天)/"w"(周)/"m"(月)/None
+            max_pages: 最大分页数
+
+        Returns:
+            WebSearchResponse 包含新闻搜索结果
+        """
+        vqd = await self._get_vqd(query)
+        if not vqd:
+            logger.warning("无法获取 VQD token，返回空结果")
+            return WebSearchResponse(
+                query=query,
+                source=SourceType.WEB_DDG_NEWS,
+                results=[],
+                total_results=0,
+            )
+
+        params: dict[str, str] = {
+            "l": region,
+            "o": "json",
+            "noamp": "1",
+            "q": query,
+            "vqd": vqd,
+            "p": _SAFESEARCH_MAP.get(safesearch, "-1"),
+        }
+        if time_range:
+            params["df"] = time_range
+
+        raw_results = await self._paginated_search(query, params, max_results, max_pages)
+
+        results: list[WebSearchResult] = []
+        seen_urls: set[str] = set()
+
+        for row in raw_results:
+            url = row.get("url", "")
+            if not url or url in seen_urls:
+                continue
+            seen_urls.add(url)
+
+            title = row.get("title", "")
+            body = normalize_text(row.get("excerpt", ""))
+            source_name = row.get("source", "")
+
+            # 格式化日期
+            date_str = ""
+            ts = row.get("date")
+            if ts:
+                try:
+                    dt = datetime.fromtimestamp(int(ts), tz=timezone.utc)
+                    date_str = dt.strftime("%Y-%m-%d")
+                except (ValueError, TypeError, OSError):
+                    pass
+
+            snippet_parts = []
+            if source_name:
+                snippet_parts.append(f"📰 {source_name}")
+            if date_str:
+                snippet_parts.append(date_str)
+            if body:
+                snippet_parts.append(body)
+            snippet = " | ".join(snippet_parts)
+
+            if title:
+                results.append(
+                    WebSearchResult(
+                        source=SourceType.WEB_DDG_NEWS,
+                        title=title,
+                        url=url,
+                        snippet=snippet,
+                        engine=self.ENGINE_NAME,
+                    )
+                )
+
+        logger.info("DDG News 返回 %d 条结果 (query=%s)", len(results), query)
+        return WebSearchResponse(
+            query=query,
+            source=SourceType.WEB_DDG_NEWS,
+            results=results,
+            total_results=len(results),
+        )

--- a/src/souwen/web/ddg_utils.py
+++ b/src/souwen/web/ddg_utils.py
@@ -1,0 +1,135 @@
+"""DuckDuckGo 搜索共享工具
+
+VQD token 提取、HTML 表单解析、URL/文本规范化等
+供 DuckDuckGo 系列搜索客户端共用。
+"""
+
+from __future__ import annotations
+
+import re
+from html import unescape
+from urllib.parse import unquote
+
+
+# VQD 提取正则 — 多模式覆盖 DDG 轮换格式
+_VQD_PATTERNS = [
+    re.compile(rb'vqd="([^"]+)"'),
+    re.compile(rb"vqd='([^']+)'"),
+    re.compile(rb"vqd=([^&]+)&"),
+    re.compile(rb'"vqd":"([^"]+)"'),
+]
+
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_MULTI_SPACE_RE = re.compile(r"\s+")
+
+
+def extract_vqd(html_bytes: bytes, keywords: str) -> str | None:
+    """从 DuckDuckGo 首页 HTML 中提取 VQD token
+
+    VQD 是 DuckDuckGo JSON 搜索接口（images/news/videos）的认证令牌。
+    DDG 轮换嵌入格式，因此尝试多种正则模式。
+
+    Args:
+        html_bytes: 首页响应的原始字节
+        keywords: 搜索关键词（用于调试日志）
+
+    Returns:
+        VQD token 字符串，未找到则返回 None
+    """
+    for pattern in _VQD_PATTERNS:
+        m = pattern.search(html_bytes)
+        if m:
+            return m.group(1).decode()
+    return None
+
+
+def normalize_url(url: str) -> str:
+    """规范化 URL — 解码 + 去除多余空格"""
+    if not url:
+        return ""
+    url = unquote(url)
+    url = url.replace(" ", "+")
+    return url.strip()
+
+
+def normalize_text(html_text: str) -> str:
+    """规范化文本 — 去 HTML 标签 + 反转义 + 压缩空白"""
+    if not html_text:
+        return ""
+    text = _HTML_TAG_RE.sub("", html_text)
+    text = unescape(text)
+    text = _MULTI_SPACE_RE.sub(" ", text)
+    return text.strip()
+
+
+def parse_next_form_data(html_bytes: bytes) -> dict[str, str] | None:
+    """从 DuckDuckGo HTML 响应中提取分页表单的隐藏字段
+
+    DDG HTML 版本的「下一页」是一个含有多个 hidden input 的 form。
+    我们需要原样回传所有 hidden 字段作为下一次 POST 的表单数据。
+
+    Args:
+        html_bytes: 响应的原始 HTML 字节
+
+    Returns:
+        隐藏字段字典 {name: value}，未找到分页表单则返回 None
+    """
+    # 快速查找：包含 "next" 相关表单
+    from lxml import html as lxml_html
+
+    try:
+        tree = lxml_html.fromstring(html_bytes)
+    except Exception:
+        return None
+
+    # html 后端: div.nav-link 里的 form
+    nav_forms = tree.xpath('//div[@class="nav-link"]//form')
+    if not nav_forms:
+        # lite 后端: form 包含 value 含 "ext" 或 "Next" 的 input
+        nav_forms = tree.xpath("//form[.//input[contains(@value, 'ext')]]")
+    if not nav_forms:
+        return None
+
+    form = nav_forms[-1]  # 取最后一个（"Next" 而非 "Previous"）
+    inputs = form.xpath(".//input[@type='hidden']")
+    if not inputs:
+        return None
+
+    data: dict[str, str] = {}
+    for inp in inputs:
+        name = inp.get("name")
+        value = inp.get("value", "")
+        if name:
+            data[name] = value
+    return data if data else None
+
+
+def build_filter_string(*tokens: str | None) -> str:
+    """构建 DDG JSON 接口的过滤字符串
+
+    Args:
+        *tokens: 各过滤维度的值（None 或空字符串表示不过滤该维度）
+
+    Returns:
+        逗号分隔的过滤字符串，例如 "time:Day,,size:Large,,,,"
+    """
+    parts = []
+    for t in tokens:
+        parts.append(t if t else "")
+    return ",".join(parts)
+
+
+def parse_next_offset(next_url: str | None) -> str | None:
+    """从 JSON 接口的 next URL 中解析分页偏移量
+
+    Args:
+        next_url: 响应中的 next 字段（如 "i.js?s=100&..."）
+
+    Returns:
+        偏移量字符串，无法解析则返回 None
+    """
+    if not next_url:
+        return None
+    # 查找 s=NNN
+    m = re.search(r"[?&]s=(\d+)", next_url)
+    return m.group(1) if m else None

--- a/src/souwen/web/ddg_videos.py
+++ b/src/souwen/web/ddg_videos.py
@@ -1,0 +1,149 @@
+"""DuckDuckGo 视频搜索
+
+通过 duckduckgo.com/v.js JSON 端点获取视频搜索结果。
+支持分辨率、时长、许可证过滤。
+"""
+
+from __future__ import annotations
+
+import logging
+
+from pydantic import BaseModel
+
+from souwen.models import SourceType
+from souwen.web.ddg_json import DDGJsonClient
+from souwen.web.ddg_utils import build_filter_string
+
+logger = logging.getLogger("souwen.web.ddg_videos")
+
+_SAFESEARCH_MAP = {"on": "1", "moderate": "-1", "off": "-2"}
+
+
+class VideoSearchResult(BaseModel):
+    """视频搜索结果"""
+
+    source: SourceType = SourceType.WEB_DDG_VIDEOS
+    title: str
+    url: str  # 视频页面 URL
+    duration: str = ""
+    publisher: str = ""
+    published: str = ""
+    description: str = ""
+    thumbnail: str = ""
+    embed_url: str = ""
+    view_count: int = 0
+    engine: str = "duckduckgo_videos"
+
+
+class VideoSearchResponse(BaseModel):
+    """视频搜索响应"""
+
+    query: str
+    source: SourceType = SourceType.WEB_DDG_VIDEOS
+    results: list[VideoSearchResult] = []
+    total_results: int = 0
+
+
+class DuckDuckGoVideosClient(DDGJsonClient):
+    """DuckDuckGo 视频搜索客户端
+
+    使用 v.js JSON 端点。支持分辨率/时长/许可证过滤。
+    """
+
+    ENGINE_NAME = "duckduckgo_videos"
+    _ENDPOINT = "/v.js"
+    _MAX_PAGES = 8
+
+    async def search(
+        self,
+        query: str,
+        max_results: int = 20,
+        region: str = "wt-wt",
+        safesearch: str = "moderate",
+        time_range: str | None = None,
+        resolution: str | None = None,
+        duration: str | None = None,
+        license_videos: str | None = None,
+        max_pages: int | None = None,
+    ) -> VideoSearchResponse:
+        """搜索 DuckDuckGo 视频
+
+        Args:
+            query: 搜索关键词
+            max_results: 最大结果数
+            region: 区域代码
+            safesearch: "on"/"moderate"/"off"
+            time_range: "d"(天)/"w"(周)/"m"(月)/None
+            resolution: "high"/"standard"/None
+            duration: "short"/"medium"/"long"/None
+            license_videos: "creativeCommon"/"youtube"/None
+            max_pages: 最大分页数
+
+        Returns:
+            VideoSearchResponse 包含视频搜索结果
+        """
+        vqd = await self._get_vqd(query)
+        if not vqd:
+            return VideoSearchResponse(query=query)
+
+        # 构建过滤字符串
+        time_token = f"publishedAfter:{time_range}" if time_range else ""
+        res_token = f"videoDefinition:{resolution}" if resolution else ""
+        dur_token = f"videoDuration:{duration}" if duration else ""
+        lic_token = f"videoLicense:{license_videos}" if license_videos else ""
+        f_str = build_filter_string(time_token, res_token, dur_token, lic_token)
+
+        params: dict[str, str] = {
+            "l": region,
+            "o": "json",
+            "q": query,
+            "vqd": vqd,
+            "f": f_str,
+            "p": _SAFESEARCH_MAP.get(safesearch, "-1"),
+        }
+
+        raw_results = await self._paginated_search(query, params, max_results, max_pages)
+
+        results: list[VideoSearchResult] = []
+        seen_urls: set[str] = set()
+
+        for row in raw_results:
+            url = row.get("content", "")
+            if not url or url in seen_urls:
+                continue
+            seen_urls.add(url)
+
+            # 提取观看次数
+            view_count = 0
+            stats = row.get("statistics", {})
+            if isinstance(stats, dict):
+                view_count = int(stats.get("viewCount", 0) or 0)
+
+            # 提取缩略图
+            thumbnail = ""
+            images = row.get("images", {})
+            if isinstance(images, dict):
+                thumbnail = (
+                    images.get("large", "") or images.get("medium", "") or images.get("small", "")
+                )
+
+            results.append(
+                VideoSearchResult(
+                    title=row.get("title", ""),
+                    url=url,
+                    duration=row.get("duration", ""),
+                    publisher=row.get("publisher", ""),
+                    published=row.get("published", ""),
+                    description=row.get("description", ""),
+                    thumbnail=thumbnail,
+                    embed_url=row.get("embed_url", ""),
+                    view_count=view_count,
+                )
+            )
+
+        logger.info("DDG Videos 返回 %d 条结果 (query=%s)", len(results), query)
+        return VideoSearchResponse(
+            query=query,
+            results=results,
+            total_results=len(results),
+        )

--- a/src/souwen/web/duckduckgo.py
+++ b/src/souwen/web/duckduckgo.py
@@ -1,113 +1,188 @@
-"""DuckDuckGo HTML 搜索引擎
+"""DuckDuckGo 网页文本搜索引擎
 
-文件用途：
-    DuckDuckGo 轻量 HTML 搜索引擎爬虫客户端。使用 HTML 版本避免 JavaScript 依赖，
-    通过重定向参数解码获取真实 URL，无需 API Key。
+使用 html.duckduckgo.com POST 接口实现网页搜索。
+支持区域、安全搜索、时间范围过滤及多页分页。
 
-函数/类清单：
-    DuckDuckGoClient（类）
-        - 功能：DuckDuckGo HTML 版本爬虫客户端，通过 CSS 选择器解析搜索结果
-        - 继承：BaseScraper（基础爬虫类）
-        - 关键属性：ENGINE_NAME = "duckduckgo", BASE_URL = "https://html.duckduckgo.com/html/",
-                  min_delay = 1.0, max_delay = 3.0, max_retries = 3
-        - 主要方法：search(query, max_results) -> WebSearchResponse
-
-    DuckDuckGoClient.__init__(**kwargs)
-        - 功能：初始化 DuckDuckGo 搜索客户端
-        - 输入：**kwargs 传递给 BaseScraper 的参数
-        - 输出：实例
-
-    DuckDuckGoClient.search(query, max_results=20) -> WebSearchResponse
-        - 功能：查询 DuckDuckGo，返回聚合结果
-        - 输入：query 搜索关键词, max_results 最大返回结果数（默认20）
-        - 输出：WebSearchResponse 包含搜索结果
-
-    DuckDuckGoClient._decode_ddg_url(url) -> str
-        - 功能：解码 DuckDuckGo 重定向 URL（从 uddg= 参数提取真实 URL）
-        - 输入：url DuckDuckGo 格式的 URL 字符串
-        - 输出：解码后的真实 URL
-
-模块依赖：
-    - logging: 日志记录
-    - urllib.parse: URL 编码/解码
-    - bs4: HTML 解析
-    - souwen.models: SourceType, WebSearchResult, WebSearchResponse 数据模型
-    - souwen.scraper.base: BaseScraper 基础爬虫类
-
-技术要点：
-    - 使用 HTML 版本避免 JavaScript 渲染
-    - CSS 选择器：.result（结果容器）、.result__a（标题）、.result__snippet（描述）
-    - 解码 DuckDuckGo 重定向 URL：//duckduckgo.com/l/?uddg=ENCODED_URL&rut=...
-    - URL 必须是 http/https 开头（过滤相对路径）
+技术方案：
+    - POST 表单提交搜索（html 后端）
+    - 分页：echo 服务端返回的 hidden form inputs
+    - TLS 指纹模拟 via BaseScraper (curl_cffi)
+    - 禁用 follow_redirects（301 = 反爬信号）
+    - 多模式 no-results 检测
 """
 
 from __future__ import annotations
 
 import logging
-from urllib.parse import unquote, quote_plus
+from html import unescape
 
-from bs4 import BeautifulSoup
+from lxml import html as lxml_html
 
 from souwen.models import SourceType, WebSearchResult, WebSearchResponse
 from souwen.scraper.base import BaseScraper
+from souwen.web.ddg_utils import normalize_url, normalize_text, parse_next_form_data
 
 logger = logging.getLogger("souwen.web.duckduckgo")
 
+# DDG 的 "无结果" 标记 — html 后端用两个空格
+_NO_RESULTS_HTML = b"No  results."
+_NO_RESULTS_LITE = b"No more results."
+
+# 广告 URL 前缀 — 需要过滤
+_AD_PREFIXES = (
+    "http://www.google.com/search?q=",
+    "https://duckduckgo.com/y.js?ad_domain",
+)
+
 
 class DuckDuckGoClient(BaseScraper):
-    """DuckDuckGo HTML 搜索客户端
+    """DuckDuckGo 网页搜索客户端
 
-    使用 html.duckduckgo.com 轻量版本，无需 JavaScript 渲染。
-    通过 CSS 选择器解析搜索结果。
+    通过 POST 提交搜索并解析 HTML 结果。
+    支持区域、安全搜索、时间范围、分页。
+    TLS 指纹模拟 + 自适应退避。
     """
 
     ENGINE_NAME = "duckduckgo"
     BASE_URL = "https://html.duckduckgo.com/html/"
 
     def __init__(self, **kwargs):
-        # 初始化爬虫配置：最小延迟 1.0s、最大延迟 3.0s、最多重试 3 次
-        super().__init__(min_delay=1.0, max_delay=3.0, max_retries=3, **kwargs)
+        super().__init__(
+            min_delay=0.75,
+            max_delay=1.5,
+            max_retries=3,
+            follow_redirects=False,
+            **kwargs,
+        )
 
-    async def search(self, query: str, max_results: int = 20) -> WebSearchResponse:
-        """搜索 DuckDuckGo
+    async def search(
+        self,
+        query: str,
+        max_results: int = 20,
+        region: str = "wt-wt",
+        safesearch: str = "moderate",
+        time_range: str | None = None,
+        max_pages: int = 3,
+    ) -> WebSearchResponse:
+        """搜索 DuckDuckGo 网页
 
         Args:
             query: 搜索关键词
             max_results: 最大返回结果数
+            region: 区域代码，如 "wt-wt"(全球), "us-en", "cn-zh"
+            safesearch: 安全搜索级别 "on"/"moderate"/"off"
+            time_range: 时间范围 "d"(天)/"w"(周)/"m"(月)/"y"(年)/None
+            max_pages: 最大分页数（默认 3）
 
         Returns:
             WebSearchResponse 包含搜索结果
         """
-        url = f"{self._resolved_base_url}?q={quote_plus(query)}"
+        results: list[WebSearchResult] = []
+        seen_urls: set[str] = set()
 
-        resp = await self._fetch(url)
-        html = resp.text
+        # 首次请求的 form data
+        form_data: dict[str, str] = {
+            "q": query,
+            "b": "",
+            "kl": region,
+        }
+        if time_range:
+            form_data["df"] = time_range
 
-        soup = BeautifulSoup(html, "lxml")
+        url = self._resolved_base_url
+
+        for page in range(max_pages):
+            try:
+                resp = await self._fetch(url, method="POST", data=form_data)
+
+                # 301/302/202/403 = DDG 反爬信号
+                if resp.status_code in (301, 302, 202, 403, 418):
+                    logger.warning("DDG 反爬响应 status=%d，停止分页", resp.status_code)
+                    break
+
+                if resp.status_code != 200:
+                    logger.warning("DDG 异常状态码 %d", resp.status_code)
+                    break
+
+                content = resp.content if hasattr(resp, "content") else resp.text.encode()
+
+                # 检测 no-results 标记
+                if _NO_RESULTS_HTML in content or _NO_RESULTS_LITE in content:
+                    break
+
+                # 解析结果
+                page_results = self._parse_html_results(content, seen_urls)
+                results.extend(page_results)
+
+                if len(results) >= max_results:
+                    results = results[:max_results]
+                    break
+
+                # 没有解析出任何结果 → 可能被阻断
+                if not page_results:
+                    break
+
+                # 提取分页 form data
+                next_data = parse_next_form_data(content)
+                if not next_data:
+                    break
+                form_data = next_data
+
+            except Exception as e:
+                logger.warning("DDG 第 %d 页请求失败: %s", page + 1, e)
+                break
+
+        logger.info("DuckDuckGo 返回 %d 条结果 (query=%s)", len(results), query)
+        return WebSearchResponse(
+            query=query,
+            source=SourceType.WEB_DUCKDUCKGO,
+            results=results,
+            total_results=len(results),
+        )
+
+    def _parse_html_results(self, content: bytes, seen_urls: set[str]) -> list[WebSearchResult]:
+        """解析 DuckDuckGo HTML 搜索结果页"""
         results: list[WebSearchResult] = []
 
         try:
-            # 遍历 DuckDuckGo 搜索结果的容器 .result
-            for element in soup.select(".result"):
-                # 标题在 .result__a
-                title_el = element.select_one(".result__a")
-                if title_el is None:
+            tree = lxml_html.fromstring(content)
+        except Exception as e:
+            logger.warning("HTML 解析失败: %s", e)
+            return results
+
+        # html 后端: div[h2] 格式
+        for div in tree.xpath("//div[h2]"):
+            try:
+                # 标题 + href — 仅从 h2 内的 a 提取
+                anchors = div.xpath("./h2/a/@href")
+                if not anchors:
+                    anchors = div.xpath("./a/@href")
+                titles = div.xpath("./h2/a//text()")
+                if not anchors or not titles:
                     continue
 
-                title = title_el.get_text(strip=True)
-                raw_url = title_el.get("href", "")
+                raw_url = anchors[0]
+                title = unescape("".join(t.strip() for t in titles if t.strip()))
 
-                # 提取 snippet（描述文本）
-                snippet_el = element.select_one(".result__snippet")
-                snippet = snippet_el.get_text(strip=True) if snippet_el else ""
-
-                # DuckDuckGo URL 重定向解码
-                # 格式: //duckduckgo.com/l/?uddg=ENCODED_URL&rut=...
-                real_url = self._decode_ddg_url(str(raw_url))
-
-                # 过滤非 HTTP 链接
-                if not real_url or not real_url.startswith(("http://", "https://")):
+                # 跳过广告
+                if any(raw_url.startswith(p) for p in _AD_PREFIXES):
                     continue
+
+                real_url = normalize_url(self._decode_ddg_url(str(raw_url)))
+                if not real_url.startswith(("http://", "https://")):
+                    continue
+
+                if real_url in seen_urls:
+                    continue
+                seen_urls.add(real_url)
+
+                # 描述文本
+                body_parts = div.xpath(".//a[@class='result__snippet']//text()")
+                if not body_parts:
+                    body_parts = div.xpath(".//td[@class='result-snippet']//text()")
+                if not body_parts:
+                    body_parts = div.xpath(".//a[contains(@class,'snippet')]//text()")
+                snippet = normalize_text(" ".join(body_parts)) if body_parts else ""
 
                 if title:
                     results.append(
@@ -119,40 +194,22 @@ class DuckDuckGoClient(BaseScraper):
                             engine=self.ENGINE_NAME,
                         )
                     )
+            except Exception:
+                continue
 
-                if len(results) >= max_results:
-                    break
-        except Exception as e:
-            logger.warning("DuckDuckGo HTML 解析失败: %s", e)
-
-        logger.info("DuckDuckGo 返回 %d 条结果 (query=%s)", len(results), query)
-
-        return WebSearchResponse(
-            query=query,
-            source=SourceType.WEB_DUCKDUCKGO,
-            results=results,
-            total_results=len(results),
-        )
+        return results
 
     @staticmethod
     def _decode_ddg_url(url: str) -> str:
         """解码 DuckDuckGo 重定向 URL
 
         DuckDuckGo 通过 //duckduckgo.com/l/?uddg=ENCODED_URL 跳转。
-        提取真实 URL 并解码。
-
-        Args:
-            url: DuckDuckGo 格式的 URL 字符串（可能包含 uddg 重定向参数）
-
-        Returns:
-            str: 解码后的真实 URL；不是重定向格式则返回原 URL
         """
-        if url.startswith("//duckduckgo.com/l/?uddg="):
-            # 提取 uddg= 之后的部分（& 前面的内容）
+        from urllib.parse import unquote as _unquote
+
+        if "uddg=" in url:
             parts = url.split("uddg=", 1)
             if len(parts) > 1:
-                # 获取编码的 URL，忽略后续参数（& 分隔）
                 encoded = parts[1].split("&", 1)[0]
-                # URL 解码还原真实链接
-                return unquote(encoded)
+                return _unquote(encoded)
         return url

--- a/src/souwen/web/search.py
+++ b/src/souwen/web/search.py
@@ -52,6 +52,9 @@ from typing import Sequence
 from souwen.config import get_config
 from souwen.models import WebSearchResult, WebSearchResponse, SourceType
 from souwen.web.duckduckgo import DuckDuckGoClient
+from souwen.web.ddg_news import DuckDuckGoNewsClient
+from souwen.web.ddg_images import DuckDuckGoImagesClient  # noqa: F401
+from souwen.web.ddg_videos import DuckDuckGoVideosClient  # noqa: F401
 from souwen.web.yahoo import YahooClient
 from souwen.web.brave import BraveClient
 from souwen.web.google import GoogleClient
@@ -212,6 +215,7 @@ async def web_search(
     engine_map: dict[str, type] = {
         # 爬虫引擎（无需 API Key）
         "duckduckgo": DuckDuckGoClient,
+        "duckduckgo_news": DuckDuckGoNewsClient,
         "yahoo": YahooClient,
         "brave": BraveClient,
         "google": GoogleClient,
@@ -252,6 +256,7 @@ async def web_search(
     # 引擎名 -> SourceType 的映射，用于标记结果来源
     source_map: dict[str, SourceType] = {
         "duckduckgo": SourceType.WEB_DUCKDUCKGO,
+        "duckduckgo_news": SourceType.WEB_DDG_NEWS,
         "yahoo": SourceType.WEB_YAHOO,
         "brave": SourceType.WEB_BRAVE,
         "google": SourceType.WEB_GOOGLE,

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,11 +1,11 @@
 """SouWen doctor 模块测试。
 
 覆盖 ``souwen.doctor`` 中 ``check_all()`` 与 ``format_report()`` 的诊断功能。
-验证：62 个数据源的完整性检查、状态判断（ok/missing_key/limited/unavailable/warning）、
+验证：65 个数据源的完整性检查、状态判断（ok/missing_key/limited/unavailable/warning）、
 报告格式化与符号呈现、以及 Tier 分层显示。
 
 测试清单：
-- ``TestCheckAll``：check_all() 返回 62 源、必要字段完整性、Key 配置状态检测
+- ``TestCheckAll``：check_all() 返回 65 源、必要字段完整性、Key 配置状态检测
 - ``TestFormatReport``：format_report() 字符串输出、标题/Tier 分组、状态符号
 """
 
@@ -23,7 +23,7 @@ class TestCheckAll:
 
         get_config.cache_clear()
         results = check_all()
-        assert len(results) == 62
+        assert len(results) == 65
 
     def test_result_has_required_keys(self):
         """每条结果包含必要字段"""
@@ -102,8 +102,8 @@ class TestCheckAll:
             get_config.cache_clear()
 
     def test_source_config_matches_37(self):
-        """source registry 有 62 个数据源"""
-        assert len(get_all_sources()) == 62
+        """source registry 有 65 个数据源"""
+        assert len(get_all_sources()) == 65
 
     def test_semantic_scholar_without_key_is_limited(self, monkeypatch):
         """Semantic Scholar 无 Key 时标记为 limited。"""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -82,7 +82,7 @@ class TestSourceTypeEnum:
 
     def test_has_37_values(self):
         """枚举有 48 个值"""
-        assert len(SourceType) == 51
+        assert len(SourceType) == 54
 
     def test_paper_sources_exist(self):
         """论文数据源枚举存在"""

--- a/tests/test_web/test_ddg_extended.py
+++ b/tests/test_web/test_ddg_extended.py
@@ -1,0 +1,338 @@
+"""DuckDuckGo News / Images / Videos 客户端测试"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from souwen.models import SourceType, WebSearchResponse
+from souwen.web.ddg_news import DuckDuckGoNewsClient
+from souwen.web.ddg_images import DuckDuckGoImagesClient, ImageSearchResponse
+from souwen.web.ddg_videos import DuckDuckGoVideosClient, VideoSearchResponse
+from souwen.web.ddg_utils import extract_vqd, normalize_text, normalize_url, parse_next_offset
+
+
+class TestDDGUtils:
+    """共享工具函数测试"""
+
+    def test_extract_vqd_double_quote(self):
+        html = b'some html vqd="abc123" more html'
+        assert extract_vqd(html, "test") == "abc123"
+
+    def test_extract_vqd_single_quote(self):
+        html = b"some html vqd='xyz789' more html"
+        assert extract_vqd(html, "test") == "xyz789"
+
+    def test_extract_vqd_ampersand(self):
+        html = b"some html vqd=token456&other=1 more"
+        assert extract_vqd(html, "test") == "token456"
+
+    def test_extract_vqd_json(self):
+        html = b'{"vqd":"json_vqd_value"}'
+        assert extract_vqd(html, "test") == "json_vqd_value"
+
+    def test_extract_vqd_none(self):
+        html = b"no vqd here"
+        assert extract_vqd(html, "test") is None
+
+    def test_normalize_text(self):
+        assert normalize_text("<b>Hello</b> <em>World</em>") == "Hello World"
+
+    def test_normalize_text_empty(self):
+        assert normalize_text("") == ""
+
+    def test_normalize_url(self):
+        assert normalize_url("https%3A%2F%2Fexample.com") == "https://example.com"
+
+    def test_parse_next_offset(self):
+        assert parse_next_offset("i.js?s=100&o=json") == "100"
+
+    def test_parse_next_offset_none(self):
+        assert parse_next_offset(None) is None
+        assert parse_next_offset("no-s-param") is None
+
+
+class TestDuckDuckGoNewsClient:
+    """新闻搜索客户端测试"""
+
+    @pytest.fixture
+    def client(self):
+        return DuckDuckGoNewsClient()
+
+    def test_engine_name(self, client):
+        assert client.ENGINE_NAME == "duckduckgo_news"
+
+    @pytest.mark.asyncio
+    async def test_search_no_vqd(self, client):
+        """VQD 获取失败返回空"""
+        with patch.object(client, "_get_vqd", new_callable=AsyncMock, return_value=None):
+            resp = await client.search("test")
+
+        assert isinstance(resp, WebSearchResponse)
+        assert len(resp.results) == 0
+
+    @pytest.mark.asyncio
+    async def test_search_success(self, client):
+        """正常搜索"""
+        mock_json = {
+            "results": [
+                {
+                    "title": "Breaking News",
+                    "url": "https://news.example.com/1",
+                    "excerpt": "<b>Important</b> event",
+                    "source": "ExampleNews",
+                    "date": 1700000000,
+                },
+                {
+                    "title": "Tech Update",
+                    "url": "https://tech.example.com/2",
+                    "excerpt": "New <em>release</em>",
+                    "source": "TechBlog",
+                    "date": 1700100000,
+                },
+            ],
+            "next": None,
+        }
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = mock_json
+
+        with (
+            patch.object(client, "_get_vqd", new_callable=AsyncMock, return_value="vqd123"),
+            patch.object(client, "_fetch", new_callable=AsyncMock, return_value=mock_resp),
+        ):
+            resp = await client.search("news test")
+
+        assert resp.source == SourceType.WEB_DDG_NEWS
+        assert len(resp.results) == 2
+        assert resp.results[0].title == "Breaking News"
+        assert "ExampleNews" in resp.results[0].snippet
+        assert "Important event" in resp.results[0].snippet
+
+    @pytest.mark.asyncio
+    async def test_search_empty_results(self, client):
+        """空结果"""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"results": [], "next": None}
+
+        with (
+            patch.object(client, "_get_vqd", new_callable=AsyncMock, return_value="vqd123"),
+            patch.object(client, "_fetch", new_callable=AsyncMock, return_value=mock_resp),
+        ):
+            resp = await client.search("nothing")
+
+        assert len(resp.results) == 0
+
+    @pytest.mark.asyncio
+    async def test_search_deduplicates_urls(self, client):
+        """URL 去重"""
+        mock_json = {
+            "results": [
+                {"title": "A", "url": "https://same.com", "excerpt": "", "source": "", "date": 0},
+                {"title": "B", "url": "https://same.com", "excerpt": "", "source": "", "date": 0},
+            ],
+            "next": None,
+        }
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = mock_json
+
+        with (
+            patch.object(client, "_get_vqd", new_callable=AsyncMock, return_value="v"),
+            patch.object(client, "_fetch", new_callable=AsyncMock, return_value=mock_resp),
+        ):
+            resp = await client.search("test")
+
+        assert len(resp.results) == 1
+
+
+class TestDuckDuckGoImagesClient:
+    """图片搜索客户端测试"""
+
+    @pytest.fixture
+    def client(self):
+        return DuckDuckGoImagesClient()
+
+    def test_engine_name(self, client):
+        assert client.ENGINE_NAME == "duckduckgo_images"
+
+    @pytest.mark.asyncio
+    async def test_search_no_vqd(self, client):
+        with patch.object(client, "_get_vqd", new_callable=AsyncMock, return_value=None):
+            resp = await client.search("test")
+
+        assert isinstance(resp, ImageSearchResponse)
+        assert len(resp.results) == 0
+
+    @pytest.mark.asyncio
+    async def test_search_success(self, client):
+        """正常图片搜索"""
+        mock_json = {
+            "results": [
+                {
+                    "title": "Cat Photo",
+                    "url": "https://example.com/cat",
+                    "image": "https://cdn.example.com/cat.jpg",
+                    "thumbnail": "https://cdn.example.com/cat_thumb.jpg",
+                    "width": 1920,
+                    "height": 1080,
+                    "source": "Unsplash",
+                },
+            ],
+            "next": None,
+        }
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = mock_json
+
+        with (
+            patch.object(client, "_get_vqd", new_callable=AsyncMock, return_value="vqd"),
+            patch.object(client, "_fetch", new_callable=AsyncMock, return_value=mock_resp),
+        ):
+            resp = await client.search("cat")
+
+        assert len(resp.results) == 1
+        r = resp.results[0]
+        assert r.title == "Cat Photo"
+        assert r.image_url == "https://cdn.example.com/cat.jpg"
+        assert r.width == 1920
+        assert r.height == 1080
+        assert r.image_source == "Unsplash"
+
+    @pytest.mark.asyncio
+    async def test_search_deduplicates_images(self, client):
+        """相同图片 URL 去重"""
+        mock_json = {
+            "results": [
+                {
+                    "title": "A",
+                    "url": "u1",
+                    "image": "https://same.jpg",
+                    "thumbnail": "",
+                    "width": 0,
+                    "height": 0,
+                    "source": "",
+                },
+                {
+                    "title": "B",
+                    "url": "u2",
+                    "image": "https://same.jpg",
+                    "thumbnail": "",
+                    "width": 0,
+                    "height": 0,
+                    "source": "",
+                },
+            ],
+            "next": None,
+        }
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = mock_json
+
+        with (
+            patch.object(client, "_get_vqd", new_callable=AsyncMock, return_value="v"),
+            patch.object(client, "_fetch", new_callable=AsyncMock, return_value=mock_resp),
+        ):
+            resp = await client.search("test")
+
+        assert len(resp.results) == 1
+
+
+class TestDuckDuckGoVideosClient:
+    """视频搜索客户端测试"""
+
+    @pytest.fixture
+    def client(self):
+        return DuckDuckGoVideosClient()
+
+    def test_engine_name(self, client):
+        assert client.ENGINE_NAME == "duckduckgo_videos"
+
+    @pytest.mark.asyncio
+    async def test_search_no_vqd(self, client):
+        with patch.object(client, "_get_vqd", new_callable=AsyncMock, return_value=None):
+            resp = await client.search("test")
+
+        assert isinstance(resp, VideoSearchResponse)
+        assert len(resp.results) == 0
+
+    @pytest.mark.asyncio
+    async def test_search_success(self, client):
+        """正常视频搜索"""
+        mock_json = {
+            "results": [
+                {
+                    "title": "Python Tutorial",
+                    "content": "https://youtube.com/watch?v=abc",
+                    "duration": "10:30",
+                    "publisher": "YouTube",
+                    "published": "2024-01-15",
+                    "description": "Learn Python",
+                    "embed_url": "https://youtube.com/embed/abc",
+                    "statistics": {"viewCount": 50000},
+                    "images": {"large": "https://img.youtube.com/large.jpg"},
+                },
+            ],
+            "next": None,
+        }
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = mock_json
+
+        with (
+            patch.object(client, "_get_vqd", new_callable=AsyncMock, return_value="vqd"),
+            patch.object(client, "_fetch", new_callable=AsyncMock, return_value=mock_resp),
+        ):
+            resp = await client.search("python")
+
+        assert len(resp.results) == 1
+        r = resp.results[0]
+        assert r.title == "Python Tutorial"
+        assert r.url == "https://youtube.com/watch?v=abc"
+        assert r.duration == "10:30"
+        assert r.view_count == 50000
+        assert r.thumbnail == "https://img.youtube.com/large.jpg"
+
+    @pytest.mark.asyncio
+    async def test_search_deduplicates_content_url(self, client):
+        """相同视频 URL 去重"""
+        mock_json = {
+            "results": [
+                {
+                    "title": "V1",
+                    "content": "https://same.com/v",
+                    "duration": "",
+                    "publisher": "",
+                    "published": "",
+                    "description": "",
+                    "embed_url": "",
+                    "statistics": {},
+                    "images": {},
+                },
+                {
+                    "title": "V2",
+                    "content": "https://same.com/v",
+                    "duration": "",
+                    "publisher": "",
+                    "published": "",
+                    "description": "",
+                    "embed_url": "",
+                    "statistics": {},
+                    "images": {},
+                },
+            ],
+            "next": None,
+        }
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = mock_json
+
+        with (
+            patch.object(client, "_get_vqd", new_callable=AsyncMock, return_value="v"),
+            patch.object(client, "_fetch", new_callable=AsyncMock, return_value=mock_resp),
+        ):
+            resp = await client.search("test")
+
+        assert len(resp.results) == 1

--- a/tests/test_web/test_duckduckgo.py
+++ b/tests/test_web/test_duckduckgo.py
@@ -1,0 +1,196 @@
+"""DuckDuckGo 网页搜索客户端测试"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from souwen.models import SourceType, WebSearchResponse
+from souwen.web.duckduckgo import DuckDuckGoClient
+
+
+# 模拟 DDG HTML 响应
+MOCK_HTML_PAGE = b"""
+<html>
+<body>
+<div class="results">
+  <div><h2><a href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fpage1&amp;rut=abc">
+    First Result Title
+  </a></h2>
+  <a class="result__snippet">This is the first result description</a>
+  </div>
+  <div><h2><a href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fpage2&amp;rut=def">
+    Second Result Title
+  </a></h2>
+  <a class="result__snippet">This is the second result description</a>
+  </div>
+</div>
+</body>
+</html>
+"""
+
+MOCK_HTML_NO_RESULTS = b"""
+<html><body>
+<div class="no-results">No  results.</div>
+</body></html>
+"""
+
+MOCK_HTML_WITH_NEXT = b"""
+<html><body>
+<div><h2><a href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fr1">Title 1</a></h2>
+<a class="result__snippet">Snippet 1</a></div>
+<div class="nav-link"><form>
+<input type="hidden" name="q" value="test"/>
+<input type="hidden" name="s" value="30"/>
+<input type="hidden" name="dc" value="31"/>
+<input type="hidden" name="nextParams" value="abc"/>
+<input type="submit" value="Next"/>
+</form></div>
+</body></html>
+"""
+
+
+class TestDuckDuckGoClient:
+    """DuckDuckGoClient 测试"""
+
+    @pytest.fixture
+    def client(self):
+        return DuckDuckGoClient()
+
+    def test_engine_name(self, client):
+        assert client.ENGINE_NAME == "duckduckgo"
+
+    def test_base_url(self, client):
+        assert client.BASE_URL == "https://html.duckduckgo.com/html/"
+
+    def test_low_delay(self, client):
+        assert client.min_delay == 0.75
+        assert client.max_delay == 1.5
+
+    def test_follow_redirects_disabled(self, client):
+        assert client._follow_redirects is False
+
+    @pytest.mark.asyncio
+    async def test_search_success(self, client):
+        """正常搜索返回结果"""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = MOCK_HTML_PAGE
+
+        with patch.object(client, "_fetch", new_callable=AsyncMock, return_value=mock_resp):
+            resp = await client.search("test query")
+
+        assert isinstance(resp, WebSearchResponse)
+        assert resp.source == SourceType.WEB_DUCKDUCKGO
+        assert resp.query == "test query"
+        assert len(resp.results) == 2
+        assert resp.results[0].title == "First Result Title"
+        assert resp.results[0].url == "https://example.com/page1"
+        assert "first result description" in resp.results[0].snippet
+
+    @pytest.mark.asyncio
+    async def test_search_no_results(self, client):
+        """无结果时返回空"""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = MOCK_HTML_NO_RESULTS
+
+        with patch.object(client, "_fetch", new_callable=AsyncMock, return_value=mock_resp):
+            resp = await client.search("xyznonexist")
+
+        assert len(resp.results) == 0
+
+    @pytest.mark.asyncio
+    async def test_search_rate_limited(self, client):
+        """反爬信号停止分页"""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 403
+
+        with patch.object(client, "_fetch", new_callable=AsyncMock, return_value=mock_resp):
+            resp = await client.search("test")
+
+        assert len(resp.results) == 0
+
+    @pytest.mark.asyncio
+    async def test_search_respects_max_results(self, client):
+        """max_results 限制"""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = MOCK_HTML_PAGE
+
+        with patch.object(client, "_fetch", new_callable=AsyncMock, return_value=mock_resp):
+            resp = await client.search("test", max_results=1)
+
+        assert len(resp.results) == 1
+
+    @pytest.mark.asyncio
+    async def test_search_exception_handled(self, client):
+        """网络异常不崩溃"""
+        with patch.object(
+            client, "_fetch", new_callable=AsyncMock, side_effect=Exception("network")
+        ):
+            resp = await client.search("test")
+
+        assert len(resp.results) == 0
+
+    @pytest.mark.asyncio
+    async def test_search_pagination(self, client):
+        """分页：第一页有 next form，第二页无"""
+        page1_resp = MagicMock()
+        page1_resp.status_code = 200
+        page1_resp.content = MOCK_HTML_WITH_NEXT
+
+        page2_resp = MagicMock()
+        page2_resp.status_code = 200
+        page2_resp.content = MOCK_HTML_PAGE  # 无 next form
+
+        with patch.object(
+            client, "_fetch", new_callable=AsyncMock, side_effect=[page1_resp, page2_resp]
+        ):
+            resp = await client.search("test", max_results=10)
+
+        # page1 有 1 结果 + page2 有 2 结果
+        assert len(resp.results) == 3
+
+    @pytest.mark.asyncio
+    async def test_search_deduplicates(self, client):
+        """相同 URL 去重"""
+        # 两页返回同样的内容
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = MOCK_HTML_PAGE
+
+        with patch.object(client, "_fetch", new_callable=AsyncMock, return_value=mock_resp):
+            resp = await client.search("test", max_results=10, max_pages=1)
+
+        # 同一页内 URL 不重复
+        urls = [r.url for r in resp.results]
+        assert len(urls) == len(set(urls))
+
+    def test_decode_ddg_url(self):
+        """URL 解码"""
+        encoded = "//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Ftest&rut=abc"
+        assert DuckDuckGoClient._decode_ddg_url(encoded) == "https://example.com/test"
+
+    def test_decode_ddg_url_passthrough(self):
+        """非重定向 URL 原样返回"""
+        url = "https://example.com/direct"
+        assert DuckDuckGoClient._decode_ddg_url(url) == url
+
+    @pytest.mark.asyncio
+    async def test_search_with_region_and_time(self, client):
+        """参数传递验证"""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = MOCK_HTML_PAGE
+
+        with patch.object(
+            client, "_fetch", new_callable=AsyncMock, return_value=mock_resp
+        ) as mock_fetch:
+            await client.search("test", region="cn-zh", time_range="w")
+
+        # 验证 POST 调用中包含正确的 data
+        call_kwargs = mock_fetch.call_args
+        assert call_kwargs.kwargs["data"]["kl"] == "cn-zh"
+        assert call_kwargs.kwargs["data"]["df"] == "w"
+        assert call_kwargs.kwargs["method"] == "POST"


### PR DESCRIPTION
## 概述

对标 [ddg-mcp](https://github.com/misanthropic-ai/ddg-mcp) 项目，**不引入任何新依赖**，原生重写 DuckDuckGo 搜索实现。研究 `duckduckgo-search` 库的核心技术（VQD token、JSON 端点、分页机制），用 SouWen 的 BaseScraper 基础设施从零实现。

## 改进对比

| 维度 | 改前 | 改后 |
|------|------|------|
| 搜索类型 | 仅 web | **web + news + images + videos** |
| 请求方式 | GET (易被拦) | **POST form** |
| 参数 | 仅 query + max_results | **+ region / safesearch / time_range** |
| 分页 | 无（单页20条） | **echo hidden form inputs，最多3页** |
| 反爬检测 | 无 | **301/202/403/418 检测 + no-results 标记** |
| 请求延迟 | 1-3s | **0.75-1.5s（DDG 阈值优化）** |
| VQD token | 无 | **images/news/videos 共享 VQD 管理** |
| 测试 | 0 个 | **37 个** |

## 新增文件（7 个）

| 文件 | 说明 |
|------|------|
| `src/souwen/web/ddg_utils.py` | VQD 多模式提取、分页表单解析、URL/文本规范化、过滤字符串构建 |
| `src/souwen/web/ddg_json.py` | DDGJsonClient 共享基类（VQD per-query + JSON 分页循环） |
| `src/souwen/web/ddg_news.py` | DuckDuckGoNewsClient (news.js 端点) |
| `src/souwen/web/ddg_images.py` | DuckDuckGoImagesClient (i.js 端点) + ImageSearchResult/Response 模型 |
| `src/souwen/web/ddg_videos.py` | DuckDuckGoVideosClient (v.js 端点) + VideoSearchResult/Response 模型 |
| `tests/test_web/test_duckduckgo.py` | DuckDuckGoClient 单元测试（12 cases） |
| `tests/test_web/test_ddg_extended.py` | Utils + News + Images + Videos 测试（25 cases） |

## 修改文件（9 个）

| 文件 | 变更内容 |
|------|---------|
| `src/souwen/scraper/base.py` | \_fetch() + \_do_request() 新增 `data=` 参数支持 POST 表单 |
| `src/souwen/web/duckduckgo.py` | 完全重写：POST + 分页 + 参数 + 反爬检测 + lxml 解析 |
| `src/souwen/models.py` | +3 SourceType 枚举 (WEB_DDG_NEWS/IMAGES/VIDEOS) |
| `src/souwen/source_registry.py` | +3 数据源注册 (general 类别) |
| `src/souwen/web/search.py` | 导入 + engine_map 注册 duckduckgo_news |
| `src/souwen/web/__init__.py` | 导出新客户端和模型 |
| `tests/test_doctor.py` | 计数 62→65 |
| `tests/test_models.py` | SourceType 计数 51→54 |
| `README.md` | 数据源总数 62→65，引擎描述更新 |

## 技术设计

### VQD Token 管理
- VQD 是 DDG JSON 接口的认证令牌（per-query，不跨查询缓存）
- 从 `GET duckduckgo.com/?q=<keywords>` 的 HTML 中提取
- 4 种正则模式覆盖 DDG 轮换格式：`vqd="..."`、`vqd='...'`、`vqd=...&`、`"vqd":"..."`

### 文本搜索（POST 表单）
- 端点：`POST https://html.duckduckgo.com/html/`
- 表单字段：`q`(关键词)、`b=""`、`kl`(区域)、`df`(时间范围)
- 分页：解析 DDG 返回的 `div.nav-link form` 中的 hidden inputs，原样回传
- 反爬：禁用 follow_redirects，301/202/403/418 视为阻断信号

### JSON 端点（News/Images/Videos）
- 共享基类 DDGJsonClient 管理 VQD 获取 + 分页循环
- 通过 `next` URL 中的 `s=<offset>` 参数分页
- 最多 5 页（videos 最多 8 页）

### 图片/视频专属过滤
- 图片：size/color/type/layout/license → 逗号拼接的 `f` 参数
- 视频：resolution/duration/license → 同上

### 架构决策
- **不引入 Chat**：维护负担大（DDG 月度轮换 FE 版本号），且非搜索能力，共享 IP 有封禁风险
- **images/videos 不注入 web_search() 聚合器**：返回类型不同（ImageSearchResponse/VideoSearchResponse），作为独立入口使用
- **duckduckgo_news 参与聚合**：返回 WebSearchResponse，可通过 `engines=["duckduckgo_news"]` 使用

## 测试

- 新增 37 个单元测试，覆盖：正常搜索、空结果、反爬检测、分页、去重、异常处理、参数传递、VQD 提取
- 全量 605 passed, 2 skipped
- ruff check + format 全部通过