### PR TITLE
ci: 添加 PR 自动格式化 workflow (ruff format)

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -1,0 +1,51 @@
+name: Auto Format
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '**.py'
+      - 'pyproject.toml'
+      - '.github/workflows/auto-format.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: auto-format-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  auto-format:
+    name: 自动格式化
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # 仅处理同仓库 PR（fork PR 无写入权限，跳过）
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+
+      - name: 安装 ruff
+        run: pip install ruff
+
+      - name: 运行 ruff format
+        run: ruff format src/ tests/
+
+      - name: 提交格式化修复
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "style: auto-format with ruff"
+          commit_author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          file_pattern: "src/**/*.py tests/**/*.py"
+
+      - name: 最终格式检查（Gate）
+        run: ruff format --check src/ tests/


### PR DESCRIPTION
## 变更内容

当 PR 中 Python 文件未通过 `ruff format` 检查时，**自动格式化并提交修复**，无需人工干预。

## 工作原理

1. PR 触发后，workflow 检出 PR 分支
2. 运行 `ruff format src/ tests/` 进行格式化
3. 如有变更，自动 commit 回 PR 分支
4. 最终 gate 步骤 `ruff format --check` 确认格式正确

## 安全设计

- **仅同仓库 PR**：fork PR 无写权限，自动跳过（lint job 仍会报错提示手动修复）
- **并发控制**：同一 PR 多次 push 时，取消旧的运行，只处理最新
- **路径过滤**：仅 `.py` / `pyproject.toml` / workflow 自身变更时触发
- **最小权限**：仅 `contents: write`
- **不做语义修改**：只运行 `ruff format`（纯格式），不执行 `ruff check --fix`（避免自动删除 import 等语义变更）

## 已知限制

- 使用默认 `GITHUB_TOKEN` 时，自动提交不会重新触发 ci.yml（GitHub 递归保护机制）
- 如需自动触发完整 CI，可配置 `secrets.PAT` 替换 token
- 当前设计：auto-format workflow 自身的 gate 步骤即可确认格式正确

## 相关

修复了 PR #19 遇到的 CI 格式检查失败问题，未来 PR 不再需要手动 `ruff format`。