### PR TITLE
feat(zotero): 新增 Zotero 个人文献库搜索客户端

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## 🎯 简介
 
-SouWen（搜文）为 AI Agent 提供统一的学术论文、专利和网页搜索接口，整合 **65 个数据源**，归一化为 Pydantic v2 数据模型。
+SouWen（搜文）为 AI Agent 提供统一的学术论文、专利和网页搜索接口，整合 **66 个数据源**，归一化为 Pydantic v2 数据模型。
 
 - **8 论文源 + 8 专利源 + 22 搜索引擎** — 18 个零配置即用（5 论文 + 2 专利 + 9 爬虫 + 2 自建）
 - **统一数据模型** — `PaperResult` / `PatentResult` / `WebSearchResult`
@@ -156,7 +156,7 @@ asyncio.run(main())
 
 | 文档 | 内容 |
 |------|------|
-| [数据源详情](docs/data-sources.md) | 65 个数据源完整列表、分级说明 |
+| [数据源详情](docs/data-sources.md) | 66 个数据源完整列表、分级说明 |
 | [配置详解](docs/configuration.md) | 配置优先级、全部字段、代理池、YAML 格式 |
 | [架构设计](docs/architecture.md) | 数据流、基类模式、限流器、异常体系、项目结构 |
 | [外观定制](docs/appearance.md) | 皮肤、明暗模式、配色方案、自定义皮肤指南 |

--- a/src/souwen/config.py
+++ b/src/souwen/config.py
@@ -200,6 +200,10 @@ class SouWenConfig(BaseModel):
     pubmed_api_key: str | None = None
     unpaywall_email: str | None = None
     ieee_api_key: str | None = None
+    # Zotero 个人文献库
+    zotero_api_key: str | None = None  # Zotero Web API Key
+    zotero_library_id: str | None = None  # 用户 ID 或群组 ID
+    zotero_library_type: str | None = None  # "user" (默认) 或 "group"
 
     # ===== 专利数据源 =====
     uspto_api_key: str | None = None

--- a/src/souwen/models.py
+++ b/src/souwen/models.py
@@ -129,6 +129,7 @@ class SourceType(str, Enum):
     CORE = "core"
     PUBMED = "pubmed"
     UNPAYWALL = "unpaywall"
+    ZOTERO = "zotero"
     # 专利数据源
     PATENTSVIEW = "patentsview"
     USPTO_ODP = "uspto_odp"
@@ -428,6 +429,7 @@ ALL_SOURCES: dict[str, list[tuple[str, bool, str]]] = {
         ("dblp", False, "DBLP 计算机科学索引"),
         ("core", True, "CORE 全文开放获取"),
         ("pubmed", False, "PubMed 生物医学"),
+        ("zotero", True, "Zotero 个人文献库搜索 (需 API Key + Library ID)"),
     ],
     "patent": [
         ("epo_ops", True, "EPO OPS 欧洲专利 (OAuth)"),

--- a/src/souwen/paper/__init__.py
+++ b/src/souwen/paper/__init__.py
@@ -23,6 +23,7 @@ from souwen.paper.core import CoreClient
 from souwen.paper.pubmed import PubMedClient
 from souwen.paper.unpaywall import UnpaywallClient
 from souwen.paper.pdf_fetcher import fetch_pdf
+from souwen.paper.zotero import ZoteroClient
 
 __all__ = [
     "OpenAlexClient",
@@ -35,4 +36,5 @@ __all__ = [
     "PubMedClient",
     "UnpaywallClient",
     "fetch_pdf",
+    "ZoteroClient",
 ]

--- a/src/souwen/paper/zotero.py
+++ b/src/souwen/paper/zotero.py
@@ -1,0 +1,461 @@
+"""Zotero 个人文献库搜索客户端
+
+官方文档: https://www.zotero.org/support/dev/web_api/v3/start
+鉴权: Zotero-API-Key 请求头，需要在 https://www.zotero.org/settings/keys 创建
+限流: 服务端可能返回 Backoff / Retry-After 头，客户端应遵守
+
+文件用途：Zotero 个人/群组文献库搜索客户端，支持全文搜索、标签过滤、
+         元数据获取、全文提取、集合列表等功能。
+
+函数/类清单：
+    ZoteroClient（类）
+        - 功能：Zotero 文献库搜索客户端，支持用户/群组两种库类型
+        - 关键属性：api_key (str) API Key, library_id (str) 库 ID,
+                   library_type (str) 库类型 (user/group),
+                   _client (SouWenHttpClient) HTTP 客户端,
+                   _limiter (TokenBucketLimiter) 限流器
+
+    search(query, qmode, tag, limit, start) -> SearchResponse
+        - 功能：搜索文献库中的条目
+        - 输入：query 搜索关键词, qmode 搜索模式, tag 标签过滤, limit/start 分页
+        - 输出：SearchResponse 包含 PaperResult 列表
+
+    get_item(item_key) -> PaperResult
+        - 功能：通过 key 获取单条文献元数据
+
+    get_fulltext(item_key) -> dict
+        - 功能：获取文献的全文内容（PDF/HTML 提取文本）
+
+    list_collections() -> list[dict]
+        - 功能：列出所有文献集合
+
+模块依赖：
+    - SouWenHttpClient: 统一 HTTP 客户端
+    - TokenBucketLimiter: 令牌桶限流器
+    - safe_parse_date: 安全日期解析工具
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from souwen._parsing import safe_parse_date
+from souwen.config import get_config
+from souwen.exceptions import ConfigError, NotFoundError, ParseError
+from souwen.http_client import SouWenHttpClient
+from souwen.models import Author, PaperResult, SearchResponse, SourceType
+from souwen.rate_limiter import TokenBucketLimiter
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://api.zotero.org"
+
+# Zotero 推荐速率（保守设定）
+_DEFAULT_RPS = 8.0
+
+# 需要排除的非文献条目类型
+_SKIP_ITEM_TYPES = frozenset({"note", "attachment", "annotation"})
+
+# 可提取全文的附件链接模式
+_IMPORTABLE_LINK_MODES = frozenset({"imported_file", "imported_url"})
+
+# Zotero Key 注册页面
+_REGISTER_URL = "https://www.zotero.org/settings/keys"
+
+
+class ZoteroClient:
+    """Zotero 个人/群组文献库搜索客户端。
+
+    Attributes:
+        api_key: Zotero API Key。
+        library_id: 文献库 ID（用户 ID 或群组 ID）。
+        library_type: 库类型，``"user"`` 或 ``"group"``。
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        library_id: str | None = None,
+        library_type: str | None = None,
+    ) -> None:
+        cfg = get_config()
+        self.api_key: str | None = api_key or cfg.resolve_api_key(
+            "zotero", "zotero_api_key"
+        )
+        self.library_id: str | None = library_id or getattr(
+            cfg, "zotero_library_id", None
+        )
+        self.library_type: str = (
+            library_type
+            or getattr(cfg, "zotero_library_type", None)
+            or "user"
+        )
+
+        if not self.api_key:
+            raise ConfigError(
+                key="zotero_api_key",
+                service="Zotero",
+                register_url=_REGISTER_URL,
+            )
+        if not self.library_id:
+            raise ConfigError(
+                key="zotero_library_id",
+                service="Zotero",
+                register_url="https://www.zotero.org/settings",
+            )
+
+        # 去除用户复制粘贴可能带来的空格
+        self.library_id = str(self.library_id).strip()
+
+        headers: dict[str, str] = {"Zotero-API-Key": self.api_key}
+        self._client = SouWenHttpClient(
+            base_url=_BASE_URL, headers=headers, source_name="zotero"
+        )
+        self._limiter = TokenBucketLimiter(rate=_DEFAULT_RPS, burst=_DEFAULT_RPS)
+
+    # ------------------------------------------------------------------
+    # async context manager
+    # ------------------------------------------------------------------
+
+    async def __aenter__(self) -> ZoteroClient:
+        await self._client.__aenter__()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> None:
+        await self._client.__aexit__(exc_type, exc_val, exc_tb)
+
+    # ------------------------------------------------------------------
+    # 内部工具
+    # ------------------------------------------------------------------
+
+    @property
+    def _base_path(self) -> str:
+        """构建库前缀路径。"""
+        if self.library_type == "group":
+            return f"/groups/{self.library_id}"
+        return f"/users/{self.library_id}"
+
+    async def _respect_backoff(self, resp: Any) -> None:
+        """遵守 Zotero 服务端的 Backoff / Retry-After 头。"""
+        backoff = resp.headers.get("Backoff") or resp.headers.get("Retry-After")
+        if backoff:
+            try:
+                delay = float(backoff)
+                if 0 < delay <= 60:
+                    logger.info("Zotero Backoff: 等待 %.1f 秒", delay)
+                    await asyncio.sleep(delay)
+            except (ValueError, TypeError):
+                pass
+
+    @staticmethod
+    def _is_paper_type(item: dict[str, Any]) -> bool:
+        """判断是否为文献条目（排除笔记、附件、注释）。"""
+        return item.get("data", {}).get("itemType", "") not in _SKIP_ITEM_TYPES
+
+    def _parse_item(self, item: dict[str, Any]) -> PaperResult:
+        """将 Zotero 条目转换为 PaperResult。
+
+        Args:
+            item: Zotero API 返回的单条 item JSON。
+
+        Returns:
+            统一的 PaperResult 模型。
+
+        Raises:
+            ParseError: 解析失败。
+        """
+        try:
+            data = item.get("data", {})
+
+            # 提取作者列表
+            creators = data.get("creators", [])
+            authors: list[Author] = []
+            for c in creators:
+                if "lastName" in c:
+                    name = f"{c.get('firstName', '')} {c['lastName']}".strip()
+                else:
+                    name = c.get("name", "")
+                if name:
+                    authors.append(Author(name=name))
+
+            # 提取 DOI
+            doi: str | None = (data.get("DOI") or "").strip() or None
+
+            # 提取日期和年份（调用一次，复用结果）
+            pub_date = safe_parse_date(data.get("date"))
+            year: int | None = pub_date.year if pub_date else None
+
+            # 构建 source_url
+            item_key = item.get("key", "")
+            url = data.get("url", "")
+            if not url and doi:
+                url = f"https://doi.org/{doi}"
+            if not url:
+                url = f"{_BASE_URL}{self._base_path}/items/{item_key}"
+
+            # 提取标签
+            tags = [
+                t.get("tag", "")
+                for t in data.get("tags", [])
+                if t.get("tag")
+            ]
+
+            return PaperResult(
+                source=SourceType.ZOTERO,
+                title=data.get("title", ""),
+                authors=authors,
+                abstract=data.get("abstractNote", "") or None,
+                doi=doi,
+                year=year,
+                publication_date=pub_date,
+                journal=(
+                    data.get("publicationTitle")
+                    or data.get("bookTitle")
+                    or None
+                ),
+                venue=(
+                    data.get("conferenceName")
+                    or data.get("proceedingsTitle")
+                    or None
+                ),
+                source_url=url,
+                raw={
+                    "item_key": item_key,
+                    "item_type": data.get("itemType"),
+                    "tags": tags,
+                },
+            )
+        except Exception as exc:
+            raise ParseError(f"解析 Zotero item 失败: {exc}") from exc
+
+    @staticmethod
+    def _pick_best_attachment(children: list[dict[str, Any]]) -> str | None:
+        """从子条目中选择最佳可提取全文的附件。
+
+        优先级: imported PDF > imported HTML > 其他 imported
+        在同类中按 dateAdded 倒序选取最新的。
+        """
+        candidates: list[dict[str, Any]] = []
+        for child in children:
+            d = child.get("data", {})
+            link_mode = d.get("linkMode", "")
+            if link_mode not in _IMPORTABLE_LINK_MODES:
+                continue
+            candidates.append(child)
+
+        if not candidates:
+            return None
+
+        # 分类：PDF / HTML / 其他
+        pdfs = [
+            c for c in candidates
+            if c["data"].get("contentType") == "application/pdf"
+        ]
+        htmls = [
+            c for c in candidates
+            if (c["data"].get("contentType") or "").startswith("text/html")
+        ]
+        others = [
+            c for c in candidates
+            if c not in pdfs and c not in htmls
+        ]
+
+        # 每组按 dateAdded 倒序
+        def _sort_key(c: dict[str, Any]) -> str:
+            return c.get("data", {}).get("dateAdded", "")
+
+        for group in [pdfs, htmls, others]:
+            if group:
+                group.sort(key=_sort_key, reverse=True)
+                return group[0].get("key", "")
+
+        return None
+
+    # ------------------------------------------------------------------
+    # 公开方法
+    # ------------------------------------------------------------------
+
+    async def search(
+        self,
+        query: str,
+        qmode: str = "everything",
+        tag: str | None = None,
+        limit: int = 10,
+        start: int = 0,
+    ) -> SearchResponse:
+        """搜索文献库中的条目。
+
+        Args:
+            query: 搜索关键词。
+            qmode: 搜索模式，``"titleCreatorYear"`` 或 ``"everything"``（全文）。
+            tag: 标签过滤（支持布尔语法，如 ``"tag1 || tag2"``、``"-exclude"``）。
+            limit: 返回条数，上限 100。
+            start: 起始偏移量。
+
+        Returns:
+            SearchResponse 包含 PaperResult 列表。
+        """
+        await self._limiter.acquire()
+
+        params: dict[str, str | int] = {
+            "q": query,
+            "qmode": qmode,
+            "limit": min(limit, 100),
+            "start": start,
+            "itemType": "-note || -attachment || -annotation",
+        }
+        if tag:
+            params["tag"] = tag
+
+        resp = await self._client.get(
+            f"{self._base_path}/items", params=params
+        )
+        await self._respect_backoff(resp)
+
+        # Zotero 通过 Total-Results 头返回总数
+        total = int(resp.headers.get("Total-Results", "0"))
+        items: list[dict[str, Any]] = resp.json()
+
+        results = [
+            self._parse_item(item)
+            for item in items
+            if self._is_paper_type(item)
+        ]
+
+        return SearchResponse(
+            query=query,
+            source=SourceType.ZOTERO,
+            total_results=total,
+            results=results,
+            page=(start // max(limit, 1)) + 1,
+            per_page=limit,
+        )
+
+    async def get_item(self, item_key: str) -> PaperResult:
+        """通过 key 获取单条文献元数据。
+
+        Args:
+            item_key: Zotero item key（如 ``"ABCD1234"``）。
+
+        Returns:
+            PaperResult 模型。
+
+        Raises:
+            NotFoundError: 条目不存在。
+        """
+        await self._limiter.acquire()
+        resp = await self._client.get(
+            f"{self._base_path}/items/{item_key}"
+        )
+        await self._respect_backoff(resp)
+
+        if resp.status_code == 404:
+            raise NotFoundError(f"Zotero 未找到条目: {item_key}")
+
+        return self._parse_item(resp.json())
+
+    async def get_fulltext(self, item_key: str) -> dict[str, Any]:
+        """获取文献的全文内容。
+
+        如果 item_key 指向一个父条目（非附件），会自动查找最佳附件。
+        全文来自 Zotero 服务端的索引（PDF 需已被 Zotero 索引）。
+
+        Args:
+            item_key: Zotero item key。
+
+        Returns:
+            包含 ``content``、``word_count``、``indexed_pages`` 等信息的字典。
+
+        Raises:
+            NotFoundError: 找不到可提取全文的附件，或附件未被索引。
+        """
+        await self._limiter.acquire()
+
+        # 获取条目信息
+        resp = await self._client.get(
+            f"{self._base_path}/items/{item_key}"
+        )
+        await self._respect_backoff(resp)
+
+        if resp.status_code == 404:
+            raise NotFoundError(f"Zotero 未找到条目: {item_key}")
+
+        item = resp.json()
+        item_type = item.get("data", {}).get("itemType", "")
+
+        # 如果不是附件，查找最佳子附件
+        attachment_key = item_key
+        if item_type != "attachment":
+            await self._limiter.acquire()
+            children_resp = await self._client.get(
+                f"{self._base_path}/items/{item_key}/children"
+            )
+            await self._respect_backoff(children_resp)
+
+            children: list[dict[str, Any]] = children_resp.json()
+            best = self._pick_best_attachment(children)
+            if not best:
+                raise NotFoundError(
+                    f"Zotero 条目 {item_key} 没有可提取全文的附件"
+                )
+            attachment_key = best
+
+        # 获取全文
+        await self._limiter.acquire()
+        try:
+            ft_resp = await self._client.get(
+                f"{self._base_path}/items/{attachment_key}/fulltext"
+            )
+            await self._respect_backoff(ft_resp)
+        except Exception:
+            raise NotFoundError(
+                f"Zotero 附件 {attachment_key} 的全文未被索引（需 Zotero 7.1+）"
+            )
+
+        if ft_resp.status_code == 404:
+            raise NotFoundError(
+                f"Zotero 附件 {attachment_key} 的全文未被索引"
+            )
+
+        data = ft_resp.json()
+        content = data.get("content", "")
+
+        return {
+            "item_key": item_key,
+            "attachment_key": attachment_key,
+            "content": content,
+            "word_count": len(content.split()) if content else 0,
+            "indexed_pages": data.get("indexedPages"),
+            "total_pages": data.get("totalPages"),
+            "indexed_chars": data.get("indexedChars"),
+            "total_chars": data.get("totalChars"),
+        }
+
+    async def list_collections(self) -> list[dict[str, Any]]:
+        """列出文献库中的所有集合。
+
+        Returns:
+            集合列表，每项包含 ``key``、``name``、``parent`` 字段。
+        """
+        await self._limiter.acquire()
+        resp = await self._client.get(
+            f"{self._base_path}/collections"
+        )
+        await self._respect_backoff(resp)
+
+        return [
+            {
+                "key": c.get("key", ""),
+                "name": c.get("data", {}).get("name", ""),
+                "parent": c.get("data", {}).get("parentCollection"),
+                "num_items": c.get("meta", {}).get("numItems", 0),
+            }
+            for c in resp.json()
+        ]

--- a/src/souwen/paper/zotero.py
+++ b/src/souwen/paper/zotero.py
@@ -81,17 +81,9 @@ class ZoteroClient:
         library_type: str | None = None,
     ) -> None:
         cfg = get_config()
-        self.api_key: str | None = api_key or cfg.resolve_api_key(
-            "zotero", "zotero_api_key"
-        )
-        self.library_id: str | None = library_id or getattr(
-            cfg, "zotero_library_id", None
-        )
-        self.library_type: str = (
-            library_type
-            or getattr(cfg, "zotero_library_type", None)
-            or "user"
-        )
+        self.api_key: str | None = api_key or cfg.resolve_api_key("zotero", "zotero_api_key")
+        self.library_id: str | None = library_id or getattr(cfg, "zotero_library_id", None)
+        self.library_type: str = library_type or getattr(cfg, "zotero_library_type", None) or "user"
 
         if not self.api_key:
             raise ConfigError(
@@ -110,9 +102,7 @@ class ZoteroClient:
         self.library_id = str(self.library_id).strip()
 
         headers: dict[str, str] = {"Zotero-API-Key": self.api_key}
-        self._client = SouWenHttpClient(
-            base_url=_BASE_URL, headers=headers, source_name="zotero"
-        )
+        self._client = SouWenHttpClient(base_url=_BASE_URL, headers=headers, source_name="zotero")
         self._limiter = TokenBucketLimiter(rate=_DEFAULT_RPS, burst=_DEFAULT_RPS)
 
     # ------------------------------------------------------------------
@@ -201,11 +191,7 @@ class ZoteroClient:
                 url = f"{_BASE_URL}{self._base_path}/items/{item_key}"
 
             # 提取标签
-            tags = [
-                t.get("tag", "")
-                for t in data.get("tags", [])
-                if t.get("tag")
-            ]
+            tags = [t.get("tag", "") for t in data.get("tags", []) if t.get("tag")]
 
             return PaperResult(
                 source=SourceType.ZOTERO,
@@ -215,16 +201,8 @@ class ZoteroClient:
                 doi=doi,
                 year=year,
                 publication_date=pub_date,
-                journal=(
-                    data.get("publicationTitle")
-                    or data.get("bookTitle")
-                    or None
-                ),
-                venue=(
-                    data.get("conferenceName")
-                    or data.get("proceedingsTitle")
-                    or None
-                ),
+                journal=(data.get("publicationTitle") or data.get("bookTitle") or None),
+                venue=(data.get("conferenceName") or data.get("proceedingsTitle") or None),
                 source_url=url,
                 raw={
                     "item_key": item_key,
@@ -254,18 +232,11 @@ class ZoteroClient:
             return None
 
         # 分类：PDF / HTML / 其他
-        pdfs = [
-            c for c in candidates
-            if c["data"].get("contentType") == "application/pdf"
-        ]
+        pdfs = [c for c in candidates if c["data"].get("contentType") == "application/pdf"]
         htmls = [
-            c for c in candidates
-            if (c["data"].get("contentType") or "").startswith("text/html")
+            c for c in candidates if (c["data"].get("contentType") or "").startswith("text/html")
         ]
-        others = [
-            c for c in candidates
-            if c not in pdfs and c not in htmls
-        ]
+        others = [c for c in candidates if c not in pdfs and c not in htmls]
 
         # 每组按 dateAdded 倒序
         def _sort_key(c: dict[str, Any]) -> str:
@@ -314,20 +285,14 @@ class ZoteroClient:
         if tag:
             params["tag"] = tag
 
-        resp = await self._client.get(
-            f"{self._base_path}/items", params=params
-        )
+        resp = await self._client.get(f"{self._base_path}/items", params=params)
         await self._respect_backoff(resp)
 
         # Zotero 通过 Total-Results 头返回总数
         total = int(resp.headers.get("Total-Results", "0"))
         items: list[dict[str, Any]] = resp.json()
 
-        results = [
-            self._parse_item(item)
-            for item in items
-            if self._is_paper_type(item)
-        ]
+        results = [self._parse_item(item) for item in items if self._is_paper_type(item)]
 
         return SearchResponse(
             query=query,
@@ -351,9 +316,7 @@ class ZoteroClient:
             NotFoundError: 条目不存在。
         """
         await self._limiter.acquire()
-        resp = await self._client.get(
-            f"{self._base_path}/items/{item_key}"
-        )
+        resp = await self._client.get(f"{self._base_path}/items/{item_key}")
         await self._respect_backoff(resp)
 
         if resp.status_code == 404:
@@ -379,9 +342,7 @@ class ZoteroClient:
         await self._limiter.acquire()
 
         # 获取条目信息
-        resp = await self._client.get(
-            f"{self._base_path}/items/{item_key}"
-        )
+        resp = await self._client.get(f"{self._base_path}/items/{item_key}")
         await self._respect_backoff(resp)
 
         if resp.status_code == 404:
@@ -394,35 +355,25 @@ class ZoteroClient:
         attachment_key = item_key
         if item_type != "attachment":
             await self._limiter.acquire()
-            children_resp = await self._client.get(
-                f"{self._base_path}/items/{item_key}/children"
-            )
+            children_resp = await self._client.get(f"{self._base_path}/items/{item_key}/children")
             await self._respect_backoff(children_resp)
 
             children: list[dict[str, Any]] = children_resp.json()
             best = self._pick_best_attachment(children)
             if not best:
-                raise NotFoundError(
-                    f"Zotero 条目 {item_key} 没有可提取全文的附件"
-                )
+                raise NotFoundError(f"Zotero 条目 {item_key} 没有可提取全文的附件")
             attachment_key = best
 
         # 获取全文
         await self._limiter.acquire()
         try:
-            ft_resp = await self._client.get(
-                f"{self._base_path}/items/{attachment_key}/fulltext"
-            )
+            ft_resp = await self._client.get(f"{self._base_path}/items/{attachment_key}/fulltext")
             await self._respect_backoff(ft_resp)
         except Exception:
-            raise NotFoundError(
-                f"Zotero 附件 {attachment_key} 的全文未被索引（需 Zotero 7.1+）"
-            )
+            raise NotFoundError(f"Zotero 附件 {attachment_key} 的全文未被索引（需 Zotero 7.1+）")
 
         if ft_resp.status_code == 404:
-            raise NotFoundError(
-                f"Zotero 附件 {attachment_key} 的全文未被索引"
-            )
+            raise NotFoundError(f"Zotero 附件 {attachment_key} 的全文未被索引")
 
         data = ft_resp.json()
         content = data.get("content", "")
@@ -445,9 +396,7 @@ class ZoteroClient:
             集合列表，每项包含 ``key``、``name``、``parent`` 字段。
         """
         await self._limiter.acquire()
-        resp = await self._client.get(
-            f"{self._base_path}/collections"
-        )
+        resp = await self._client.get(f"{self._base_path}/collections")
         await self._respect_backoff(resp)
 
         return [

--- a/src/souwen/search.py
+++ b/src/souwen/search.py
@@ -83,6 +83,7 @@ from souwen.paper.arxiv import ArxivClient
 from souwen.paper.dblp import DblpClient
 from souwen.paper.core import CoreClient
 from souwen.paper.pubmed import PubMedClient
+from souwen.paper.zotero import ZoteroClient
 
 # ── 专利客户端 ──────────────────────────────────────────────
 from souwen.patent.patentsview import PatentsViewClient
@@ -254,6 +255,13 @@ _PAPER_SOURCES: dict[str, Any] = {
         "search",
         query=q,
         retmax=n,
+        **kw,
+    ),
+    "zotero": lambda q, n, **kw: _run_client(
+        ZoteroClient,
+        "search",
+        query=q,
+        limit=n,
         **kw,
     ),
 }

--- a/src/souwen/source_registry.py
+++ b/src/souwen/source_registry.py
@@ -128,6 +128,13 @@ _reg(
 )
 _reg("core", "paper", "official_api", "core_api_key", description="CORE 开放获取聚合")
 _reg("unpaywall", "paper", "official_api", "unpaywall_email", description="Unpaywall OA 查找")
+_reg(
+    "zotero",
+    "paper",
+    "official_api",
+    "zotero_api_key",
+    description="Zotero 个人文献库搜索 (需 API Key + Library ID)",
+)
 
 # ── 专利：公开接口 ────────────────────────────────────────
 _reg("patentsview", "patent", "open_api", None, description="PatentsView 美国专利 (待修复)")

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,11 +1,11 @@
 """SouWen doctor 模块测试。
 
 覆盖 ``souwen.doctor`` 中 ``check_all()`` 与 ``format_report()`` 的诊断功能。
-验证：65 个数据源的完整性检查、状态判断（ok/missing_key/limited/unavailable/warning）、
+验证：66 个数据源的完整性检查、状态判断（ok/missing_key/limited/unavailable/warning）、
 报告格式化与符号呈现、以及 Tier 分层显示。
 
 测试清单：
-- ``TestCheckAll``：check_all() 返回 65 源、必要字段完整性、Key 配置状态检测
+- ``TestCheckAll``：check_all() 返回 66 源、必要字段完整性、Key 配置状态检测
 - ``TestFormatReport``：format_report() 字符串输出、标题/Tier 分组、状态符号
 """
 
@@ -23,7 +23,7 @@ class TestCheckAll:
 
         get_config.cache_clear()
         results = check_all()
-        assert len(results) == 65
+        assert len(results) == 66
 
     def test_result_has_required_keys(self):
         """每条结果包含必要字段"""
@@ -102,8 +102,8 @@ class TestCheckAll:
             get_config.cache_clear()
 
     def test_source_config_matches_37(self):
-        """source registry 有 65 个数据源"""
-        assert len(get_all_sources()) == 65
+        """source registry 有 66 个数据源"""
+        assert len(get_all_sources()) == 66
 
     def test_semantic_scholar_without_key_is_limited(self, monkeypatch):
         """Semantic Scholar 无 Key 时标记为 limited。"""

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -414,7 +414,7 @@ class TestUnifiedSearch:
         """论文数据源映射完整性"""
         from souwen.search import _PAPER_SOURCES, _DEFAULT_PAPER_SOURCES
 
-        assert len(_PAPER_SOURCES) == 7  # 7 sources (unpaywall excluded as DOI resolver)
+        assert len(_PAPER_SOURCES) == 8  # 8 sources (unpaywall excluded as DOI resolver)
         for s in _DEFAULT_PAPER_SOURCES:
             assert s in _PAPER_SOURCES, f"默认源 {s} 不在映射中"
 
@@ -493,7 +493,7 @@ class TestCLI:
         """数据源清单完整性"""
         from souwen.models import ALL_SOURCES
 
-        assert len(ALL_SOURCES["paper"]) == 7
+        assert len(ALL_SOURCES["paper"]) == 8
         assert len(ALL_SOURCES["patent"]) == 6
         total_web = sum(
             len(ALL_SOURCES[c])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -28,8 +28,8 @@ class TestAllSources:
     """ALL_SOURCES 元信息测试"""
 
     def test_paper_count(self):
-        """paper 暴露 7 个搜索数据源"""
-        assert len(ALL_SOURCES["paper"]) == 7
+        """paper 暴露 8 个搜索数据源"""
+        assert len(ALL_SOURCES["paper"]) == 8
 
     def test_patent_count(self):
         """patent 暴露 6 个搜索数据源"""
@@ -47,7 +47,7 @@ class TestAllSources:
     def test_total_count(self):
         """总计暴露 34 个可选数据源"""
         total = sum(len(v) for v in ALL_SOURCES.values())
-        assert total == 47
+        assert total == 48
 
     def test_each_entry_is_tuple_of_three(self):
         """每条目是 (name, requires_key, desc) 三元组"""
@@ -82,7 +82,7 @@ class TestSourceTypeEnum:
 
     def test_has_37_values(self):
         """枚举有 48 个值"""
-        assert len(SourceType) == 54
+        assert len(SourceType) == 55
 
     def test_paper_sources_exist(self):
         """论文数据源枚举存在"""

--- a/tests/test_paper/test_zotero.py
+++ b/tests/test_paper/test_zotero.py
@@ -1,0 +1,502 @@
+"""Zotero 客户端单元测试（pytest-httpx mock）。
+
+覆盖 ``souwen.paper.zotero`` 中 ZoteroClient 的搜索、条目获取、全文提取、
+集合列表、附件选择逻辑等。
+
+测试清单：
+- ``test_search_basic``：基本搜索解析
+- ``test_search_with_tag_filter``：标签过滤搜索
+- ``test_search_pagination``：分页偏移逻辑
+- ``test_search_empty_results``：无结果处理
+- ``test_search_filters_notes``：排除笔记/附件/注释
+- ``test_get_item``：单条目获取
+- ``test_get_fulltext_from_parent``：从父条目查找附件后提取全文
+- ``test_get_fulltext_direct_attachment``：直接附件全文提取
+- ``test_get_fulltext_no_attachment``：无可用附件时抛异常
+- ``test_list_collections``：集合列表
+- ``test_pick_best_attachment_prefers_pdf``：附件选择优先 PDF
+- ``test_pick_best_attachment_filters_linked``：排除 linked 附件
+- ``test_parse_item_minimal``：最小字段解析
+- ``test_config_error_no_api_key``：无 API Key 抛 ConfigError
+- ``test_config_error_no_library_id``：无 Library ID 抛 ConfigError
+- ``test_group_library_path``：群组库路径正确性
+- ``test_backoff_header_respected``：Backoff 头处理
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from souwen.exceptions import ConfigError, NotFoundError
+from souwen.models import SourceType
+from souwen.paper.zotero import ZoteroClient
+
+
+# ---------------------------------------------------------------------------
+# Fixtures & mock data
+# ---------------------------------------------------------------------------
+
+ZOTERO_ITEM_1 = {
+    "key": "ABCD1234",
+    "version": 42,
+    "data": {
+        "key": "ABCD1234",
+        "itemType": "journalArticle",
+        "title": "Attention Is All You Need",
+        "creators": [
+            {"creatorType": "author", "firstName": "Ashish", "lastName": "Vaswani"},
+            {"creatorType": "author", "name": "Google Brain Team"},
+        ],
+        "date": "2017-06-12",
+        "DOI": "10.1038/s41586-021-03819-2",
+        "url": "https://arxiv.org/abs/1706.03762",
+        "abstractNote": "The dominant sequence transduction models...",
+        "publicationTitle": "Nature",
+        "tags": [{"tag": "transformer"}, {"tag": "attention"}],
+    },
+    "meta": {"numChildren": 1},
+}
+
+ZOTERO_ITEM_NOTE = {
+    "key": "NOTE0001",
+    "data": {
+        "key": "NOTE0001",
+        "itemType": "note",
+        "note": "<p>My note</p>",
+        "tags": [],
+    },
+}
+
+ZOTERO_ITEM_BOOK = {
+    "key": "BOOK0001",
+    "data": {
+        "key": "BOOK0001",
+        "itemType": "book",
+        "title": "Deep Learning",
+        "creators": [
+            {"creatorType": "author", "firstName": "Ian", "lastName": "Goodfellow"},
+        ],
+        "date": "2016",
+        "DOI": "",
+        "url": "",
+        "abstractNote": "",
+        "bookTitle": "MIT Press Series",
+        "tags": [],
+    },
+}
+
+ZOTERO_ATTACHMENT_PDF = {
+    "key": "PDF00001",
+    "data": {
+        "key": "PDF00001",
+        "itemType": "attachment",
+        "contentType": "application/pdf",
+        "linkMode": "imported_file",
+        "dateAdded": "2024-01-15T10:00:00Z",
+        "tags": [],
+    },
+}
+
+ZOTERO_ATTACHMENT_HTML = {
+    "key": "HTML0001",
+    "data": {
+        "key": "HTML0001",
+        "itemType": "attachment",
+        "contentType": "text/html",
+        "linkMode": "imported_url",
+        "dateAdded": "2024-01-16T10:00:00Z",
+        "tags": [],
+    },
+}
+
+ZOTERO_ATTACHMENT_LINKED = {
+    "key": "LINK0001",
+    "data": {
+        "key": "LINK0001",
+        "itemType": "attachment",
+        "contentType": "application/pdf",
+        "linkMode": "linked_url",
+        "dateAdded": "2024-01-17T10:00:00Z",
+        "tags": [],
+    },
+}
+
+ZOTERO_FULLTEXT = {
+    "content": "The dominant sequence transduction models are based on complex...",
+    "indexedPages": 15,
+    "totalPages": 15,
+    "indexedChars": 50000,
+    "totalChars": 50000,
+}
+
+ZOTERO_COLLECTIONS = [
+    {
+        "key": "COL00001",
+        "data": {"name": "Transformers", "parentCollection": False},
+        "meta": {"numItems": 12},
+    },
+    {
+        "key": "COL00002",
+        "data": {"name": "NLP Subset", "parentCollection": "COL00001"},
+        "meta": {"numItems": 5},
+    },
+]
+
+
+@pytest.fixture()
+def zotero_env(monkeypatch):
+    """设置 Zotero 必要环境变量。"""
+    monkeypatch.setenv("SOUWEN_ZOTERO_API_KEY", "test-zotero-key-123")
+    monkeypatch.setenv("SOUWEN_ZOTERO_LIBRARY_ID", "9876543")
+    monkeypatch.setenv("SOUWEN_ZOTERO_LIBRARY_TYPE", "user")
+    from souwen.config import get_config
+
+    get_config.cache_clear()
+    yield
+    get_config.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Search tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_basic(httpx_mock: HTTPXMock, zotero_env):
+    """基本搜索：解析条目、作者、DOI、日期。"""
+    httpx_mock.add_response(
+        url=re.compile(r".*/users/9876543/items\?.*"),
+        json=[ZOTERO_ITEM_1],
+        headers={"Total-Results": "1"},
+    )
+    async with ZoteroClient() as client:
+        resp = await client.search("attention")
+
+    assert resp.source == SourceType.ZOTERO
+    assert resp.query == "attention"
+    assert resp.total_results == 1
+    assert len(resp.results) == 1
+
+    paper = resp.results[0]
+    assert paper.title == "Attention Is All You Need"
+    assert len(paper.authors) == 2
+    assert paper.authors[0].name == "Ashish Vaswani"
+    assert paper.authors[1].name == "Google Brain Team"
+    assert paper.doi == "10.1038/s41586-021-03819-2"
+    assert paper.year == 2017
+    assert paper.journal == "Nature"
+    assert paper.raw["tags"] == ["transformer", "attention"]
+    assert paper.raw["item_key"] == "ABCD1234"
+
+
+@pytest.mark.asyncio
+async def test_search_with_tag_filter(httpx_mock: HTTPXMock, zotero_env):
+    """标签过滤搜索。"""
+    httpx_mock.add_response(
+        url=re.compile(r".*/users/9876543/items\?.*tag=transformer.*"),
+        json=[ZOTERO_ITEM_1],
+        headers={"Total-Results": "1"},
+    )
+    async with ZoteroClient() as client:
+        resp = await client.search("attention", tag="transformer")
+
+    assert len(resp.results) == 1
+
+
+@pytest.mark.asyncio
+async def test_search_pagination(httpx_mock: HTTPXMock, zotero_env):
+    """分页偏移逻辑。"""
+    httpx_mock.add_response(
+        url=re.compile(r".*/users/9876543/items\?.*start=10.*"),
+        json=[ZOTERO_ITEM_1],
+        headers={"Total-Results": "50"},
+    )
+    async with ZoteroClient() as client:
+        resp = await client.search("test", limit=10, start=10)
+
+    assert resp.page == 2
+    assert resp.per_page == 10
+    assert resp.total_results == 50
+
+
+@pytest.mark.asyncio
+async def test_search_empty_results(httpx_mock: HTTPXMock, zotero_env):
+    """无结果处理。"""
+    httpx_mock.add_response(
+        url=re.compile(r".*/users/9876543/items\?.*"),
+        json=[],
+        headers={"Total-Results": "0"},
+    )
+    async with ZoteroClient() as client:
+        resp = await client.search("nonexistent_query_xyz")
+
+    assert resp.total_results == 0
+    assert len(resp.results) == 0
+
+
+@pytest.mark.asyncio
+async def test_search_filters_notes(httpx_mock: HTTPXMock, zotero_env):
+    """客户端侧排除笔记/附件条目。"""
+    httpx_mock.add_response(
+        url=re.compile(r".*/users/9876543/items\?.*"),
+        json=[ZOTERO_ITEM_1, ZOTERO_ITEM_NOTE],
+        headers={"Total-Results": "2"},
+    )
+    async with ZoteroClient() as client:
+        resp = await client.search("mixed")
+
+    # 笔记被过滤，只剩 1 条
+    assert len(resp.results) == 1
+    assert resp.results[0].title == "Attention Is All You Need"
+
+
+# ---------------------------------------------------------------------------
+# Get item tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_item(httpx_mock: HTTPXMock, zotero_env):
+    """单条目获取。"""
+    httpx_mock.add_response(
+        url=re.compile(r".*/users/9876543/items/ABCD1234$"),
+        json=ZOTERO_ITEM_1,
+    )
+    async with ZoteroClient() as client:
+        paper = await client.get_item("ABCD1234")
+
+    assert paper.title == "Attention Is All You Need"
+    assert paper.source == SourceType.ZOTERO
+
+
+# ---------------------------------------------------------------------------
+# Fulltext tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_fulltext_from_parent(httpx_mock: HTTPXMock, zotero_env):
+    """从父条目自动查找附件后提取全文。"""
+    # 第 1 次请求：获取父条目
+    httpx_mock.add_response(
+        url=re.compile(r".*/users/9876543/items/ABCD1234$"),
+        json=ZOTERO_ITEM_1,
+    )
+    # 第 2 次请求：获取子条目
+    httpx_mock.add_response(
+        url=re.compile(r".*/users/9876543/items/ABCD1234/children$"),
+        json=[ZOTERO_ATTACHMENT_PDF, ZOTERO_ATTACHMENT_HTML],
+    )
+    # 第 3 次请求：获取全文
+    httpx_mock.add_response(
+        url=re.compile(r".*/users/9876543/items/PDF00001/fulltext$"),
+        json=ZOTERO_FULLTEXT,
+    )
+
+    async with ZoteroClient() as client:
+        result = await client.get_fulltext("ABCD1234")
+
+    assert result["item_key"] == "ABCD1234"
+    assert result["attachment_key"] == "PDF00001"
+    assert "dominant sequence" in result["content"]
+    assert result["word_count"] > 0
+    assert result["indexed_pages"] == 15
+
+
+@pytest.mark.asyncio
+async def test_get_fulltext_direct_attachment(httpx_mock: HTTPXMock, zotero_env):
+    """直接附件提取全文（跳过子条目查找）。"""
+    httpx_mock.add_response(
+        url=re.compile(r".*/users/9876543/items/PDF00001$"),
+        json=ZOTERO_ATTACHMENT_PDF,
+    )
+    httpx_mock.add_response(
+        url=re.compile(r".*/users/9876543/items/PDF00001/fulltext$"),
+        json=ZOTERO_FULLTEXT,
+    )
+
+    async with ZoteroClient() as client:
+        result = await client.get_fulltext("PDF00001")
+
+    assert result["attachment_key"] == "PDF00001"
+    assert result["content"] != ""
+
+
+@pytest.mark.asyncio
+async def test_get_fulltext_no_attachment(httpx_mock: HTTPXMock, zotero_env):
+    """无可用附件时抛 NotFoundError。"""
+    httpx_mock.add_response(
+        url=re.compile(r".*/users/9876543/items/BOOK0001$"),
+        json=ZOTERO_ITEM_BOOK,
+    )
+    httpx_mock.add_response(
+        url=re.compile(r".*/users/9876543/items/BOOK0001/children$"),
+        json=[ZOTERO_ATTACHMENT_LINKED],  # 仅 linked 附件，不可提取全文
+    )
+
+    async with ZoteroClient() as client:
+        with pytest.raises(NotFoundError, match="没有可提取全文的附件"):
+            await client.get_fulltext("BOOK0001")
+
+
+# ---------------------------------------------------------------------------
+# Collections test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_collections(httpx_mock: HTTPXMock, zotero_env):
+    """集合列表解析。"""
+    httpx_mock.add_response(
+        url=re.compile(r".*/users/9876543/collections$"),
+        json=ZOTERO_COLLECTIONS,
+    )
+    async with ZoteroClient() as client:
+        cols = await client.list_collections()
+
+    assert len(cols) == 2
+    assert cols[0]["name"] == "Transformers"
+    assert cols[0]["num_items"] == 12
+    assert cols[1]["parent"] == "COL00001"
+
+
+# ---------------------------------------------------------------------------
+# Attachment selection tests
+# ---------------------------------------------------------------------------
+
+
+def test_pick_best_attachment_prefers_pdf():
+    """附件选择优先 PDF，按 dateAdded 倒序。"""
+    key = ZoteroClient._pick_best_attachment(
+        [ZOTERO_ATTACHMENT_HTML, ZOTERO_ATTACHMENT_PDF]
+    )
+    assert key == "PDF00001"
+
+
+def test_pick_best_attachment_filters_linked():
+    """排除 linked_url 模式的附件。"""
+    key = ZoteroClient._pick_best_attachment(
+        [ZOTERO_ATTACHMENT_LINKED]
+    )
+    assert key is None
+
+
+def test_pick_best_attachment_falls_back_to_html():
+    """无 PDF 时回退到 HTML。"""
+    key = ZoteroClient._pick_best_attachment(
+        [ZOTERO_ATTACHMENT_HTML]
+    )
+    assert key == "HTML0001"
+
+
+# ---------------------------------------------------------------------------
+# Parse item edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_parse_item_minimal(zotero_env):
+    """最小字段条目解析不崩溃。"""
+    minimal = {
+        "key": "MIN00001",
+        "data": {
+            "itemType": "webpage",
+            "title": "Minimal Page",
+            "creators": [],
+            "date": "",
+            "DOI": "",
+            "url": "",
+            "abstractNote": "",
+            "tags": [],
+        },
+    }
+    client = ZoteroClient()
+    paper = client._parse_item(minimal)
+    assert paper.title == "Minimal Page"
+    assert paper.doi is None
+    assert paper.year is None
+    assert paper.authors == []
+    # source_url 使用 API 路径作为回退
+    assert "/items/MIN00001" in paper.source_url
+
+
+def test_parse_item_book_fields(zotero_env):
+    """图书条目的 journal 从 bookTitle 取得。"""
+    client = ZoteroClient()
+    paper = client._parse_item(ZOTERO_ITEM_BOOK)
+    assert paper.title == "Deep Learning"
+    assert paper.journal == "MIT Press Series"
+
+
+# ---------------------------------------------------------------------------
+# Config error tests
+# ---------------------------------------------------------------------------
+
+
+def test_config_error_no_api_key(monkeypatch):
+    """无 API Key 时抛 ConfigError。"""
+    monkeypatch.delenv("SOUWEN_ZOTERO_API_KEY", raising=False)
+    monkeypatch.delenv("SOUWEN_ZOTERO_LIBRARY_ID", raising=False)
+    from souwen.config import get_config
+
+    get_config.cache_clear()
+    try:
+        with pytest.raises(ConfigError):
+            ZoteroClient()
+    finally:
+        get_config.cache_clear()
+
+
+def test_config_error_no_library_id(monkeypatch):
+    """有 API Key 但无 Library ID 时抛 ConfigError。"""
+    monkeypatch.setenv("SOUWEN_ZOTERO_API_KEY", "test-key")
+    monkeypatch.delenv("SOUWEN_ZOTERO_LIBRARY_ID", raising=False)
+    from souwen.config import get_config
+
+    get_config.cache_clear()
+    try:
+        with pytest.raises(ConfigError):
+            ZoteroClient()
+    finally:
+        get_config.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Group library path
+# ---------------------------------------------------------------------------
+
+
+def test_group_library_path(monkeypatch):
+    """群组库路径使用 /groups/ 前缀。"""
+    monkeypatch.setenv("SOUWEN_ZOTERO_API_KEY", "test-key")
+    monkeypatch.setenv("SOUWEN_ZOTERO_LIBRARY_ID", "12345")
+    monkeypatch.setenv("SOUWEN_ZOTERO_LIBRARY_TYPE", "group")
+    from souwen.config import get_config
+
+    get_config.cache_clear()
+    try:
+        client = ZoteroClient()
+        assert client._base_path == "/groups/12345"
+    finally:
+        get_config.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Backoff header
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_backoff_header_respected(httpx_mock: HTTPXMock, zotero_env):
+    """Backoff 头正常处理不崩溃（不真正 sleep，仅验证逻辑路径）。"""
+    httpx_mock.add_response(
+        url=re.compile(r".*/users/9876543/items\?.*"),
+        json=[ZOTERO_ITEM_1],
+        headers={"Total-Results": "1", "Backoff": "0.01"},
+    )
+    async with ZoteroClient() as client:
+        resp = await client.search("backoff_test")
+
+    assert len(resp.results) == 1

--- a/tests/test_paper/test_zotero.py
+++ b/tests/test_paper/test_zotero.py
@@ -370,25 +370,19 @@ async def test_list_collections(httpx_mock: HTTPXMock, zotero_env):
 
 def test_pick_best_attachment_prefers_pdf():
     """附件选择优先 PDF，按 dateAdded 倒序。"""
-    key = ZoteroClient._pick_best_attachment(
-        [ZOTERO_ATTACHMENT_HTML, ZOTERO_ATTACHMENT_PDF]
-    )
+    key = ZoteroClient._pick_best_attachment([ZOTERO_ATTACHMENT_HTML, ZOTERO_ATTACHMENT_PDF])
     assert key == "PDF00001"
 
 
 def test_pick_best_attachment_filters_linked():
     """排除 linked_url 模式的附件。"""
-    key = ZoteroClient._pick_best_attachment(
-        [ZOTERO_ATTACHMENT_LINKED]
-    )
+    key = ZoteroClient._pick_best_attachment([ZOTERO_ATTACHMENT_LINKED])
     assert key is None
 
 
 def test_pick_best_attachment_falls_back_to_html():
     """无 PDF 时回退到 HTML。"""
-    key = ZoteroClient._pick_best_attachment(
-        [ZOTERO_ATTACHMENT_HTML]
-    )
+    key = ZoteroClient._pick_best_attachment([ZOTERO_ATTACHMENT_HTML])
     assert key == "HTML0001"
 
 


### PR DESCRIPTION
## 概述

基于 Zotero Web API v3 原生实现 Zotero 个人/群组文献库搜索客户端。不依赖 `pyzotero` 第三方库，直接调用 REST API。

参考项目：[kujenga/zotero-mcp](https://github.com/kujenga/zotero-mcp)（MCP 薄包装），本实现在以下方面做了改进：
- 附件选择算法：仅 `imported_file/imported_url` 模式 + PDF 优先 + `dateAdded` 排序（原项目用 md5 当大小代理，有 bug）
- 全文提取返回索引元信息（`indexedPages/totalPages/indexedChars/totalChars`）
- 遵守 Zotero 的 `Backoff` / `Retry-After` 头
- 类型排除同时在服务端（`itemType` 参数）和客户端双重过滤

## 功能清单

| 功能 | 方法 | 说明 |
|---|---|---|
| 文献搜索 | `search(query, qmode, tag, limit, start)` | 支持 `titleCreatorYear` / `everything` 两种搜索模式 |
| 标签过滤 | `search(..., tag=)` | 支持布尔语法（`tag1 \|\| tag2`、`-exclude`） |
| 分页 | `search(..., limit=, start=)` | offset 式分页，`Total-Results` 头获取总数 |
| 单条目获取 | `get_item(item_key)` | 通过 key 获取元数据 |
| 全文提取 | `get_fulltext(item_key)` | 自动查找最佳 PDF/HTML 附件并提取全文 |
| 集合列表 | `list_collections()` | 列出所有文献集合及父子关系 |

## 配置

```yaml
# souwen.yaml
zotero_api_key: "your-api-key"      # https://www.zotero.org/settings/keys
zotero_library_id: "9876543"         # 用户 ID 或群组 ID
zotero_library_type: "user"          # user (默认) 或 group
```

或环境变量：
```bash
export SOUWEN_ZOTERO_API_KEY=your-api-key
export SOUWEN_ZOTERO_LIBRARY_ID=9876543
export SOUWEN_ZOTERO_LIBRARY_TYPE=user
```

## 文件变更

| 文件 | 变更 | 行数 |
|---|---|---|
| `src/souwen/paper/zotero.py` | 🆕 ZoteroClient 完整实现 | +461 |
| `tests/test_paper/test_zotero.py` | 🆕 19 个测试用例 | +502 |
| `src/souwen/models.py` | SourceType +ZOTERO，ALL_SOURCES +zotero | +2 |
| `src/souwen/config.py` | +3 配置字段 | +4 |
| `src/souwen/source_registry.py` | +1 源注册（paper/official_api） | +7 |
| `src/souwen/search.py` | _PAPER_SOURCES +zotero | +8 |
| `src/souwen/paper/__init__.py` | 导出 ZoteroClient | +2 |
| `README.md` | 数据源计数 65→66 | ~ |
| `tests/test_doctor.py` | 计数 65→66 | ~ |
| `tests/test_models.py` | 计数 54→55，paper 7→8 | ~ |
| `tests/test_infra.py` | 计数 7→8 | ~ |

**总计：11 文件，+999 行**

## 测试

全量 624 测试通过（新增 19），ruff lint 通过。

## 技术细节

- **HTTP 客户端**：SouWenHttpClient（httpx），`Zotero-API-Key` 请求头认证
- **限流**：TokenBucketLimiter 8 req/s + Backoff/Retry-After 头遵守
- **条目类型过滤**：服务端 `itemType=-note || -attachment || -annotation` + 客户端二次过滤
- **附件选择**：仅 `imported_file`/`imported_url` 链接模式，PDF > HTML > 其他，按 `dateAdded` 倒序
- **搜索聚合**：已注册到 `_PAPER_SOURCES`，但 **不在默认源列表中**（需用户配置 API Key + Library ID）
