### PR TITLE
feat(youtube): 全面增强 YouTube 客户端 — 分页/过滤/详情/热门/字幕提取

### DIFF
--- a/src/souwen/web/__init__.py
+++ b/src/souwen/web/__init__.py
@@ -54,7 +54,7 @@ from souwen.web.stackoverflow import StackOverflowClient
 from souwen.web.reddit import RedditClient
 from souwen.web.bilibili import BilibiliClient
 from souwen.web.wikipedia import WikipediaClient
-from souwen.web.youtube import YouTubeClient
+from souwen.web.youtube import VideoDetail, YouTubeClient
 from souwen.web.zhihu import ZhihuClient
 from souwen.web.weibo import WeiboClient
 from souwen.web.csdn import CSDNClient
@@ -108,6 +108,7 @@ __all__ = [
     "BilibiliClient",
     "WikipediaClient",
     "YouTubeClient",
+    "VideoDetail",
     "ZhihuClient",
     "WeiboClient",
     # 中文技术社区

--- a/src/souwen/web/youtube.py
+++ b/src/souwen/web/youtube.py
@@ -1,85 +1,98 @@
-"""YouTube 视频搜索客户端
+"""YouTube Data API v3 全功能客户端
 
 文件用途：
-    YouTube Data API v3 搜索客户端。通过 Google 提供的公开 API 检索
-    YouTube 视频内容。需要 API Key（通过配置字段 youtube_api_key
+    YouTube Data API v3 客户端，提供视频搜索（含分页）、热门视频、
+    视频详情、字幕提取等功能。需要 API Key（通过配置字段 youtube_api_key
     或环境变量 YOUTUBE_API_KEY 提供），无 Key 时客户端初始化会抛出
     ConfigError 以便调度层（integration_type=official_api）跳过该数据源。
 
-函数/类清单：
-    resolve_api_key(legacy_field, env_var) -> str | None
-        - 功能：解析 YouTube API Key，依次查询频道配置 / 旧版字段 / 环境变量
-        - 输入：legacy_field 配置字段名，env_var 环境变量名
-        - 输出：找到的 Key 字符串；都未配置时返回 None
-        - 备注：作为模块级函数暴露，便于单元测试通过 monkeypatch 替换
+类清单：
+    VideoDetail — 视频详情数据类（含统计和时长）
+    YouTubeClient — 完整 YouTube API 客户端
 
-    YouTubeClient（类）
-        - 功能：YouTube Data API v3 视频搜索客户端
-        - 继承：SouWenHttpClient（HTTP 客户端基类，提供重试 / 代理 / 异常映射）
-        - 关键属性：
-            ENGINE_NAME = "youtube"
-            BASE_URL = "https://www.googleapis.com"
-            SNIPPET_MAX_LEN = 300
-            VALID_ORDERS = {"relevance", "date", "rating", "viewCount", "title"}
-            VALID_VIDEO_TYPES = {"any", "episode", "movie"}
-        - 主要方法：
-            * search(query, max_results, order, video_type) → WebSearchResponse
+方法清单：
+    search() — 视频搜索（支持分页、日期/地区/语言/频道过滤、统计信息增强）
+    get_trending() — 热门视频（按地区/分类）
+    get_video_details() — 批量获取视频详情
+    get_transcript() — 提取视频字幕文本
 
-    YouTubeClient.__init__()
-        - 功能：初始化 YouTube 客户端
-        - 输入：无（API Key 通过 resolve_api_key 解析）
-        - 异常：ConfigError 当未配置 youtube_api_key 时抛出，方便上层跳过
-
-    YouTubeClient.search(query, max_results=10, order="relevance",
-                         video_type=None) → WebSearchResponse
-        - 功能：调用 GET /youtube/v3/search 检索视频
-        - 输入：
-            query (str) — 搜索关键词
-            max_results (int) — 最大返回结果数（API 单页上限 50）
-            order (str) — 排序方式：relevance / date / rating / viewCount / title
-            video_type (str|None) — 视频类型：any / episode / movie
-        - 输出：WebSearchResponse 包含 WebSearchResult 列表
-        - 异常：
-            ValueError — order / video_type 不在允许集合中
-            ParseError — YouTube 响应非 JSON 或结构异常
-        - 字段映射：
-            * source  = SourceType.WEB_YOUTUBE
-            * title   = item["snippet"]["title"]
-            * url     = "https://www.youtube.com/watch?v={item['id']['videoId']}"
-            * snippet = item["snippet"]["description"][:300]
-            * engine  = "youtube"
-            * raw     = { channelTitle, channelId, publishedAt, thumbnails }
-
-模块依赖：
-    - logging: 日志记录
-    - os: 读取环境变量回退路径
-    - typing: 类型注解
-    - souwen.config: get_config 获取全局配置
-    - souwen.exceptions: ConfigError, ParseError 异常
-    - souwen.http_client: SouWenHttpClient HTTP 客户端基类
-    - souwen.models: SourceType, WebSearchResult, WebSearchResponse 数据模型
-
-技术要点：
-    - 端点：GET https://www.googleapis.com/youtube/v3/search
-    - 鉴权：通过 query string 参数 ``key={api_key}`` 传递（YouTube Data API 标准）
-    - 单次返回上限 50，超出会被自动截断
-    - type=video 限定仅返回视频结果，避免混入频道 / 播放列表
-    - 配额：默认每日 10000 单位，search.list 单次消耗 100 单位
-    - 文档：https://developers.google.com/youtube/v3/docs/search/list
+配额说明：
+    - 默认每日 10,000 单位
+    - search.list: 100 单位/次
+    - videos.list: 1 单位/次
+    - 多页搜索消耗 = 页数 × 100
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import os
+import re
+from dataclasses import dataclass, field
 from typing import Any
+from xml.etree import ElementTree
 
 from souwen.config import get_config
-from souwen.exceptions import ConfigError, ParseError
+from souwen.exceptions import ConfigError, ParseError, RateLimitError
 from souwen.http_client import SouWenHttpClient
 from souwen.models import SourceType, WebSearchResponse, WebSearchResult
 
 logger = logging.getLogger("souwen.web.youtube")
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_MAX_PER_PAGE = 50
+_ABSOLUTE_MAX_RESULTS = 200  # 安全上限，避免配额爆表（4 页 = 400 单位）
+_VIDEOS_BATCH_SIZE = 50  # videos.list 单次最多 50 个 ID
+
+# YouTube 视频分类 ID 参考
+CATEGORY_IDS = {
+    "film": "1",
+    "autos": "2",
+    "music": "10",
+    "pets": "15",
+    "sports": "17",
+    "gaming": "20",
+    "people": "22",
+    "comedy": "23",
+    "entertainment": "24",
+    "news": "25",
+    "howto": "26",
+    "education": "27",
+    "science": "28",
+}
+
+
+# ---------------------------------------------------------------------------
+# Data Models
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class VideoDetail:
+    """视频详情数据"""
+
+    video_id: str
+    title: str
+    description: str = ""
+    channel_title: str = ""
+    channel_id: str = ""
+    published_at: str = ""
+    thumbnail_url: str = ""
+    view_count: int = 0
+    like_count: int = 0
+    comment_count: int = 0
+    duration_seconds: int = 0
+    tags: list[str] = field(default_factory=list)
+    category_id: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
 def resolve_api_key(legacy_field: str, env_var: str) -> str | None:
@@ -98,18 +111,55 @@ def resolve_api_key(legacy_field: str, env_var: str) -> str | None:
     return os.environ.get(env_var) or None
 
 
-class YouTubeClient(SouWenHttpClient):
-    """YouTube Data API v3 视频搜索客户端
+def _parse_iso8601_duration(duration: str) -> int:
+    """解析 ISO 8601 时长为秒数（如 PT4M13S → 253）"""
+    m = re.match(
+        r"^P(?:(\d+)D)?T?(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$",
+        duration or "",
+    )
+    if not m:
+        return 0
+    days = int(m.group(1) or 0)
+    hours = int(m.group(2) or 0)
+    minutes = int(m.group(3) or 0)
+    seconds = int(m.group(4) or 0)
+    return days * 86400 + hours * 3600 + minutes * 60 + seconds
 
-    需要 Google Cloud Console 创建的 API Key。无 Key 时初始化抛出
-    ``ConfigError``，调度层应捕获并跳过本数据源。
+
+# ---------------------------------------------------------------------------
+# Client
+# ---------------------------------------------------------------------------
+
+
+class YouTubeClient(SouWenHttpClient):
+    """YouTube Data API v3 全功能客户端
+
+    功能：视频搜索（分页、过滤、增强）、热门视频、视频详情、字幕提取。
+    需要 Google Cloud Console 创建的 API Key。
 
     Example:
         async with YouTubeClient() as c:
-            resp = await c.search("python tutorial", max_results=20,
-                                  order="viewCount")
-            for r in resp.results:
-                print(r.title, r.url)
+            # 基础搜索
+            resp = await c.search("python tutorial", max_results=20)
+
+            # 高级搜索：带过滤和统计增强
+            resp = await c.search(
+                "machine learning",
+                max_results=100,
+                order="viewCount",
+                published_after="2024-01-01T00:00:00Z",
+                region_code="US",
+                enrich=True,
+            )
+
+            # 热门视频
+            trending = await c.get_trending(region_code="JP", category_id="20")
+
+            # 视频详情
+            details = await c.get_video_details(["dQw4w9WgXcQ", "jNQXAC9IVRw"])
+
+            # 字幕提取
+            transcript = await c.get_transcript("dQw4w9WgXcQ", lang="en")
     """
 
     ENGINE_NAME = "youtube"
@@ -123,7 +173,6 @@ class YouTubeClient(SouWenHttpClient):
     def __init__(self):
         api_key = resolve_api_key("youtube_api_key", "YOUTUBE_API_KEY")
         if not api_key:
-            # 未配置 Key 时抛 ConfigError 以便调度层跳过
             raise ConfigError(
                 "youtube_api_key",
                 "YouTube",
@@ -137,27 +186,76 @@ class YouTubeClient(SouWenHttpClient):
         )
         self._api_key = api_key
 
+    # ------------------------------------------------------------------
+    # Override: YouTube 特殊的 403 处理（配额超限 vs 权限不足）
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _check_response(resp: Any, url: str) -> None:
+        """YouTube 专用响应检查：区分配额超限和普通 403"""
+        if resp.status_code == 403:
+            try:
+                data = resp.json()
+                errors = data.get("error", {}).get("errors", [])
+                if any(e.get("reason") == "quotaExceeded" for e in errors):
+                    raise RateLimitError(
+                        "YouTube API 每日配额已用尽，请明日再试",
+                        retry_after=86400.0,
+                    )
+                if any(e.get("reason") == "rateLimitExceeded" for e in errors):
+                    raise RateLimitError(
+                        "YouTube API 请求频率过高",
+                        retry_after=60.0,
+                    )
+            except (ValueError, AttributeError, KeyError):
+                pass
+        # 其余状态码由父类统一处理
+        SouWenHttpClient._check_response(resp, url)
+
+    # ------------------------------------------------------------------
+    # 搜索
+    # ------------------------------------------------------------------
+
     async def search(
         self,
         query: str,
         max_results: int = 10,
         order: str = "relevance",
         video_type: str | None = None,
+        *,
+        published_after: str | None = None,
+        published_before: str | None = None,
+        region_code: str | None = None,
+        relevance_language: str | None = None,
+        video_category_id: str | None = None,
+        channel_id: str | None = None,
+        enrich: bool = False,
     ) -> WebSearchResponse:
-        """通过 YouTube Data API v3 搜索视频
+        """搜索 YouTube 视频
+
+        支持多页分页（max_results > 50 时自动翻页），以及丰富的过滤条件。
+        可选通过 videos.list 增强统计信息（播放量/点赞/评论/时长）。
 
         Args:
             query: 搜索关键词
-            max_results: 最大返回结果数（YouTube 单页上限 50，超出自动截断）
-            order: 排序方式 - relevance / date / rating / viewCount / title
-            video_type: 视频类型过滤 - any / episode / movie；None 则不传
+            max_results: 最大返回数（上限 200，超出截断）
+            order: 排序 - relevance/date/rating/viewCount/title
+            video_type: 类型过滤 - any/episode/movie
+            published_after: 发布时间下限（RFC 3339，如 2024-01-01T00:00:00Z）
+            published_before: 发布时间上限
+            region_code: 地区码（ISO 3166-1 alpha-2，如 US/CN/JP）
+            relevance_language: 相关语言（ISO 639-1，如 en/zh/ja）
+            video_category_id: 视频分类 ID（参见 CATEGORY_IDS）
+            channel_id: 限定频道
+            enrich: 是否增强统计信息（额外 1 单位/50 视频配额）
 
         Returns:
-            WebSearchResponse 包含归一化后的搜索结果
+            WebSearchResponse
 
         Raises:
-            ValueError: order / video_type 不在允许集合中
-            ParseError: YouTube 响应非 JSON 或结构异常
+            ValueError: 参数不合法
+            ParseError: 响应解析失败
+            RateLimitError: 配额超限
         """
         if order not in self.VALID_ORDERS:
             raise ValueError(f"无效的 order: {order!r}，可选值: {sorted(self.VALID_ORDERS)}")
@@ -166,29 +264,268 @@ class YouTubeClient(SouWenHttpClient):
                 f"无效的 video_type: {video_type!r}，可选值: {sorted(self.VALID_VIDEO_TYPES)}"
             )
 
-        # YouTube Data API 单次最多返回 50 条，超出需翻页（这里只取首页）
-        capped = max(1, min(max_results, 50))
+        # 安全上限
+        target = max(1, min(max_results, _ABSOLUTE_MAX_RESULTS))
+        if max_results > _ABSOLUTE_MAX_RESULTS:
+            logger.warning(
+                "max_results=%d 超出安全上限 %d，已截断",
+                max_results,
+                _ABSOLUTE_MAX_RESULTS,
+            )
 
-        params: dict[str, Any] = {
+        # 构建基础参数
+        base_params: dict[str, Any] = {
             "part": "snippet",
             "q": query,
             "type": "video",
-            "maxResults": capped,
             "order": order,
             "key": self._api_key,
         }
         if video_type is not None:
-            params["videoType"] = video_type
+            base_params["videoType"] = video_type
+        if published_after:
+            base_params["publishedAfter"] = published_after
+        if published_before:
+            base_params["publishedBefore"] = published_before
+        if region_code:
+            base_params["regionCode"] = region_code
+        if relevance_language:
+            base_params["relevanceLanguage"] = relevance_language
+        if video_category_id:
+            base_params["videoCategoryId"] = video_category_id
+        if channel_id:
+            base_params["channelId"] = channel_id
 
-        resp = await self.get("/youtube/v3/search", params=params)
+        # 分页循环
+        all_items: list[dict] = []
+        page_token: str | None = None
+        pages_fetched = 0
 
+        while len(all_items) < target:
+            per_page = min(_MAX_PER_PAGE, target - len(all_items))
+            params = {**base_params, "maxResults": per_page}
+            if page_token:
+                params["pageToken"] = page_token
+
+            resp = await self.get("/youtube/v3/search", params=params)
+            data = self._parse_json(resp)
+
+            items = data.get("items") or []
+            all_items.extend(items)
+            pages_fetched += 1
+
+            page_token = data.get("nextPageToken")
+            if not page_token or not items:
+                break
+
+            if pages_fetched > 1:
+                logger.info(
+                    "YouTube 搜索翻页中: 已获取 %d 条，第 %d 页",
+                    len(all_items),
+                    pages_fetched,
+                )
+
+        # 解析结果
+        results = self._parse_search_items(all_items[:target])
+
+        # 可选: 统计信息增强
+        if enrich and results:
+            results = await self._enrich_results(results)
+
+        logger.info(
+            "YouTube 搜索完成: %d 条结果, %d 页 (query=%s, order=%s)",
+            len(results),
+            pages_fetched,
+            query,
+            order,
+        )
+
+        return WebSearchResponse(
+            query=query,
+            source=SourceType.WEB_YOUTUBE,
+            results=results,
+            total_results=len(results),
+        )
+
+    # ------------------------------------------------------------------
+    # 热门视频
+    # ------------------------------------------------------------------
+
+    async def get_trending(
+        self,
+        region_code: str = "US",
+        category_id: str | None = None,
+        max_results: int = 10,
+    ) -> WebSearchResponse:
+        """获取热门/流行视频
+
+        Args:
+            region_code: 地区码（ISO 3166-1 alpha-2）
+            category_id: 视频分类 ID（参见 CATEGORY_IDS）
+            max_results: 最大返回数（上限 50）
+
+        Returns:
+            WebSearchResponse（query 格式为 "trending:{region}:{category}"）
+        """
+        capped = max(1, min(max_results, _MAX_PER_PAGE))
+
+        params: dict[str, Any] = {
+            "part": "snippet,statistics",
+            "chart": "mostPopular",
+            "regionCode": region_code,
+            "maxResults": capped,
+            "key": self._api_key,
+        }
+        if category_id:
+            params["videoCategoryId"] = category_id
+
+        resp = await self.get("/youtube/v3/videos", params=params)
+        data = self._parse_json(resp)
+
+        items = data.get("items") or []
+        results: list[WebSearchResult] = []
+
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            video_id = item.get("id", "")
+            snippet_data = item.get("snippet") or {}
+            stats = item.get("statistics") or {}
+            title = (snippet_data.get("title") or "").strip()
+            if not video_id or not title:
+                continue
+
+            description = (snippet_data.get("description") or "").strip()
+
+            raw: dict[str, Any] = {
+                "channelTitle": snippet_data.get("channelTitle"),
+                "channelId": snippet_data.get("channelId"),
+                "publishedAt": snippet_data.get("publishedAt"),
+                "thumbnails": snippet_data.get("thumbnails"),
+                "viewCount": int(stats.get("viewCount", 0)),
+                "likeCount": int(stats.get("likeCount", 0)),
+                "commentCount": int(stats.get("commentCount", 0)),
+            }
+
+            results.append(
+                WebSearchResult(
+                    source=SourceType.WEB_YOUTUBE,
+                    title=title,
+                    url=f"https://www.youtube.com/watch?v={video_id}",
+                    snippet=description[: self.SNIPPET_MAX_LEN],
+                    engine=self.ENGINE_NAME,
+                    raw=raw,
+                )
+            )
+
+        query_label = f"trending:{region_code}"
+        if category_id:
+            query_label += f":{category_id}"
+
+        return WebSearchResponse(
+            query=query_label,
+            source=SourceType.WEB_YOUTUBE,
+            results=results,
+            total_results=len(results),
+        )
+
+    # ------------------------------------------------------------------
+    # 视频详情
+    # ------------------------------------------------------------------
+
+    async def get_video_details(self, video_ids: list[str]) -> list[VideoDetail]:
+        """批量获取视频详情（含统计信息和时长）
+
+        Args:
+            video_ids: 视频 ID 列表（自动去重，保留顺序）
+
+        Returns:
+            VideoDetail 列表（不存在/私有的视频会被跳过）
+        """
+        # 去重并保留顺序
+        seen: set[str] = set()
+        unique_ids: list[str] = []
+        for vid in video_ids:
+            if vid not in seen:
+                seen.add(vid)
+                unique_ids.append(vid)
+
+        all_details: dict[str, VideoDetail] = {}
+
+        # 分批请求（每批最多 50）
+        for i in range(0, len(unique_ids), _VIDEOS_BATCH_SIZE):
+            batch = unique_ids[i : i + _VIDEOS_BATCH_SIZE]
+            params: dict[str, Any] = {
+                "part": "snippet,statistics,contentDetails",
+                "id": ",".join(batch),
+                "key": self._api_key,
+            }
+
+            resp = await self.get("/youtube/v3/videos", params=params)
+            data = self._parse_json(resp)
+
+            for item in data.get("items") or []:
+                detail = self._parse_video_item(item)
+                if detail:
+                    all_details[detail.video_id] = detail
+
+        # 保留输入顺序
+        return [all_details[vid] for vid in unique_ids if vid in all_details]
+
+    # ------------------------------------------------------------------
+    # 字幕提取
+    # ------------------------------------------------------------------
+
+    async def get_transcript(
+        self,
+        video_id: str,
+        lang: str = "en",
+    ) -> str | None:
+        """提取视频字幕文本
+
+        通过解析视频页面获取字幕轨道信息，然后下载字幕 XML 并提取纯文本。
+        此功能不消耗 YouTube Data API 配额。
+
+        Args:
+            video_id: 视频 ID
+            lang: 首选语言代码（如 en/zh/ja），找不到时尝试第一个可用轨道
+
+        Returns:
+            字幕全文（各段落以换行分隔），无字幕时返回 None
+        """
         try:
-            data = resp.json()
+            # 获取视频页面，提取字幕轨道
+            caption_url = await self._get_caption_url(video_id, lang)
+            if not caption_url:
+                return None
+
+            # 下载字幕 XML
+            resp = await self._client.request("GET", caption_url)
+            if resp.status_code != 200:
+                logger.debug("字幕下载失败: %d for video %s", resp.status_code, video_id)
+                return None
+
+            # 解析 XML 提取文本
+            return self._parse_caption_xml(resp.text)
+
+        except Exception as e:
+            logger.debug("字幕提取失败 (video=%s): %s", video_id, e)
+            return None
+
+    # ------------------------------------------------------------------
+    # Private Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _parse_json(resp: Any) -> dict:
+        """解析 JSON 响应"""
+        try:
+            return resp.json()
         except Exception as e:
             raise ParseError(f"YouTube 响应解析失败: {e}") from e
 
-        items = data.get("items") or []
-
+    def _parse_search_items(self, items: list[dict]) -> list[WebSearchResult]:
+        """将 search.list items 转为 WebSearchResult"""
         results: list[WebSearchResult] = []
         for item in items:
             if not isinstance(item, dict):
@@ -198,11 +535,9 @@ class YouTubeClient(SouWenHttpClient):
             video_id = id_data.get("videoId") if isinstance(id_data, dict) else None
             title = (snippet_data.get("title") or "").strip()
             if not video_id or not title:
-                # 缺关键字段的不完整记录直接跳过
                 continue
 
             description = (snippet_data.get("description") or "").strip()
-            snippet = description[: self.SNIPPET_MAX_LEN]
 
             raw: dict[str, Any] = {
                 "channelTitle": snippet_data.get("channelTitle"),
@@ -216,25 +551,186 @@ class YouTubeClient(SouWenHttpClient):
                     source=SourceType.WEB_YOUTUBE,
                     title=title,
                     url=f"https://www.youtube.com/watch?v={video_id}",
-                    snippet=snippet,
+                    snippet=description[: self.SNIPPET_MAX_LEN],
                     engine=self.ENGINE_NAME,
                     raw=raw,
                 )
             )
+        return results
 
-            if len(results) >= max_results:
+    async def _enrich_results(self, results: list[WebSearchResult]) -> list[WebSearchResult]:
+        """通过 videos.list 增强搜索结果的统计信息"""
+        # 提取 video IDs
+        video_ids: list[str] = []
+        for r in results:
+            vid = r.url.rsplit("v=", 1)[-1] if "v=" in r.url else ""
+            if vid:
+                video_ids.append(vid)
+
+        if not video_ids:
+            return results
+
+        # 批量获取统计
+        stats_map: dict[str, dict] = {}
+        try:
+            for i in range(0, len(video_ids), _VIDEOS_BATCH_SIZE):
+                batch = video_ids[i : i + _VIDEOS_BATCH_SIZE]
+                params: dict[str, Any] = {
+                    "part": "statistics,contentDetails",
+                    "id": ",".join(batch),
+                    "key": self._api_key,
+                }
+                resp = await self.get("/youtube/v3/videos", params=params)
+                data = self._parse_json(resp)
+                for item in data.get("items") or []:
+                    vid = item.get("id", "")
+                    stats = item.get("statistics") or {}
+                    content = item.get("contentDetails") or {}
+                    stats_map[vid] = {
+                        "viewCount": int(stats.get("viewCount", 0)),
+                        "likeCount": int(stats.get("likeCount", 0)),
+                        "commentCount": int(stats.get("commentCount", 0)),
+                        "duration": content.get("duration", ""),
+                        "durationSeconds": _parse_iso8601_duration(content.get("duration", "")),
+                    }
+        except Exception as e:
+            # 增强失败不影响主搜索结果
+            logger.warning("统计增强失败，返回原始结果: %s", e)
+            return results
+
+        # 将统计信息合并到 raw
+        enriched: list[WebSearchResult] = []
+        for r, vid in zip(results, video_ids):
+            if vid in stats_map:
+                new_raw = {**(r.raw or {}), **stats_map[vid]}
+                enriched.append(
+                    WebSearchResult(
+                        source=r.source,
+                        title=r.title,
+                        url=r.url,
+                        snippet=r.snippet,
+                        engine=r.engine,
+                        raw=new_raw,
+                    )
+                )
+            else:
+                enriched.append(r)
+        return enriched
+
+    @staticmethod
+    def _parse_video_item(item: dict) -> VideoDetail | None:
+        """解析 videos.list 单条 item 为 VideoDetail"""
+        video_id = item.get("id", "")
+        snippet = item.get("snippet") or {}
+        stats = item.get("statistics") or {}
+        content = item.get("contentDetails") or {}
+
+        title = (snippet.get("title") or "").strip()
+        if not video_id or not title:
+            return None
+
+        thumbnails = snippet.get("thumbnails") or {}
+        thumb = (
+            thumbnails.get("high", {}).get("url")
+            or thumbnails.get("medium", {}).get("url")
+            or thumbnails.get("default", {}).get("url", "")
+        )
+
+        return VideoDetail(
+            video_id=video_id,
+            title=title,
+            description=(snippet.get("description") or "").strip(),
+            channel_title=snippet.get("channelTitle", ""),
+            channel_id=snippet.get("channelId", ""),
+            published_at=snippet.get("publishedAt", ""),
+            thumbnail_url=thumb,
+            view_count=int(stats.get("viewCount", 0)),
+            like_count=int(stats.get("likeCount", 0)),
+            comment_count=int(stats.get("commentCount", 0)),
+            duration_seconds=_parse_iso8601_duration(content.get("duration", "")),
+            tags=snippet.get("tags") or [],
+            category_id=snippet.get("categoryId", ""),
+        )
+
+    async def _get_caption_url(self, video_id: str, lang: str) -> str | None:
+        """从视频页面提取字幕轨道 URL"""
+        watch_url = f"https://www.youtube.com/watch?v={video_id}"
+        try:
+            resp = await self._client.request(
+                "GET",
+                watch_url,
+                headers={
+                    "Accept-Language": "en-US,en;q=0.9",
+                    "User-Agent": (
+                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                        "AppleWebKit/537.36 (KHTML, like Gecko) "
+                        "Chrome/120.0.0.0 Safari/537.36"
+                    ),
+                },
+            )
+            if resp.status_code != 200:
+                return None
+        except Exception:
+            return None
+
+        html = resp.text
+
+        # 提取 captionTracks 从 ytInitialPlayerResponse
+        match = re.search(
+            r'"captionTracks"\s*:\s*(\[.*?\])',
+            html,
+        )
+        if not match:
+            return None
+
+        try:
+            tracks = json.loads(match.group(1))
+        except (json.JSONDecodeError, ValueError):
+            return None
+
+        if not tracks:
+            return None
+
+        # 查找匹配语言的轨道
+        target_track = None
+        for track in tracks:
+            code = track.get("languageCode", "")
+            if code == lang or code.startswith(f"{lang}-"):
+                target_track = track
                 break
 
-        logger.info(
-            "YouTube 返回 %d 条结果 (query=%s, order=%s)",
-            len(results),
-            query,
-            order,
-        )
+        # 回退到第一个轨道
+        if not target_track:
+            target_track = tracks[0]
 
-        return WebSearchResponse(
-            query=query,
-            source=SourceType.WEB_YOUTUBE,
-            results=results,
-            total_results=len(results),
-        )
+        base_url = target_track.get("baseUrl", "")
+        if not base_url:
+            return None
+
+        return base_url
+
+    @staticmethod
+    def _parse_caption_xml(xml_text: str) -> str | None:
+        """解析字幕 XML，提取纯文本"""
+        try:
+            root = ElementTree.fromstring(xml_text)
+        except ElementTree.ParseError:
+            return None
+
+        segments: list[str] = []
+        for elem in root.iter("text"):
+            text = elem.text
+            if text:
+                # 替换 HTML 实体和换行
+                text = text.replace("&amp;", "&")
+                text = text.replace("&lt;", "<")
+                text = text.replace("&gt;", ">")
+                text = text.replace("&#39;", "'")
+                text = text.replace("&quot;", '"')
+                text = text.replace("\n", " ")
+                segments.append(text.strip())
+
+        if not segments:
+            return None
+
+        return "\n".join(segments)

--- a/tests/test_web/test_youtube.py
+++ b/tests/test_web/test_youtube.py
@@ -1,35 +1,32 @@
-"""YouTube 搜索客户端单元测试。
+"""YouTube 客户端单元测试。
 
-覆盖 ``souwen.web.youtube.YouTubeClient`` 视频搜索路径。使用 ``pytest-httpx``
+覆盖 ``souwen.web.youtube.YouTubeClient`` 全功能路径。使用 ``pytest-httpx``
 直接 mock HTTP 层（YouTube Data API v3 是纯 JSON）。
-
-测试清单：
-- ``test_no_api_key_raises_config_error``：未配置 Key 时初始化抛 ConfigError
-- ``test_basic_search``：正常搜索：返回结果且字段映射正确
-- ``test_empty_results``：空结果（items=[]）返回空列表不崩溃
-- ``test_max_results_capped_at_50``：max_results > 50 时 maxResults 参数被截断为 50
-- ``test_order_param``：order 参数被透传到 URL
-- ``test_url_construction``：YouTube 视频 URL 正确拼接 watch?v= 形式
-- ``test_snippet_truncation``：超长描述截断到 300 字符
-- ``test_parse_error_on_bad_json``：非 JSON 响应抛 ParseError
 """
 
 from __future__ import annotations
 
+import re
+
 import pytest
 
-from souwen.exceptions import ConfigError, ParseError
-from souwen.web.youtube import YouTubeClient
+from souwen.exceptions import ConfigError, ParseError, RateLimitError
+from souwen.web.youtube import (
+    VideoDetail,
+    YouTubeClient,
+    _parse_iso8601_duration,
+)
 
-
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
+# URL patterns for matching
+_SEARCH_URL = re.compile(r"https://www\.googleapis\.com/youtube/v3/search")
+_VIDEOS_URL = re.compile(r"https://www\.googleapis\.com/youtube/v3/videos")
+_WATCH_URL = re.compile(r"https://www\.youtube\.com/watch")
+_TIMEDTEXT_URL = re.compile(r"https://www\.youtube\.com/api/timedtext")
 
 
 @pytest.fixture(autouse=True)
 def _mock_api_key(monkeypatch):
-    """默认让 resolve_api_key 返回测试 Key，避免依赖真实环境变量"""
+    """默认让 resolve_api_key 返回测试 Key"""
     monkeypatch.setattr(
         "souwen.web.youtube.resolve_api_key",
         lambda *a, **kw: "test-youtube-key",
@@ -37,14 +34,13 @@ def _mock_api_key(monkeypatch):
 
 
 def _sample_item(
-    video_id: str = "dQw4w9WgXcQ",
-    title: str = "Sample Video Title",
-    description: str = "Sample description text.",
-    channel_title: str = "Sample Channel",
-    channel_id: str = "UC1234567890",
-    published_at: str = "2024-01-01T00:00:00Z",
-) -> dict:
-    """构造一条 YouTube search.list item"""
+    video_id="dQw4w9WgXcQ",
+    title="Sample Video Title",
+    description="Sample description text.",
+    channel_title="Sample Channel",
+    channel_id="UC1234567890",
+    published_at="2024-01-01T00:00:00Z",
+):
     return {
         "kind": "youtube#searchResult",
         "id": {"kind": "youtube#video", "videoId": video_id},
@@ -59,189 +55,385 @@ def _sample_item(
     }
 
 
-def _sample_response(items: list[dict] | None = None) -> dict:
-    """构造 YouTube /youtube/v3/search 风格的响应"""
+def _sample_response(items=None, next_page_token=None):
     items = items if items is not None else []
-    return {
+    resp = {
         "kind": "youtube#searchListResponse",
         "pageInfo": {"totalResults": len(items), "resultsPerPage": len(items)},
         "items": items,
     }
+    if next_page_token:
+        resp["nextPageToken"] = next_page_token
+    return resp
+
+
+def _sample_video_item(
+    video_id="abc123",
+    title="Test Video",
+    view_count="1000000",
+    like_count="50000",
+    comment_count="3000",
+    duration="PT4M13S",
+):
+    return {
+        "kind": "youtube#video",
+        "id": video_id,
+        "snippet": {
+            "title": title,
+            "description": "A test video",
+            "channelTitle": "TestChannel",
+            "channelId": "UCtest",
+            "publishedAt": "2024-01-01T00:00:00Z",
+            "thumbnails": {"high": {"url": f"https://i.ytimg.com/vi/{video_id}/hqdefault.jpg"}},
+            "tags": ["test", "video"],
+            "categoryId": "22",
+        },
+        "statistics": {
+            "viewCount": view_count,
+            "likeCount": like_count,
+            "commentCount": comment_count,
+        },
+        "contentDetails": {"duration": duration},
+    }
 
 
 # ---------------------------------------------------------------------------
-# __init__ tests
+# ISO 8601 Duration Parser
+# ---------------------------------------------------------------------------
+
+
+class TestDurationParser:
+    def test_minutes_seconds(self):
+        assert _parse_iso8601_duration("PT4M13S") == 253
+
+    def test_hours_minutes_seconds(self):
+        assert _parse_iso8601_duration("PT1H30M5S") == 5405
+
+    def test_seconds_only(self):
+        assert _parse_iso8601_duration("PT45S") == 45
+
+    def test_days(self):
+        assert _parse_iso8601_duration("P1DT2H") == 93600
+
+    def test_empty(self):
+        assert _parse_iso8601_duration("") == 0
+
+    def test_invalid(self):
+        assert _parse_iso8601_duration("not_a_duration") == 0
+
+
+# ---------------------------------------------------------------------------
+# Init
 # ---------------------------------------------------------------------------
 
 
 async def test_no_api_key_raises_config_error(monkeypatch):
-    """未配置 Key 时初始化抛 ConfigError"""
     monkeypatch.setattr("souwen.web.youtube.resolve_api_key", lambda *a, **kw: None)
     with pytest.raises(ConfigError):
         YouTubeClient()
 
 
 # ---------------------------------------------------------------------------
-# search tests
+# Search
 # ---------------------------------------------------------------------------
 
 
 async def test_basic_search(httpx_mock):
-    """正常搜索：返回结果并映射字段"""
     httpx_mock.add_response(
-        url=(
-            "https://www.googleapis.com/youtube/v3/search"
-            "?part=snippet&q=python&type=video&maxResults=10&order=relevance"
-            "&key=test-youtube-key"
-        ),
+        url=_SEARCH_URL,
         json=_sample_response(
             items=[
                 _sample_item(
                     video_id="abc123",
                     title="Python Tutorial",
-                    description="Learn Python in 10 minutes",
-                    channel_title="DevChannel",
+                    description="Learn Python",
+                    channel_title="DevCh",
                     channel_id="UCdev",
                     published_at="2024-05-01T12:00:00Z",
                 ),
-                _sample_item(
-                    video_id="xyz789",
-                    title="Async Python",
-                    description="asyncio basics",
-                ),
+                _sample_item(video_id="xyz789", title="Async Python", description="asyncio"),
             ]
         ),
     )
-
     async with YouTubeClient() as client:
         resp = await client.search("python", max_results=10)
 
     assert resp.query == "python"
     assert resp.source.value == "web_youtube"
     assert len(resp.results) == 2
-
     first = resp.results[0]
     assert first.title == "Python Tutorial"
     assert first.url == "https://www.youtube.com/watch?v=abc123"
-    assert first.snippet == "Learn Python in 10 minutes"
+    assert first.snippet == "Learn Python"
     assert first.engine == "youtube"
-    assert first.source.value == "web_youtube"
-    assert first.raw["channelTitle"] == "DevChannel"
-    assert first.raw["channelId"] == "UCdev"
-    assert first.raw["publishedAt"] == "2024-05-01T12:00:00Z"
-    assert "default" in first.raw["thumbnails"]
+    assert first.raw["channelTitle"] == "DevCh"
 
 
 async def test_empty_results(httpx_mock):
-    """空结果返回空列表，不抛异常"""
-    httpx_mock.add_response(
-        url=(
-            "https://www.googleapis.com/youtube/v3/search"
-            "?part=snippet&q=zzznoresult&type=video&maxResults=10&order=relevance"
-            "&key=test-youtube-key"
-        ),
-        json=_sample_response(items=[]),
-    )
-
+    httpx_mock.add_response(url=_SEARCH_URL, json=_sample_response(items=[]))
     async with YouTubeClient() as client:
         resp = await client.search("zzznoresult")
-
     assert resp.results == []
     assert resp.total_results == 0
 
 
-async def test_max_results_capped_at_50(httpx_mock):
-    """max_results > 50 时 API maxResults 参数被截断为 50"""
+async def test_pagination(httpx_mock):
+    page1 = [_sample_item(video_id=f"vid{i}", title=f"V{i}") for i in range(50)]
     httpx_mock.add_response(
-        url=(
-            "https://www.googleapis.com/youtube/v3/search"
-            "?part=snippet&q=many&type=video&maxResults=50&order=relevance"
-            "&key=test-youtube-key"
-        ),
-        json=_sample_response(
-            items=[_sample_item(video_id=f"vid{i}", title=f"Video {i}") for i in range(3)]
-        ),
+        url=_SEARCH_URL,
+        json=_sample_response(items=page1, next_page_token="PAGE2"),
     )
+    page2 = [_sample_item(video_id=f"vid{i}", title=f"V{i}") for i in range(50, 70)]
+    httpx_mock.add_response(url=_SEARCH_URL, json=_sample_response(items=page2))
 
     async with YouTubeClient() as client:
-        # 即便传入 100，URL 中应该出现 maxResults=50（由 httpx_mock 严格匹配）
-        resp = await client.search("many", max_results=100)
-
-    assert len(resp.results) == 3
+        resp = await client.search("paginate", max_results=60)
+    assert len(resp.results) == 60
 
 
-async def test_order_param(httpx_mock):
-    """order 参数被透传到查询字符串"""
-    httpx_mock.add_response(
-        url=(
-            "https://www.googleapis.com/youtube/v3/search"
-            "?part=snippet&q=q&type=video&maxResults=10&order=viewCount"
-            "&key=test-youtube-key"
-        ),
-        json=_sample_response(items=[_sample_item()]),
-    )
-
+async def test_search_filters(httpx_mock):
+    httpx_mock.add_response(url=_SEARCH_URL, json=_sample_response(items=[_sample_item()]))
     async with YouTubeClient() as client:
-        resp = await client.search("q", order="viewCount")
+        await client.search(
+            "test",
+            published_after="2024-01-01T00:00:00Z",
+            region_code="US",
+            relevance_language="en",
+            channel_id="UCtest",
+        )
+    req = httpx_mock.get_requests()[0]
+    url_str = str(req.url)
+    assert "regionCode=US" in url_str
+    assert "relevanceLanguage=en" in url_str
+    assert "channelId=UCtest" in url_str
 
+
+async def test_search_with_enrich(httpx_mock):
+    httpx_mock.add_response(
+        url=_SEARCH_URL,
+        json=_sample_response(items=[_sample_item(video_id="enr1", title="Enrich")]),
+    )
+    httpx_mock.add_response(
+        url=_VIDEOS_URL,
+        json={
+            "items": [
+                {
+                    "id": "enr1",
+                    "statistics": {"viewCount": "999", "likeCount": "100", "commentCount": "10"},
+                    "contentDetails": {"duration": "PT5M30S"},
+                }
+            ]
+        },
+    )
+    async with YouTubeClient() as client:
+        resp = await client.search("test", enrich=True)
+    assert resp.results[0].raw["viewCount"] == 999
+    assert resp.results[0].raw["durationSeconds"] == 330
+
+
+async def test_enrich_failure_returns_original(httpx_mock):
+    httpx_mock.add_response(
+        url=_SEARCH_URL,
+        json=_sample_response(items=[_sample_item(video_id="f1", title="Fail")]),
+    )
+    httpx_mock.add_response(url=_VIDEOS_URL, status_code=500)
+    async with YouTubeClient() as client:
+        resp = await client.search("test", enrich=True)
+    assert len(resp.results) == 1
+    assert resp.results[0].title == "Fail"
+
+
+async def test_max_results_capped(httpx_mock):
+    httpx_mock.add_response(url=_SEARCH_URL, json=_sample_response(items=[_sample_item()]))
+    async with YouTubeClient() as client:
+        resp = await client.search("test", max_results=999)
     assert len(resp.results) == 1
 
 
-async def test_url_construction(httpx_mock):
-    """YouTube 视频 URL 拼接为 https://www.youtube.com/watch?v={videoId}"""
-    httpx_mock.add_response(
-        url=(
-            "https://www.googleapis.com/youtube/v3/search"
-            "?part=snippet&q=url&type=video&maxResults=10&order=relevance"
-            "&key=test-youtube-key"
-        ),
-        json=_sample_response(items=[_sample_item(video_id="MY_VIDEO_ID", title="t")]),
-    )
+async def test_order_param(httpx_mock):
+    httpx_mock.add_response(url=_SEARCH_URL, json=_sample_response(items=[_sample_item()]))
+    async with YouTubeClient() as client:
+        await client.search("q", order="viewCount")
+    assert "order=viewCount" in str(httpx_mock.get_requests()[0].url)
 
+
+async def test_url_construction(httpx_mock):
+    httpx_mock.add_response(
+        url=_SEARCH_URL,
+        json=_sample_response(items=[_sample_item(video_id="MY_VID", title="t")]),
+    )
     async with YouTubeClient() as client:
         resp = await client.search("url")
-
-    assert resp.results[0].url == "https://www.youtube.com/watch?v=MY_VIDEO_ID"
+    assert resp.results[0].url == "https://www.youtube.com/watch?v=MY_VID"
 
 
 async def test_snippet_truncation(httpx_mock):
-    """超长描述被截断到 300 字符"""
-    long_desc = "x" * 1000
     httpx_mock.add_response(
-        url=(
-            "https://www.googleapis.com/youtube/v3/search"
-            "?part=snippet&q=long&type=video&maxResults=10&order=relevance"
-            "&key=test-youtube-key"
-        ),
-        json=_sample_response(items=[_sample_item(description=long_desc)]),
+        url=_SEARCH_URL,
+        json=_sample_response(items=[_sample_item(description="x" * 1000)]),
     )
-
     async with YouTubeClient() as client:
         resp = await client.search("long")
-
     assert len(resp.results[0].snippet) == 300
-    assert resp.results[0].snippet == "x" * 300
 
 
 async def test_parse_error_on_bad_json(httpx_mock):
-    """非 JSON 响应抛 ParseError"""
     httpx_mock.add_response(
-        url=(
-            "https://www.googleapis.com/youtube/v3/search"
-            "?part=snippet&q=bad&type=video&maxResults=10&order=relevance"
-            "&key=test-youtube-key"
-        ),
+        url=_SEARCH_URL,
         content=b"<html>not json</html>",
         headers={"Content-Type": "text/html"},
     )
-
     async with YouTubeClient() as client:
         with pytest.raises(ParseError):
             await client.search("bad")
 
 
 async def test_invalid_order_raises_value_error():
-    """非法 order 抛 ValueError（参数校验路径）"""
     async with YouTubeClient() as client:
         with pytest.raises(ValueError):
-            await client.search("q", order="not_a_real_order")
+            await client.search("q", order="invalid")
+
+
+# ---------------------------------------------------------------------------
+# Quota exceeded
+# ---------------------------------------------------------------------------
+
+
+async def test_quota_exceeded_raises_rate_limit_error(httpx_mock):
+    httpx_mock.add_response(
+        url=_SEARCH_URL,
+        status_code=403,
+        json={
+            "error": {
+                "errors": [{"reason": "quotaExceeded", "domain": "youtube.quota"}],
+                "code": 403,
+                "message": "quota exceeded",
+            }
+        },
+    )
+    async with YouTubeClient() as client:
+        with pytest.raises(RateLimitError, match="配额已用尽"):
+            await client.search("test")
+
+
+# ---------------------------------------------------------------------------
+# Trending
+# ---------------------------------------------------------------------------
+
+
+async def test_get_trending(httpx_mock):
+    httpx_mock.add_response(
+        url=_VIDEOS_URL,
+        json={
+            "items": [
+                {
+                    "id": "trend1",
+                    "snippet": {
+                        "title": "Trending",
+                        "description": "pop",
+                        "channelTitle": "Ch",
+                        "channelId": "UC1",
+                        "publishedAt": "2024-06-01T00:00:00Z",
+                        "thumbnails": {},
+                    },
+                    "statistics": {
+                        "viewCount": "5000000",
+                        "likeCount": "200000",
+                        "commentCount": "15000",
+                    },
+                }
+            ]
+        },
+    )
+    async with YouTubeClient() as client:
+        resp = await client.get_trending(region_code="US", category_id="20")
+    assert resp.query == "trending:US:20"
+    assert resp.results[0].title == "Trending"
+    assert resp.results[0].raw["viewCount"] == 5000000
+    url_str = str(httpx_mock.get_requests()[0].url)
+    assert "chart=mostPopular" in url_str
+    assert "regionCode=US" in url_str
+
+
+# ---------------------------------------------------------------------------
+# Video Details
+# ---------------------------------------------------------------------------
+
+
+async def test_get_video_details(httpx_mock):
+    httpx_mock.add_response(
+        url=_VIDEOS_URL,
+        json={"items": [_sample_video_item(video_id="d1", title="Detail")]},
+    )
+    async with YouTubeClient() as client:
+        details = await client.get_video_details(["d1"])
+    assert len(details) == 1
+    d = details[0]
+    assert isinstance(d, VideoDetail)
+    assert d.video_id == "d1"
+    assert d.view_count == 1000000
+    assert d.duration_seconds == 253
+    assert d.tags == ["test", "video"]
+
+
+async def test_get_video_details_dedup(httpx_mock):
+    httpx_mock.add_response(
+        url=_VIDEOS_URL,
+        json={"items": [_sample_video_item(video_id="dup1")]},
+    )
+    async with YouTubeClient() as client:
+        details = await client.get_video_details(["dup1", "dup1", "dup1"])
+    assert len(details) == 1
+
+
+async def test_get_video_details_missing(httpx_mock):
+    httpx_mock.add_response(
+        url=_VIDEOS_URL,
+        json={"items": [_sample_video_item(video_id="exists")]},
+    )
+    async with YouTubeClient() as client:
+        details = await client.get_video_details(["exists", "gone"])
+    assert len(details) == 1
+    assert details[0].video_id == "exists"
+
+
+# ---------------------------------------------------------------------------
+# Transcript
+# ---------------------------------------------------------------------------
+
+
+async def test_get_transcript_success(httpx_mock):
+    watch_html = (
+        "<html><script>"
+        '"captionTracks":[{"baseUrl":"https://www.youtube.com/api/timedtext?v=t&lang=en",'
+        '"languageCode":"en"}]'
+        "</script></html>"
+    )
+    httpx_mock.add_response(url=_WATCH_URL, text=watch_html)
+    caption_xml = (
+        '<?xml version="1.0"?><transcript>'
+        '<text start="0" dur="5">Hello world</text>'
+        '<text start="5" dur="3">Testing</text>'
+        "</transcript>"
+    )
+    httpx_mock.add_response(url=_TIMEDTEXT_URL, text=caption_xml)
+
+    async with YouTubeClient() as client:
+        transcript = await client.get_transcript("test123", lang="en")
+    assert transcript is not None
+    assert "Hello world" in transcript
+    assert "Testing" in transcript
+
+
+async def test_get_transcript_no_captions(httpx_mock):
+    httpx_mock.add_response(url=_WATCH_URL, text="<html>no captions</html>")
+    async with YouTubeClient() as client:
+        transcript = await client.get_transcript("nocap")
+    assert transcript is None
+
+
+async def test_get_transcript_network_error(httpx_mock):
+    httpx_mock.add_exception(Exception("fail"), url=_WATCH_URL)
+    async with YouTubeClient() as client:
+        transcript = await client.get_transcript("err")
+    assert transcript is None


### PR DESCRIPTION
## 变更概要

基于 [youtube-data-mcp-server](https://github.com/icraft2170/youtube-data-mcp-server) 项目研究，**原生实现**（非套用 MCP）全面增强 YouTubeClient。

## 对比提升

| 能力 | 增强前 | 增强后 |
|------|--------|--------|
| 搜索分页 | ❌ 单页最多 50 | ✅ 自动翻页，上限 200 |
| 日期过滤 | ❌ | ✅ publishedAfter/Before |
| 地区/语言 | ❌ | ✅ regionCode, relevanceLanguage |
| 频道限定 | ❌ | ✅ channelId |
| 分类过滤 | ❌ | ✅ videoCategoryId |
| 统计信息 | ❌ | ✅ 可选增强（viewCount/likeCount/duration） |
| 热门视频 | ❌ | ✅ get_trending(region, category) |
| 视频详情 | ❌ | ✅ get_video_details(ids) → VideoDetail |
| 字幕提取 | ❌ | ✅ get_transcript(video_id, lang) |
| 配额保护 | ❌ | ✅ quotaExceeded → RateLimitError |
| ISO 8601 时长 | ❌ | ✅ PT4M13S → 253 秒 |

## 设计决策

1. **配额安全**：搜索上限 200 条（4 页 = 400 单位），多页时日志警告
2. **增强 opt-in**：`enrich=True` 才走 videos.list（避免无谓配额消耗）
3. **增强容错**：videos.list 失败时返回原始结果，不阻塞搜索
4. **字幕隔离**：通过视频页面提取（零配额消耗），失败返回 None
5. **配额超限识别**：覆写 `_check_response` 区分 quotaExceeded vs 普通 403
6. **类型安全**：`VideoDetail` 数据类，非 raw dict
7. **跳过已废弃 API**：不实现 relatedToVideoId（2023 年已删除）

## 测试

- 27 个测试用例全部通过
- 覆盖：分页、过滤、增强、增强失败容错、热门、详情（去重/缺失）、字幕（成功/无字幕/网络错误）、配额超限、参数校验
- 全套 642 测试通过，ruff lint + format 通过

## 文件变更

- `src/souwen/web/youtube.py`: 240 → 460+ 行（全面重写）
- `tests/test_web/test_youtube.py`: 8 → 27 测试用例
- `src/souwen/web/__init__.py`: 新增 VideoDetail 导出