### PR TITLE
feat(paper): 新增 7 个学术论文搜索源 — Europe PMC, PMC, DOAJ, Zenodo, HAL, OpenAIRE, IACR

### DIFF
--- a/src/souwen/config.py
+++ b/src/souwen/config.py
@@ -197,6 +197,9 @@ class SouWenConfig(BaseModel):
     openalex_email: str | None = None
     semantic_scholar_api_key: str | None = None
     core_api_key: str | None = None
+    openaire_api_key: str | None = None
+    doaj_api_key: str | None = None
+    zenodo_access_token: str | None = None
     pubmed_api_key: str | None = None
     unpaywall_email: str | None = None
     ieee_api_key: str | None = None
@@ -618,6 +621,9 @@ paper:
   pubmed_api_key: ~
   unpaywall_email: ~
   ieee_api_key: ~
+  openaire_api_key: ~
+  doaj_api_key: ~
+  zenodo_access_token: ~
 
 # ===== 专利数据源 =====
 patent:

--- a/src/souwen/integrations/mcp_server.py
+++ b/src/souwen/integrations/mcp_server.py
@@ -20,7 +20,8 @@ Model Context Protocol (MCP) 集成，使 Claude Code、Cursor、Windsurf 等 AI
     search_papers
         - 搜索学术论文
         - 参数：query, sources (可选), limit (可选，默认 5)
-        - 支持：OpenAlex, Semantic Scholar, Crossref, arXiv, DBLP, CORE, PubMed, HuggingFace Papers
+        - 支持：OpenAlex, Semantic Scholar, Crossref, arXiv, DBLP, CORE, PubMed, HuggingFace Papers,
+                Europe PMC, PMC, DOAJ, Zenodo, HAL, OpenAIRE, IACR
         - 返回：论文列表 (JSON)
 
     search_patents
@@ -109,7 +110,8 @@ def create_server() -> "Server":
                 name="search_papers",
                 description=(
                     "搜索学术论文。支持 OpenAlex, Semantic Scholar, "
-                    "Crossref, arXiv, DBLP, CORE, PubMed, Unpaywall, HuggingFace Papers。"
+                    "Crossref, arXiv, DBLP, CORE, PubMed, Unpaywall, HuggingFace Papers, "
+                    "Europe PMC, PMC, DOAJ, Zenodo, HAL, OpenAIRE, IACR。"
                 ),
                 inputSchema={
                     "type": "object",

--- a/src/souwen/models.py
+++ b/src/souwen/models.py
@@ -131,6 +131,13 @@ class SourceType(str, Enum):
     UNPAYWALL = "unpaywall"
     ZOTERO = "zotero"
     HUGGINGFACE = "huggingface"
+    EUROPEPMC = "europepmc"
+    PMC = "pmc"
+    DOAJ = "doaj"
+    ZENODO = "zenodo"
+    HAL = "hal"
+    OPENAIRE = "openaire"
+    IACR = "iacr"
     # 专利数据源
     PATENTSVIEW = "patentsview"
     USPTO_ODP = "uspto_odp"
@@ -441,6 +448,13 @@ ALL_SOURCES: dict[str, list[tuple[str, bool, str]]] = {
         ("pubmed", False, "PubMed 生物医学"),
         ("zotero", True, "Zotero 个人文献库搜索 (需 API Key + Library ID)"),
         ("huggingface", False, "HuggingFace Papers 社区精选（语义搜索 + 热度排行）"),
+        ("europepmc", False, "Europe PMC 欧洲生物医学文献"),
+        ("pmc", False, "PubMed Central 生物医学全文"),
+        ("doaj", False, "DOAJ 开放获取期刊目录（可选 Key）"),
+        ("zenodo", False, "Zenodo CERN 开放科学仓库（可选 Token）"),
+        ("hal", False, "HAL 法国开放档案（Solr API，无需 Key）"),
+        ("openaire", False, "OpenAIRE 欧盟开放科研基础设施（可选 API Key）"),
+        ("iacr", False, "IACR ePrint 密码学预印本（实验性）"),
     ],
     "patent": [
         ("epo_ops", True, "EPO OPS 欧洲专利 (OAuth)"),

--- a/src/souwen/paper/__init__.py
+++ b/src/souwen/paper/__init__.py
@@ -11,6 +11,13 @@
 - PubMedClient: PubMed (可选Key)
 - UnpaywallClient: Unpaywall (需email)
 - HuggingFaceClient: HuggingFace Papers (无需Key，语义搜索 + 社区热度)
+- EuropePmcClient: Europe PMC (无需Key)
+- PmcClient: PubMed Central (可选Key，复用 PubMed Key)
+- DoajClient: DOAJ (可选Key)
+- ZenodoClient: Zenodo (可选Token)
+- HalClient: HAL (无需Key)
+- OpenAireClient: OpenAIRE (可选Key)
+- IacrClient: IACR ePrint (无需Key，实验性 HTML 爬虫)
 - fetch_pdf: PDF 回退链获取器
 """
 
@@ -26,6 +33,13 @@ from souwen.paper.unpaywall import UnpaywallClient
 from souwen.paper.pdf_fetcher import fetch_pdf
 from souwen.paper.zotero import ZoteroClient
 from souwen.paper.huggingface import HuggingFaceClient
+from souwen.paper.europepmc import EuropePmcClient
+from souwen.paper.pmc import PmcClient
+from souwen.paper.doaj import DoajClient
+from souwen.paper.zenodo import ZenodoClient
+from souwen.paper.hal import HalClient
+from souwen.paper.openaire import OpenAireClient
+from souwen.paper.iacr import IacrClient
 
 __all__ = [
     "OpenAlexClient",
@@ -40,4 +54,11 @@ __all__ = [
     "fetch_pdf",
     "ZoteroClient",
     "HuggingFaceClient",
+    "EuropePmcClient",
+    "PmcClient",
+    "DoajClient",
+    "ZenodoClient",
+    "HalClient",
+    "OpenAireClient",
+    "IacrClient",
 ]

--- a/src/souwen/paper/doaj.py
+++ b/src/souwen/paper/doaj.py
@@ -1,0 +1,303 @@
+"""DOAJ (Directory of Open Access Journals) API 客户端
+
+官方端点: https://doaj.org/api/search/articles/{query}
+鉴权: 可选 API Key (X-API-Key Header) — 无 Key 也可使用，仅影响限流
+注册: https://doaj.org/account/register
+
+文件用途：DOAJ 开放获取期刊文章搜索客户端，覆盖全球开放获取期刊
+论文元数据。免费可用，无需 Key，配置 Key 后限流更宽松。
+
+函数/类清单：
+    DoajClient（类）
+        - 功能：DOAJ 开放获取文章搜索客户端，解析 bibjson 响应为统一数据模型
+        - 关键属性：api_key (str|None) 可选 API 密钥, _client (SouWenHttpClient)
+                   HTTP 客户端, _limiter (TokenBucketLimiter) 令牌桶限流器
+                   （有 Key 时 ~2 req/s，无 Key 时 ~1 req/s）
+
+    _parse_result(item: dict) -> PaperResult
+        - 功能：将 DOAJ API 返回的单条 bibjson 文章转换为统一 PaperResult
+        - 输入：DOAJ API 响应中单条结果对象（含 bibjson 子键）
+        - 输出：统一的 PaperResult 模型，raw 中保留 keywords、subject、issn 等
+
+    search(query: str, page_size: int = 10, page: int = 1) -> SearchResponse
+        - 功能：按关键词查询 DOAJ 文章索引
+        - 输入：query 检索关键词, page_size 每页条数, page 当前页码
+        - 输出：SearchResponse 包含结果列表、总数、分页信息
+
+模块依赖：
+    - SouWenHttpClient: 统一 HTTP 客户端
+    - TokenBucketLimiter: 令牌桶限流器
+    - PaperResult, SearchResponse: 统一论文数据模型
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from urllib.parse import quote
+
+from souwen.config import get_config
+from souwen.exceptions import ParseError
+from souwen.http_client import SouWenHttpClient
+from souwen.models import Author, PaperResult, SearchResponse
+from souwen.rate_limiter import TokenBucketLimiter
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://doaj.org/api"
+_ARTICLE_URL = "https://doaj.org/article"
+
+# 限流：有 Key 0.5s/req (2 rps)，无 Key 1.0s/req (1 rps)
+_RPS_WITH_KEY = 2.0
+_RPS_WITHOUT_KEY = 1.0
+
+
+class DoajClient:
+    """DOAJ 开放获取期刊文章搜索客户端。
+
+    特点:
+        - 完全开放获取的同行评议期刊文章
+        - API Key 可选，未配置时仍可使用（限流更严）
+        - 返回 bibjson 元数据，包含 DOI、ISSN、关键词、主题等
+        - 不提供引用计数
+    """
+
+    def __init__(self, api_key: str | None = None) -> None:
+        """初始化 DOAJ 客户端。
+
+        Args:
+            api_key: DOAJ API Key（可选）。未提供时从全局配置读取，
+                     仍未配置则匿名访问，限流更严格。
+        """
+        cfg = get_config()
+        self.api_key: str | None = api_key or cfg.resolve_api_key("doaj", "doaj_api_key")
+
+        headers: dict[str, str] = {}
+        if self.api_key:
+            headers["X-API-Key"] = self.api_key
+
+        self._client = SouWenHttpClient(
+            base_url=_BASE_URL,
+            headers=headers,
+            source_name="doaj",
+        )
+        rps = _RPS_WITH_KEY if self.api_key else _RPS_WITHOUT_KEY
+        self._limiter = TokenBucketLimiter(rate=rps, burst=rps)
+
+    # ------------------------------------------------------------------
+    # async context manager
+    # ------------------------------------------------------------------
+
+    async def __aenter__(self) -> DoajClient:
+        await self._client.__aenter__()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> None:
+        await self._client.__aexit__(exc_type, exc_val, exc_tb)
+
+    # ------------------------------------------------------------------
+    # 内部工具
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _parse_result(item: dict[str, Any]) -> PaperResult:
+        """将 DOAJ 单条搜索结果转换为 PaperResult。
+
+        DOAJ 响应结构：
+        {
+            "id": "...",
+            "bibjson": {
+                "title": "...",
+                "author": [{"name": "..."}, ...],
+                "abstract": "..." 或 {"text": "..."},
+                "identifier": [{"type": "doi", "id": "10.xxx"}, ...],
+                "year": "2024", "month": "3",
+                "journal": {"title": "...", "issn": [...], ...},
+                "keywords": [...],
+                "subject": [{"term": "..."}, ...],
+                "link": [{"type": "fulltext", "url": "..."}, ...]
+            }
+        }
+
+        Args:
+            item: DOAJ API 响应中的单条结果。
+
+        Returns:
+            统一的 PaperResult 模型。
+
+        Raises:
+            ParseError: 解析关键字段失败时抛出。
+        """
+        try:
+            bibjson: dict[str, Any] = item.get("bibjson", {}) or {}
+            doaj_id: str = item.get("id", "")
+
+            title: str = bibjson.get("title", "") or ""
+
+            # 作者列表：[{"name": "..."}]
+            authors: list[Author] = []
+            for author_item in bibjson.get("author", []) or []:
+                name = (
+                    author_item.get("name", "")
+                    if isinstance(author_item, dict)
+                    else str(author_item)
+                )
+                if name:
+                    authors.append(Author(name=name))
+
+            # 摘要：可能是字符串，也可能是 {"text": "..."} 字典
+            raw_abstract = bibjson.get("abstract")
+            abstract: str | None = None
+            if isinstance(raw_abstract, str):
+                abstract = raw_abstract or None
+            elif isinstance(raw_abstract, dict):
+                abstract = raw_abstract.get("text") or None
+
+            # DOI：在 identifier 列表中查找 type=="doi"
+            doi: str | None = None
+            for identifier in bibjson.get("identifier", []) or []:
+                if isinstance(identifier, dict) and identifier.get("type", "").lower() == "doi":
+                    doi = identifier.get("id")
+                    break
+
+            # 出版年/月
+            year: int | None = None
+            raw_year = bibjson.get("year")
+            if raw_year:
+                try:
+                    year = int(str(raw_year)[:4])
+                except (ValueError, TypeError):
+                    pass
+
+            pub_date: str | None = None
+            raw_month = bibjson.get("month")
+            if year:
+                month_int = 1
+                if raw_month:
+                    try:
+                        month_int = max(1, min(12, int(str(raw_month))))
+                    except (ValueError, TypeError):
+                        month_int = 1
+                pub_date = f"{year:04d}-{month_int:02d}-01"
+
+            # 期刊
+            journal_obj = bibjson.get("journal") or {}
+            journal_name: str | None = (
+                journal_obj.get("title") if isinstance(journal_obj, dict) else None
+            )
+
+            # 链接：找 type=="fulltext"，按是否 .pdf 区分 pdf_url 和 source_url
+            pdf_url: str | None = None
+            fulltext_url: str | None = None
+            for link in bibjson.get("link", []) or []:
+                if not isinstance(link, dict):
+                    continue
+                if link.get("type", "").lower() != "fulltext":
+                    continue
+                url = link.get("url") or ""
+                if not url:
+                    continue
+                if url.lower().endswith(".pdf"):
+                    pdf_url = pdf_url or url
+                else:
+                    fulltext_url = fulltext_url or url
+
+            # source_url：优先 fulltext 链接，否则用 DOAJ 文章页
+            source_url: str = (
+                fulltext_url
+                or (f"{_ARTICLE_URL}/{doaj_id}" if doaj_id else _ARTICLE_URL)
+            )
+
+            # 主题：[{"term": "..."}]
+            subjects: list[str] = []
+            for subj in bibjson.get("subject", []) or []:
+                if isinstance(subj, dict):
+                    term = subj.get("term")
+                    if term:
+                        subjects.append(term)
+
+            return PaperResult(
+                title=title,
+                authors=authors,
+                abstract=abstract,
+                doi=doi,
+                year=year,
+                publication_date=pub_date,
+                journal=journal_name,
+                source="doaj",  # type: ignore[arg-type]
+                source_url=source_url,
+                pdf_url=pdf_url,
+                citation_count=None,  # DOAJ 不提供引用数
+                raw={
+                    "doaj_id": doaj_id,
+                    "keywords": bibjson.get("keywords") or [],
+                    "subject": subjects,
+                    "issn": journal_obj.get("issn") if isinstance(journal_obj, dict) else None,
+                    "publisher": journal_obj.get("publisher")
+                    if isinstance(journal_obj, dict)
+                    else None,
+                    "country": journal_obj.get("country")
+                    if isinstance(journal_obj, dict)
+                    else None,
+                },
+            )
+        except Exception as exc:
+            raise ParseError(f"解析 DOAJ result 失败: {exc}") from exc
+
+    # ------------------------------------------------------------------
+    # 公开方法
+    # ------------------------------------------------------------------
+
+    async def search(
+        self,
+        query: str,
+        page_size: int = 10,
+        page: int = 1,
+    ) -> SearchResponse:
+        """按关键词查询 DOAJ 文章索引。
+
+        DOAJ 检索语法支持 Lucene 风格（field:value, AND/OR），
+        简单关键词亦可。
+
+        Args:
+            query: 检索关键词或 Lucene 表达式。
+            page_size: 每页条数。
+            page: 当前页码（从 1 开始）。
+
+        Returns:
+            SearchResponse 包含结果列表及分页信息。
+        """
+        await self._limiter.acquire()
+
+        # DOAJ 将 query 直接编码到 URL path 中
+        encoded_query = quote(query, safe="")
+        path = f"/search/articles/{encoded_query}"
+        params: dict[str, str | int] = {
+            "page": page,
+            "pageSize": page_size,
+        }
+
+        resp = await self._client.get(path, params=params)
+        data: dict[str, Any] = resp.json()
+
+        results_list = data.get("results", []) or []
+        results: list[PaperResult] = []
+        for item in results_list:
+            try:
+                results.append(self._parse_result(item))
+            except ParseError as exc:
+                logger.debug("跳过解析失败的 DOAJ 文章: %s", exc)
+
+        return SearchResponse(
+            query=query,
+            total_results=data.get("total", len(results)),
+            page=page,
+            per_page=page_size,
+            results=results,
+            source="doaj",  # type: ignore[arg-type]
+        )

--- a/src/souwen/paper/doaj.py
+++ b/src/souwen/paper/doaj.py
@@ -208,9 +208,8 @@ class DoajClient:
                     fulltext_url = fulltext_url or url
 
             # source_url：优先 fulltext 链接，否则用 DOAJ 文章页
-            source_url: str = (
-                fulltext_url
-                or (f"{_ARTICLE_URL}/{doaj_id}" if doaj_id else _ARTICLE_URL)
+            source_url: str = fulltext_url or (
+                f"{_ARTICLE_URL}/{doaj_id}" if doaj_id else _ARTICLE_URL
             )
 
             # 主题：[{"term": "..."}]

--- a/src/souwen/paper/europepmc.py
+++ b/src/souwen/paper/europepmc.py
@@ -1,0 +1,293 @@
+"""Europe PMC API 客户端
+
+官方文档: https://europepmc.org/RestfulWebService
+鉴权: 无需 Key
+限流: 宽松，建议保守 ~5 req/s
+返回: JSON（resultList.result[]）
+
+文件用途：Europe PMC（European PubMed Central）生物医学/生命科学文献搜索客户端，
+聚合 PubMed、PMC、AGRICOLA 等多源开放获取论文，并提供全文/PDF 链接、引用计数、
+开放获取标识等丰富元数据，免 Key 即用。
+
+参考来源：Europe PMC RESTful Web Service v8
+         https://www.ebi.ac.uk/europepmc/webservices/rest/search
+
+函数/类清单：
+    EuropePmcClient（类）
+        - 功能：Europe PMC 搜索客户端，解析 JSON 响应为统一数据模型
+        - 关键属性：_client (SouWenHttpClient) HTTP 客户端,
+                   _limiter (TokenBucketLimiter) 限流器（5 req/s，保守设置）
+
+    _parse_result(item: dict) -> PaperResult
+        - 功能：将 Europe PMC 单条 result 转换为 PaperResult
+        - 输入：Europe PMC API 响应 resultList.result[] 中的单条记录
+        - 输出：统一的 PaperResult 模型，raw 中含 PMID/PMCID、关键词、开放获取标识等
+
+    search(query: str, page_size: int = 10) -> SearchResponse
+        - 功能：使用 Europe PMC 全文检索查找论文
+        - 输入：query 检索式（支持字段限定如 PUB_YEAR、HAS_FT、OPEN_ACCESS、SRC）,
+               page_size 返回条数（API 上限 1000）
+        - 输出：SearchResponse 包含结果列表及分页信息
+
+模块依赖：
+    - SouWenHttpClient: 统一 HTTP 客户端
+    - TokenBucketLimiter: 令牌桶限流器
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from souwen.exceptions import ParseError
+from souwen.http_client import SouWenHttpClient
+from souwen.models import Author, PaperResult, SearchResponse, SourceType
+from souwen.rate_limiter import TokenBucketLimiter
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://www.ebi.ac.uk/europepmc/webservices/rest"
+
+# 保守限流：5 req/s
+_DEFAULT_RPS = 5.0
+
+# Europe PMC 数据源类型，待补充至 SourceType 枚举后即可替换为 SourceType.EUROPEPMC
+# SourceType.EUROPEPMC 已在 models.py 中注册
+
+
+class EuropePmcClient:
+    """Europe PMC 生物医学开放获取文献搜索客户端。
+
+    特点:
+        - 聚合 PubMed/PMC/AGRICOLA 等多源，覆盖生命科学全领域
+        - 提供 isOpenAccess、HAS_FT、fullTextUrlList 等开放获取信号
+        - 返回 citedByCount，可用于影响力筛选
+        - 无需 API Key，零配置即用
+    """
+
+    def __init__(self) -> None:
+        """初始化 Europe PMC 客户端。"""
+        self._client = SouWenHttpClient(base_url=_BASE_URL, source_name="europepmc")
+        self._limiter = TokenBucketLimiter(rate=_DEFAULT_RPS, burst=_DEFAULT_RPS)
+
+    # ------------------------------------------------------------------
+    # async context manager
+    # ------------------------------------------------------------------
+
+    async def __aenter__(self) -> EuropePmcClient:
+        await self._client.__aenter__()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> None:
+        await self._client.__aexit__(exc_type, exc_val, exc_tb)
+
+    # ------------------------------------------------------------------
+    # 内部工具
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _parse_result(item: dict[str, Any]) -> PaperResult:
+        """将 Europe PMC 单条 result 转换为 PaperResult。
+
+        Europe PMC search API 在 ``resultList.result[]`` 下返回每条记录，
+        关键字段示例：
+        {
+            "id": "12345678",
+            "source": "MED",                # MED=PubMed, PMC=PubMed Central, AGR=AGRICOLA
+            "pmid": "12345678",
+            "pmcid": "PMC1234567",
+            "doi": "10.xxxx/yyyy",
+            "title": "...",
+            "authorList": {"author": [{"fullName": "Doe J"}, ...]},
+            "abstractText": "...",
+            "pubYear": "2024",
+            "firstPublicationDate": "2024-01-15",
+            "journalTitle": "...",
+            "citedByCount": 42,
+            "isOpenAccess": "Y",
+            "fullTextUrlList": {"fullTextUrl": [
+                {"documentStyle": "pdf", "url": "..."},
+                {"documentStyle": "html", "url": "..."}
+            ]},
+            "keywordList": {"keyword": ["..."]}
+        }
+
+        Args:
+            item: Europe PMC API 响应中的单条 result 对象。
+
+        Returns:
+            统一的 PaperResult 模型。
+
+        Raises:
+            ParseError: 解析关键字段失败时抛出。
+        """
+        try:
+            paper_id: str = str(item.get("id", "") or "")
+            pmid: str = str(item.get("pmid", "") or "")
+            pmcid: str = str(item.get("pmcid", "") or "")
+            ext_source: str = str(item.get("source", "") or "")  # MED/PMC/AGR
+
+            title: str = item.get("title", "") or ""
+            abstract: str = item.get("abstractText", "") or ""
+            doi: str | None = item.get("doi") or item.get("doiId") or None
+            journal: str | None = item.get("journalTitle") or None
+
+            # 作者解析：authorList.author[] -> [{fullName: "..."}]
+            authors: list[Author] = []
+            author_list = item.get("authorList") or {}
+            for author_item in author_list.get("author", []) if isinstance(author_list, dict) else []:
+                if isinstance(author_item, dict):
+                    name = author_item.get("fullName") or author_item.get("collectiveName") or ""
+                else:
+                    name = str(author_item)
+                if name:
+                    authors.append(Author(name=name))
+
+            # 发表年份与日期
+            pub_year_raw = item.get("pubYear")
+            year: int | None = None
+            if pub_year_raw:
+                try:
+                    year = int(str(pub_year_raw)[:4])
+                except (ValueError, TypeError):
+                    year = None
+            pub_date: str | None = item.get("firstPublicationDate") or item.get("electronicPublicationDate") or None
+
+            # 引用数
+            citation_count: int | None = None
+            cc_raw = item.get("citedByCount")
+            if cc_raw is not None:
+                try:
+                    citation_count = int(cc_raw)
+                except (ValueError, TypeError):
+                    citation_count = None
+
+            # PDF / 全文 URL：在 fullTextUrlList.fullTextUrl[] 中过滤 documentStyle in (html, pdf)
+            pdf_url: str | None = None
+            html_url: str | None = None
+            full_text_urls = item.get("fullTextUrlList") or {}
+            ft_entries = (
+                full_text_urls.get("fullTextUrl", []) if isinstance(full_text_urls, dict) else []
+            )
+            for ft in ft_entries:
+                if not isinstance(ft, dict):
+                    continue
+                style = (ft.get("documentStyle") or "").lower()
+                url = ft.get("url")
+                if not url:
+                    continue
+                if style == "pdf" and not pdf_url:
+                    pdf_url = url
+                elif style == "html" and not html_url:
+                    html_url = url
+
+            # source_url：优先使用 PMC（有全文）→ PMID → Europe PMC 内部页
+            if pmcid:
+                source_url = f"https://europepmc.org/article/PMC/{pmcid}"
+            elif pmid:
+                source_url = f"https://europepmc.org/article/MED/{pmid}"
+            elif paper_id and ext_source:
+                source_url = f"https://europepmc.org/article/{ext_source}/{paper_id}"
+            elif html_url:
+                source_url = html_url
+            else:
+                source_url = "https://europepmc.org/"
+
+            # 开放获取与关键词
+            is_open_access = (item.get("isOpenAccess") or "").upper() == "Y"
+            keyword_list = item.get("keywordList") or {}
+            keywords = keyword_list.get("keyword", []) if isinstance(keyword_list, dict) else []
+
+            return PaperResult(
+                title=title,
+                authors=authors,
+                abstract=abstract,
+                doi=doi,
+                year=year,
+                publication_date=pub_date,
+                source=SourceType.EUROPEPMC,
+                source_url=source_url,
+                pdf_url=pdf_url,
+                citation_count=citation_count,
+                journal=journal,
+                open_access_url=html_url if is_open_access else None,
+                raw={
+                    "id": paper_id,
+                    "pmid": pmid or None,
+                    "pmcid": pmcid or None,
+                    "ext_source": ext_source or None,
+                    "is_open_access": is_open_access,
+                    "keywords": keywords[:20] if isinstance(keywords, list) else [],
+                    "html_url": html_url,
+                },
+            )
+        except Exception as exc:
+            raise ParseError(f"解析 Europe PMC result 失败: {exc}") from exc
+
+    # ------------------------------------------------------------------
+    # 公开方法
+    # ------------------------------------------------------------------
+
+    async def search(
+        self,
+        query: str,
+        page_size: int = 10,
+    ) -> SearchResponse:
+        """使用 Europe PMC 检索文献。
+
+        支持字段限定语法（拼接到 query 中），常用示例：
+            - 年份范围：``(PUB_YEAR:[2020 TO 2024])``
+            - 仅含全文：``(HAS_FT:Y)``
+            - 仅开放获取：``(OPEN_ACCESS:Y)``
+            - 限定来源：``(SRC:MED)`` / ``(SRC:PMC)`` / ``(SRC:AGR)``
+
+        Args:
+            query: 检索式。
+            page_size: 返回结果数量（API 上限 1000）。
+
+        Returns:
+            SearchResponse 包含结果列表及分页信息。
+        """
+        await self._limiter.acquire()
+
+        params: dict[str, str | int] = {
+            "query": query,
+            "pageSize": min(max(page_size, 1), 1000),
+            "format": "json",
+            "resultType": "core",
+            "cursorMark": "*",
+        }
+
+        resp = await self._client.get("/search", params=params)
+        data: dict[str, Any] = resp.json()
+
+        result_list = data.get("resultList") or {}
+        items = result_list.get("result", []) if isinstance(result_list, dict) else []
+
+        results: list[PaperResult] = []
+        for item in items:
+            try:
+                results.append(self._parse_result(item))
+            except ParseError as exc:
+                logger.debug("跳过解析失败的 Europe PMC 论文: %s", exc)
+
+        # hitCount 为字段名，而非 totalHits
+        total_results: int
+        try:
+            total_results = int(data.get("hitCount", len(results)))
+        except (ValueError, TypeError):
+            total_results = len(results)
+
+        return SearchResponse(
+            query=query,
+            total_results=total_results,
+            page=1,
+            per_page=page_size,
+            results=results,
+            source=SourceType.EUROPEPMC,
+        )

--- a/src/souwen/paper/europepmc.py
+++ b/src/souwen/paper/europepmc.py
@@ -140,7 +140,9 @@ class EuropePmcClient:
             # 作者解析：authorList.author[] -> [{fullName: "..."}]
             authors: list[Author] = []
             author_list = item.get("authorList") or {}
-            for author_item in author_list.get("author", []) if isinstance(author_list, dict) else []:
+            for author_item in (
+                author_list.get("author", []) if isinstance(author_list, dict) else []
+            ):
                 if isinstance(author_item, dict):
                     name = author_item.get("fullName") or author_item.get("collectiveName") or ""
                 else:
@@ -156,7 +158,9 @@ class EuropePmcClient:
                     year = int(str(pub_year_raw)[:4])
                 except (ValueError, TypeError):
                     year = None
-            pub_date: str | None = item.get("firstPublicationDate") or item.get("electronicPublicationDate") or None
+            pub_date: str | None = (
+                item.get("firstPublicationDate") or item.get("electronicPublicationDate") or None
+            )
 
             # 引用数
             citation_count: int | None = None

--- a/src/souwen/paper/hal.py
+++ b/src/souwen/paper/hal.py
@@ -1,0 +1,266 @@
+"""HAL (Hyper Articles en Ligne) API 客户端
+
+官方端点: https://api.archives-ouvertes.fr/search/
+鉴权: 无需 Key
+限流: 宽松，无明确硬限制（保守 5 req/s）
+返回: JSON（Solr 响应，多数字段为数组）
+
+文件用途：HAL 法国开放档案搜索客户端，覆盖法国及国际机构的论文、
+            预印本、博士论文等开放获取学术成果，基于 Solr 检索引擎。
+
+参考来源：HAL 官方 API 文档 https://api.archives-ouvertes.fr/docs/search
+
+函数/类清单：
+    HalClient（类）
+        - 功能：HAL Solr 检索客户端，解析 JSON 响应为统一数据模型
+        - 关键属性：_client (SouWenHttpClient) HTTP 客户端,
+                   _limiter (TokenBucketLimiter) 限流器（5 req/s）
+
+    _parse_doc(doc: dict) -> PaperResult
+        - 功能：将 HAL Solr 返回的单条 doc 转换为 PaperResult
+        - 输入：HAL response.docs 中的单条文献对象
+        - 输出：统一的 PaperResult 模型
+        - 注意：HAL 多数字段为数组（含 title_s/abstract_s），均取第一个元素
+
+    search(query: str, rows: int = 10) -> SearchResponse
+        - 功能：使用 Solr 查询语法搜索 HAL 文献库
+        - 输入：query Solr 查询串, rows 返回条数
+        - 输出：SearchResponse 包含结果列表及分页信息
+
+模块依赖：
+    - SouWenHttpClient: 统一 HTTP 客户端
+    - TokenBucketLimiter: 令牌桶限流器
+    - PaperResult, SourceType: 统一论文数据模型
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from souwen.exceptions import ParseError
+from souwen.http_client import SouWenHttpClient
+from souwen.models import Author, PaperResult, SearchResponse, SourceType
+from souwen.rate_limiter import TokenBucketLimiter
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://api.archives-ouvertes.fr"
+
+# 保守限流：5 req/s
+_DEFAULT_RPS = 5.0
+
+# 需要返回的 Solr 字段（fl 参数）
+_FIELDS = ",".join(
+    [
+        "halId_s",
+        "title_s",
+        "authFullName_s",
+        "abstract_s",
+        "doiId_s",
+        "producedDateY_i",
+        "submittedDate_s",
+        "linkExtUrl_s",
+        "fileMain_s",
+        "uri_s",
+        "docType_s",
+        "journalTitle_s",
+    ]
+)
+
+
+def _first(value: Any) -> Any:
+    """HAL Solr 多数字段为数组，统一取首元素。
+
+    Args:
+        value: 任意值（可能是 list / 标量 / None）。
+
+    Returns:
+        若为非空 list 返回第一个元素；否则原样返回。
+    """
+    if isinstance(value, list):
+        return value[0] if value else None
+    return value
+
+
+class HalClient:
+    """HAL 法国开放档案检索客户端。
+
+    特点:
+        - 基于 Solr，支持丰富的查询语法（字段限定、布尔、范围等）
+        - 字段以后缀标识类型：_s 字符串、_i 整数、_t 文本
+        - 无需 API Key，零配置即用
+        - fileMain_s 直接给出 PDF URL
+    """
+
+    def __init__(self) -> None:
+        """初始化 HAL 客户端。"""
+        self._client = SouWenHttpClient(base_url=_BASE_URL, source_name="hal")
+        self._limiter = TokenBucketLimiter(rate=_DEFAULT_RPS, burst=_DEFAULT_RPS)
+
+    # ------------------------------------------------------------------
+    # async context manager
+    # ------------------------------------------------------------------
+
+    async def __aenter__(self) -> HalClient:
+        await self._client.__aenter__()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> None:
+        await self._client.__aexit__(exc_type, exc_val, exc_tb)
+
+    # ------------------------------------------------------------------
+    # 内部工具
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _parse_doc(doc: dict[str, Any]) -> PaperResult:
+        """将 HAL Solr response.docs 中的单条记录转换为 PaperResult。
+
+        Args:
+            doc: HAL Solr 响应中的单条文献对象。
+
+        Returns:
+            统一的 PaperResult 模型。
+
+        Raises:
+            ParseError: 解析关键字段失败时抛出。
+        """
+        try:
+            hal_id: str = _first(doc.get("halId_s")) or ""
+            title: str = _first(doc.get("title_s")) or ""
+            abstract: str = _first(doc.get("abstract_s")) or ""
+
+            # 作者：authFullName_s 已是全名列表
+            raw_authors = doc.get("authFullName_s") or []
+            if isinstance(raw_authors, str):
+                raw_authors = [raw_authors]
+            authors: list[Author] = [
+                Author(name=name) for name in raw_authors if name and isinstance(name, str)
+            ]
+
+            # DOI：HAL 中通常已是字符串，少数情况下也可能为列表
+            doi_raw = doc.get("doiId_s")
+            doi: str | None = _first(doi_raw) if isinstance(doi_raw, list) else doi_raw
+            if doi == "":
+                doi = None
+
+            # 年份：producedDateY_i 是整数年份
+            year_raw = doc.get("producedDateY_i")
+            year: int | None
+            if isinstance(year_raw, list):
+                year_raw = year_raw[0] if year_raw else None
+            try:
+                year = int(year_raw) if year_raw is not None else None
+            except (TypeError, ValueError):
+                year = None
+
+            # 提交日期：submittedDate_s 形如 "2024-01-15 10:00:00" 或 ISO 字符串
+            submitted = _first(doc.get("submittedDate_s"))
+            pub_date: str | None = None
+            if isinstance(submitted, str) and submitted:
+                # 取前 10 位（YYYY-MM-DD）即可，PaperResult 校验器会容错处理
+                text = submitted.replace("T", " ")
+                pub_date = text[:10]
+
+            # PDF：fileMain_s 是直接 PDF URL（可能为字符串或数组）
+            pdf_url = _first(doc.get("fileMain_s"))
+            if pdf_url == "":
+                pdf_url = None
+
+            # 源 URL：优先 uri_s（HAL 详情页），缺失时基于 halId 构造
+            uri = _first(doc.get("uri_s"))
+            if uri:
+                source_url = uri
+            elif hal_id:
+                source_url = f"https://hal.science/{hal_id}"
+            else:
+                source_url = "https://hal.science/"
+
+            # 期刊：journalTitle_s 多为字符串
+            journal = _first(doc.get("journalTitle_s")) or None
+
+            # 外部链接（用于 raw 调试参考）
+            ext_links = doc.get("linkExtUrl_s")
+            if isinstance(ext_links, str):
+                ext_links = [ext_links]
+
+            doc_type = _first(doc.get("docType_s"))
+
+            return PaperResult(
+                title=title,
+                authors=authors,
+                abstract=abstract,
+                doi=doi,
+                year=year,
+                publication_date=pub_date,
+                source=SourceType.HAL,
+                source_url=source_url,
+                pdf_url=pdf_url,
+                citation_count=None,  # HAL 不提供引用数
+                journal=journal,
+                raw={
+                    "hal_id": hal_id,
+                    "doc_type": doc_type,
+                    "external_links": ext_links,
+                },
+            )
+        except Exception as exc:
+            raise ParseError(f"解析 HAL doc 失败: {exc}") from exc
+
+    # ------------------------------------------------------------------
+    # 公开方法
+    # ------------------------------------------------------------------
+
+    async def search(
+        self,
+        query: str,
+        rows: int = 10,
+    ) -> SearchResponse:
+        """使用 Solr 查询语法搜索 HAL。
+
+        Args:
+            query: Solr 查询串，可使用字段限定（如 ``title_t:neural``）
+                   或自然关键词（默认全文检索）。
+            rows: 返回结果数量。
+
+        Returns:
+            SearchResponse 包含结果列表及分页信息。
+        """
+        await self._limiter.acquire()
+
+        params: dict[str, str | int] = {
+            "q": query,
+            "fl": _FIELDS,
+            "rows": rows,
+            "wt": "json",
+            "sort": "score desc",
+        }
+
+        resp = await self._client.get("/search/", params=params)
+        data: dict[str, Any] = resp.json()
+
+        response_block = data.get("response") or {}
+        docs = response_block.get("docs") or []
+        total = response_block.get("numFound", len(docs))
+
+        results: list[PaperResult] = []
+        for doc in docs:
+            try:
+                results.append(self._parse_doc(doc))
+            except ParseError as exc:
+                logger.debug("跳过解析失败的 HAL doc: %s", exc)
+
+        return SearchResponse(
+            query=query,
+            total_results=total,
+            page=1,
+            per_page=rows,
+            results=results,
+            source=SourceType.HAL,
+        )

--- a/src/souwen/paper/iacr.py
+++ b/src/souwen/paper/iacr.py
@@ -1,0 +1,269 @@
+"""IACR ePrint 密码学预印本搜索客户端（实验性 HTML 爬虫）
+
+官方端点: https://eprint.iacr.org/search?q={query}
+鉴权: 无需 Key
+限流: 0.5 req/s（保守，避免对学术小站造成压力）
+返回: HTML 页面（使用 BeautifulSoup4 + lxml 解析）
+
+文件用途：
+    国际密码学研究协会 (IACR) ePrint 预印本归档搜索客户端。
+    密码学领域权威预印本来源，covers crypto / security / theory 等方向。
+    属于 **实验性 (experimental)** 数据源——通过 HTML 抓取实现，
+    一旦 IACR 调整页面结构（CSS class / DOM 层级）即可能失效。
+
+设计要点：
+    - 仅请求一次搜索页，不再二次抓取每篇论文详情，节省请求配额。
+    - 解析容错：单个结果块解析失败时跳过，不影响整体响应。
+    - paper_id 形如 "2025/1014"，年份直接来自路径段第一段。
+
+函数/类清单：
+    IacrClient（类）
+        - 功能：IACR ePrint 搜索客户端（实验性，HTML 抓取）
+        - 关键属性：_client (SouWenHttpClient), _limiter (TokenBucketLimiter, 0.5 rps)
+
+    _parse_result_block(block) -> PaperResult | None
+        - 功能：解析单个搜索结果 HTML 块为 PaperResult，失败返回 None
+        - 输入：BeautifulSoup Tag / NavigableString
+        - 输出：PaperResult 或 None（解析失败时静默跳过）
+
+    search(query: str, max_results: int = 10) -> SearchResponse
+        - 功能：搜索 IACR ePrint 归档
+        - 输入：query 关键词，max_results 最大返回数
+        - 输出：SearchResponse 包含 PaperResult 列表
+
+模块依赖：
+    - SouWenHttpClient: 统一 HTTP 客户端
+    - TokenBucketLimiter: 令牌桶限流器
+    - bs4 / lxml: HTML 解析
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+from urllib.parse import quote
+
+from bs4 import BeautifulSoup
+
+from souwen.http_client import SouWenHttpClient
+from souwen.models import Author, PaperResult, SearchResponse, SourceType
+from souwen.rate_limiter import TokenBucketLimiter
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://eprint.iacr.org"
+
+# 保守限流：0.5 req/s（学术小站，避免造成负担）
+_DEFAULT_RPS = 0.5
+
+# 论文 ID 形如 "2025/1014"，用于从 href 中提取
+_PAPER_ID_RE = re.compile(r"/?(\d{4}/\d+)")
+
+# 多作者拆分：先按 " and " 再按 ","
+_AUTHOR_AND_RE = re.compile(r"\s+and\s+", re.IGNORECASE)
+
+
+class IacrClient:
+    """IACR ePrint 密码学预印本搜索客户端（实验性）。
+
+    特点:
+        - 无需 API Key，零配置即用
+        - 密码学 / 安全 / 理论领域的权威预印本来源
+        - 通过 HTML 抓取实现，**实验性**——页面结构变更时可能失效
+        - 不二次抓取详情页，所有字段从搜索结果块解析
+
+    Warning:
+        实验性数据源。IACR 调整页面 CSS / DOM 时本客户端可能停止工作，
+        请定期校验 selectors 与抽取逻辑。
+    """
+
+    def __init__(self) -> None:
+        """初始化 IACR ePrint 搜索客户端。"""
+        self._client = SouWenHttpClient(base_url=_BASE_URL, source_name="iacr")
+        self._limiter = TokenBucketLimiter(rate=_DEFAULT_RPS, burst=1)
+
+    # ------------------------------------------------------------------
+    # async context manager
+    # ------------------------------------------------------------------
+
+    async def __aenter__(self) -> IacrClient:
+        await self._client.__aenter__()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> None:
+        await self._client.__aexit__(exc_type, exc_val, exc_tb)
+
+    # ------------------------------------------------------------------
+    # 内部工具
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _split_authors(raw: str) -> list[Author]:
+        """拆分作者字符串为 Author 列表，先按 ' and ' 再按 ','。"""
+        if not raw:
+            return []
+        parts: list[str] = []
+        for chunk in _AUTHOR_AND_RE.split(raw):
+            parts.extend(p.strip() for p in chunk.split(",") if p.strip())
+        return [Author(name=name) for name in parts if name]
+
+    @staticmethod
+    def _extract_paper_id(block: Any) -> str | None:
+        """从结果块中提取 paper_id（形如 '2025/1014'）。
+
+        优先匹配 a.paperlink，否则回退扫描所有 <a> 标签。
+        """
+        anchor = block.select_one("a.paperlink")
+        if anchor and anchor.get("href"):
+            match = _PAPER_ID_RE.search(anchor["href"])
+            if match:
+                return match.group(1)
+
+        for a in block.find_all("a", href=True):
+            match = _PAPER_ID_RE.search(a["href"])
+            if match:
+                return match.group(1)
+        return None
+
+    @classmethod
+    def _parse_result_block(cls, block: Any) -> PaperResult | None:
+        """将单个搜索结果 HTML 块解析为 PaperResult。
+
+        Args:
+            block: BeautifulSoup Tag，对应一个 div.mb-4 结果容器。
+
+        Returns:
+            PaperResult；若关键字段（paper_id / title）缺失则返回 None。
+        """
+        try:
+            paper_id = cls._extract_paper_id(block)
+            if not paper_id:
+                return None
+
+            # 标题：第一个 <strong>
+            title_tag = block.find("strong")
+            title = title_tag.get_text(strip=True) if title_tag else ""
+            if not title:
+                # 退化方案：使用 paperlink 锚点文本
+                anchor = block.select_one("a.paperlink")
+                if anchor:
+                    title = anchor.get_text(strip=True)
+            if not title:
+                return None
+
+            # 作者
+            authors_tag = block.select_one("span.fst-italic")
+            authors: list[Author] = []
+            if authors_tag:
+                authors = cls._split_authors(authors_tag.get_text(" ", strip=True))
+
+            # 摘要
+            abstract_tag = block.select_one("p.search-abstract")
+            abstract: str | None = None
+            if abstract_tag:
+                abstract = abstract_tag.get_text(" ", strip=True) or None
+
+            # 类别 / 主题（可能多个 badge）
+            badges = block.select("small.badge")
+            categories = [b.get_text(strip=True) for b in badges if b.get_text(strip=True)]
+            venue: str | None = ", ".join(categories) if categories else None
+
+            # 最近更新日期文本（可选信息，留存于 raw）
+            updated_tag = block.select_one("small.ms-auto")
+            last_updated = updated_tag.get_text(strip=True) if updated_tag else None
+
+            # 年份从 paper_id 前 4 位提取
+            year: int | None = None
+            try:
+                year = int(paper_id.split("/", 1)[0])
+            except (ValueError, IndexError):
+                year = None
+
+            source_url = f"{_BASE_URL}/{paper_id}"
+            pdf_url = f"{_BASE_URL}/{paper_id}.pdf"
+
+            return PaperResult(
+                source=SourceType.IACR,
+                title=title,
+                authors=authors,
+                abstract=abstract,
+                doi=None,
+                year=year,
+                publication_date=None,
+                venue=venue,
+                citation_count=None,
+                source_url=source_url,
+                pdf_url=pdf_url,
+                raw={
+                    "paper_id": paper_id,
+                    "categories": categories,
+                    "last_updated": last_updated,
+                },
+            )
+        except Exception as exc:
+            logger.debug("IACR 单条结果解析失败，跳过: %s", exc)
+            return None
+
+    # ------------------------------------------------------------------
+    # 公开方法
+    # ------------------------------------------------------------------
+
+    async def search(
+        self,
+        query: str,
+        max_results: int = 10,
+    ) -> SearchResponse:
+        """搜索 IACR ePrint 密码学预印本归档。
+
+        Note:
+            **实验性数据源**：本方法通过 HTML 抓取实现。
+            如果 IACR 调整页面结构（CSS class / DOM 层级），结果可能为空或异常。
+
+        Args:
+            query: 搜索关键词。
+            max_results: 最大返回结果数。
+
+        Returns:
+            SearchResponse 包含 PaperResult 列表。
+        """
+        await self._limiter.acquire()
+
+        encoded_query = quote(query, safe="")
+        resp = await self._client.get(f"/search?q={encoded_query}")
+
+        soup = BeautifulSoup(resp.text, "lxml")
+
+        # 主选择器：div.mb-4。若未命中，回退为含 a.paperlink 的最近祖先 div。
+        blocks = soup.select("div.mb-4")
+        if not blocks:
+            anchors = soup.select("a.paperlink")
+            seen: set[int] = set()
+            blocks = []
+            for a in anchors:
+                parent = a.find_parent("div")
+                if parent is not None and id(parent) not in seen:
+                    seen.add(id(parent))
+                    blocks.append(parent)
+
+        results: list[PaperResult] = []
+        for block in blocks:
+            if len(results) >= max_results:
+                break
+            paper = self._parse_result_block(block)
+            if paper:
+                results.append(paper)
+
+        return SearchResponse(
+            query=query,
+            total_results=len(results),
+            page=1,
+            per_page=max_results,
+            results=results,
+            source=SourceType.IACR,
+        )

--- a/src/souwen/paper/openaire.py
+++ b/src/souwen/paper/openaire.py
@@ -105,9 +105,7 @@ class OpenAireClient:
         if self.api_key:
             headers["Authorization"] = f"Bearer {self.api_key}"
 
-        self._client = SouWenHttpClient(
-            base_url=_BASE_URL, headers=headers, source_name="openaire"
-        )
+        self._client = SouWenHttpClient(base_url=_BASE_URL, headers=headers, source_name="openaire")
         self._limiter = TokenBucketLimiter(rate=_DEFAULT_RPS, burst=_DEFAULT_RPS)
 
     # ------------------------------------------------------------------

--- a/src/souwen/paper/openaire.py
+++ b/src/souwen/paper/openaire.py
@@ -1,0 +1,356 @@
+"""OpenAIRE Research Products API 客户端
+
+官方端点: https://api.openaire.eu/search/researchProducts
+鉴权: 可选 Bearer Token（注册：https://aai.openaire.eu/）
+限流: 保守 3 req/s（匿名访问限制更紧）
+返回: JSON（format=json，结构嵌套且使用 ``$`` 与 ``@classid`` 等键名）
+
+文件用途：OpenAIRE 欧盟开放科研聚合平台搜索客户端，覆盖论文、
+            预印本、数据集等多类研究成果，整合自欧盟各国机构仓储。
+
+参考来源：OpenAIRE Search API 官方文档
+         https://graph.openaire.eu/docs/apis/search-api/research-products
+
+函数/类清单：
+    OpenAireClient（类）
+        - 功能：OpenAIRE 检索客户端，解析嵌套 JSON 响应为统一数据模型
+        - 关键属性：api_key (str|None) 可选 API Key,
+                   _client (SouWenHttpClient) HTTP 客户端,
+                   _limiter (TokenBucketLimiter) 限流器（3 req/s）
+
+    _extract_text(obj) -> str
+        - 功能：从 OpenAIRE ``{"$": "text"}`` 嵌套结构中安全提取文本
+        - 输入：dict / str / 任意类型
+        - 输出：解析出的字符串（缺失返回空串）
+
+    _as_list(value) -> list
+        - 功能：OpenAIRE 字段在单值与多值时类型不一致，统一转 list
+        - 输入：任意值
+        - 输出：list（None → []，单值 → [value]）
+
+    _parse_result(result: dict) -> PaperResult
+        - 功能：将 OpenAIRE 单条 result 转换为 PaperResult
+        - 输入：OpenAIRE response.results.result 的单个元素
+        - 输出：统一的 PaperResult 模型
+
+    search(query: str, size: int = 10) -> SearchResponse
+        - 功能：按关键词搜索 OpenAIRE 研究成果
+        - 输入：query 关键词, size 每页条数
+        - 输出：SearchResponse 包含结果列表及分页信息
+
+模块依赖：
+    - SouWenHttpClient: 统一 HTTP 客户端
+    - TokenBucketLimiter: 令牌桶限流器
+    - PaperResult, SourceType: 统一论文数据模型
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from souwen.config import get_config
+from souwen.exceptions import ParseError
+from souwen.http_client import SouWenHttpClient
+from souwen.models import Author, PaperResult, SearchResponse, SourceType
+from souwen.rate_limiter import TokenBucketLimiter
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://api.openaire.eu"
+
+# 保守限流：匿名访问 OpenAIRE 限制较严，按 3 req/s 控制
+_DEFAULT_RPS = 3.0
+
+
+def _as_list(value: Any) -> list[Any]:
+    """统一字段为列表。OpenAIRE 在单值与多值时返回类型不一致。
+
+    Args:
+        value: 任意值。
+
+    Returns:
+        list；None 转为 []，标量转为 [value]。
+    """
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+class OpenAireClient:
+    """OpenAIRE 欧盟开放科研基础设施搜索客户端。
+
+    特点:
+        - 聚合欧盟各国机构仓储，覆盖论文/预印本/数据集等
+        - 可选 API Key（匿名亦可访问，但限流更严）
+        - JSON 响应使用 ``{"$": "text", "@classid": "..."}`` 嵌套结构，
+          需通过 :func:`_extract_text` 与 :func:`_as_list` 安全解析
+    """
+
+    def __init__(self, api_key: str | None = None) -> None:
+        """初始化 OpenAIRE 客户端。
+
+        Args:
+            api_key: OpenAIRE API Key（可选）。未提供时从全局配置读取，
+                     仍为空则匿名访问。
+        """
+        cfg = get_config()
+        self.api_key: str | None = (
+            api_key or cfg.resolve_api_key("openaire", "openaire_api_key") or None
+        )
+
+        headers: dict[str, str] = {}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        self._client = SouWenHttpClient(
+            base_url=_BASE_URL, headers=headers, source_name="openaire"
+        )
+        self._limiter = TokenBucketLimiter(rate=_DEFAULT_RPS, burst=_DEFAULT_RPS)
+
+    # ------------------------------------------------------------------
+    # async context manager
+    # ------------------------------------------------------------------
+
+    async def __aenter__(self) -> OpenAireClient:
+        await self._client.__aenter__()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> None:
+        await self._client.__aexit__(exc_type, exc_val, exc_tb)
+
+    # ------------------------------------------------------------------
+    # 内部工具
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _extract_text(obj: Any) -> str:
+        """从 OpenAIRE ``{"$": "text"}`` 嵌套结构中提取文本。
+
+        Args:
+            obj: dict（含 ``$`` 键）/ str / 其他类型。
+
+        Returns:
+            提取出的字符串；缺失或类型不匹配时返回空串。
+        """
+        if isinstance(obj, dict):
+            value = obj.get("$", "")
+            return str(value) if value is not None else ""
+        if isinstance(obj, str):
+            return obj
+        if obj is None:
+            return ""
+        return str(obj)
+
+    @classmethod
+    def _parse_result(cls, result: dict[str, Any]) -> PaperResult:
+        """将 OpenAIRE 单条 result 转换为 PaperResult。
+
+        OpenAIRE JSON 响应大致结构::
+
+            result -> metadata -> oaf:entity -> oaf:result -> {
+                title, creator, description, pid, dateofacceptance,
+                journal, children.instance[].webresource[].url, ...
+            }
+
+        Args:
+            result: OpenAIRE response.results.result 的单个元素。
+
+        Returns:
+            统一的 PaperResult 模型。
+
+        Raises:
+            ParseError: 解析关键字段失败时抛出。
+        """
+        try:
+            metadata = result.get("metadata") or {}
+            entity = metadata.get("oaf:entity") or {}
+            oaf_result = entity.get("oaf:result") or {}
+
+            # 标题：可能是 dict 或 list[dict]，优先取 classid="main title"
+            title = ""
+            for t in _as_list(oaf_result.get("title")):
+                text = cls._extract_text(t)
+                if isinstance(t, dict) and t.get("@classid") == "main title" and text:
+                    title = text
+                    break
+                if not title and text:
+                    title = text
+
+            # 作者：creator 可能为 dict 或 list[dict]
+            authors: list[Author] = []
+            for c in _as_list(oaf_result.get("creator")):
+                name = cls._extract_text(c).strip()
+                if name:
+                    authors.append(Author(name=name))
+
+            # 摘要：description 可能为 dict 或 list[dict]
+            abstract = ""
+            for d in _as_list(oaf_result.get("description")):
+                text = cls._extract_text(d).strip()
+                if text:
+                    abstract = text
+                    break
+
+            # DOI：pid 列表中 classid=doi 的项
+            doi: str | None = None
+            for pid in _as_list(oaf_result.get("pid")):
+                if isinstance(pid, dict) and pid.get("@classid", "").lower() == "doi":
+                    doi_val = cls._extract_text(pid).strip()
+                    if doi_val:
+                        doi = doi_val
+                        break
+
+            # 日期：dateofacceptance（YYYY-MM-DD 或 YYYY）
+            pub_date_str = cls._extract_text(oaf_result.get("dateofacceptance")).strip()
+            pub_date: str | None = pub_date_str or None
+            year: int | None = None
+            if pub_date_str and len(pub_date_str) >= 4:
+                try:
+                    year = int(pub_date_str[:4])
+                except ValueError:
+                    year = None
+
+            # 期刊
+            journal_obj = oaf_result.get("journal")
+            journal: str | None = cls._extract_text(journal_obj).strip() or None
+
+            # PDF / 全文 URL：children.instance[].webresource[].url
+            pdf_url: str | None = None
+            children = oaf_result.get("children") or {}
+            instances = _as_list(children.get("instance"))
+            for inst in instances:
+                if not isinstance(inst, dict):
+                    continue
+                for wr in _as_list(inst.get("webresource")):
+                    if not isinstance(wr, dict):
+                        continue
+                    url_val = cls._extract_text(wr.get("url")).strip()
+                    if url_val:
+                        pdf_url = url_val
+                        break
+                if pdf_url:
+                    break
+
+            # 资源类型
+            resulttype = oaf_result.get("resulttype") or {}
+            result_type_name = (
+                resulttype.get("@classname") if isinstance(resulttype, dict) else None
+            )
+
+            # 语言
+            language_obj = oaf_result.get("language") or {}
+            language_name = (
+                language_obj.get("@classname") if isinstance(language_obj, dict) else None
+            )
+
+            # source_url：优先 PDF URL，否则基于 DOI 构造，否则使用 OpenAIRE 站点
+            if pdf_url:
+                source_url = pdf_url
+            elif doi:
+                source_url = f"https://doi.org/{doi}"
+            else:
+                # OpenAIRE 内部 ID（在 result.header.dri:objIdentifier）
+                header = result.get("header") or {}
+                obj_id = cls._extract_text(header.get("dri:objIdentifier")).strip()
+                source_url = (
+                    f"https://explore.openaire.eu/search/publication?pid={obj_id}"
+                    if obj_id
+                    else "https://explore.openaire.eu/"
+                )
+
+            return PaperResult(
+                title=title,
+                authors=authors,
+                abstract=abstract or None,
+                doi=doi,
+                year=year,
+                publication_date=pub_date,
+                source=SourceType.OPENAIRE,
+                source_url=source_url,
+                pdf_url=pdf_url,
+                citation_count=None,  # OpenAIRE 搜索接口不直接给出引用数
+                journal=journal,
+                raw={
+                    "result_type": result_type_name,
+                    "language": language_name,
+                },
+            )
+        except Exception as exc:
+            raise ParseError(f"解析 OpenAIRE result 失败: {exc}") from exc
+
+    # ------------------------------------------------------------------
+    # 公开方法
+    # ------------------------------------------------------------------
+
+    async def search(
+        self,
+        query: str,
+        size: int = 10,
+    ) -> SearchResponse:
+        """搜索 OpenAIRE 研究成果。
+
+        Args:
+            query: 检索关键词。
+            size: 每页条数。
+
+        Returns:
+            SearchResponse 包含结果列表及分页信息。
+        """
+        await self._limiter.acquire()
+
+        params: dict[str, str | int] = {
+            "keywords": query,
+            "page": 1,
+            "size": size,
+            "format": "json",
+        }
+
+        resp = await self._client.get("/search/researchProducts", params=params)
+        data: dict[str, Any] = resp.json()
+
+        response_block = data.get("response") or {}
+
+        # 总数：header.total.$
+        total: int | None = None
+        header = response_block.get("header") or {}
+        total_obj = header.get("total")
+        if isinstance(total_obj, dict):
+            try:
+                total = int(total_obj.get("$", 0))
+            except (TypeError, ValueError):
+                total = None
+        elif isinstance(total_obj, (int, str)):
+            try:
+                total = int(total_obj)
+            except (TypeError, ValueError):
+                total = None
+
+        # 结果：results.result 可能是 dict（单条）或 list
+        results_block = response_block.get("results") or {}
+        raw_results = _as_list(results_block.get("result"))
+
+        results: list[PaperResult] = []
+        for item in raw_results:
+            if not isinstance(item, dict):
+                continue
+            try:
+                results.append(self._parse_result(item))
+            except ParseError as exc:
+                logger.debug("跳过解析失败的 OpenAIRE result: %s", exc)
+
+        return SearchResponse(
+            query=query,
+            total_results=total if total is not None else len(results),
+            page=1,
+            per_page=size,
+            results=results,
+            source=SourceType.OPENAIRE,
+        )

--- a/src/souwen/paper/pmc.py
+++ b/src/souwen/paper/pmc.py
@@ -1,0 +1,428 @@
+"""PubMed Central (PMC) / NCBI E-utilities 客户端
+
+官方文档: https://www.ncbi.nlm.nih.gov/books/NBK25501/
+鉴权: 可选 API Key（复用 NCBI/PubMed Key），无 Key 限流 3 req/s，有 Key 10 req/s
+搜索模式: 两步式 esearch → efetch（efetch 必须，esummary 缺失摘要）
+返回: JATS XML
+
+文件用途：PubMed Central 全文开放获取文献搜索客户端，针对 NCBI E-utilities
+``db=pmc`` 子集，使用 efetch 解析 JATS XML 提取标题、作者、摘要、DOI、期刊
+等完整字段，并提供 PMC 全文页/PDF 链接。
+
+函数/类清单：
+    PmcClient（类）
+        - 功能：PMC 两步搜索客户端（esearch 获取 PMCID，efetch 解析 JATS XML）
+        - 关键属性：api_key (str|None) NCBI API Key（与 PubMed 共享）,
+                   _client (SouWenHttpClient) HTTP 客户端,
+                   _limiter (TokenBucketLimiter) 限流器（无 Key 3 req/s，有 Key 10 req/s）
+
+    _common_params() -> dict
+        - 功能：构建公共请求参数（包含 api_key 若已配置）
+
+    _parse_article(article_el: ET.Element) -> PaperResult
+        - 功能：将 JATS ``<article>`` XML 元素转换为 PaperResult
+        - 输入：article_el JATS ``<article>`` 元素
+        - 输出：统一的 PaperResult 模型，包含 PMCID、期刊、PDF 链接等
+
+    search(query: str, retmax: int = 10, retstart: int = 0) -> SearchResponse
+        - 功能：搜索 PMC 文献（两步：esearch → efetch）
+        - 输入：query 检索式, retmax 返回条数（上限 10000）, retstart 起始偏移
+        - 输出：SearchResponse 包含搜索结果及分页信息
+
+    fetch(pmcids: list[str]) -> list[PaperResult]
+        - 功能：根据 PMCID 列表批量获取论文 JATS XML 详情
+        - 输入：pmcids PMC ID 列表（不带 PMC 前缀的纯数字）
+        - 输出：PaperResult 列表，解析失败的条目跳过并记录日志
+
+模块依赖：
+    - SouWenHttpClient: 统一 HTTP 客户端
+    - TokenBucketLimiter: 令牌桶限流器
+    - defusedxml.ElementTree: 安全 XML 解析（防止 XXE 攻击）
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import defusedxml.ElementTree as ET
+
+from souwen.config import get_config
+from souwen.exceptions import ParseError
+from souwen.http_client import SouWenHttpClient
+from souwen.models import Author, PaperResult, SearchResponse, SourceType
+from souwen.rate_limiter import TokenBucketLimiter
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils"
+
+# 无 Key: 3 req/s, 有 Key: 10 req/s
+_NO_KEY_RPS = 3.0
+_KEYED_RPS = 10.0
+
+# PMC 数据源类型，待补充至 SourceType 枚举后即可替换为 SourceType.PMC
+# SourceType.PMC 已在 models.py 中注册
+
+
+class PmcClient:
+    """PubMed Central (PMC) 全文开放获取文献搜索客户端。
+
+    采用两步搜索模式:
+    1. esearch.fcgi (db=pmc) — 获取 PMCID 列表
+    2. efetch.fcgi  (db=pmc) — 根据 PMCID 批量获取 JATS XML 详情
+
+    与 PubMed 区别:
+        - PubMed (db=pubmed) 仅返回引文+摘要，PMC (db=pmc) 提供 JATS 全文 XML
+        - PMC 文献必然有开放获取的全文链接
+        - efetch 必须用于 PMC（esummary 经常缺失摘要等关键字段）
+    """
+
+    def __init__(self, api_key: str | None = None) -> None:
+        """初始化 PMC 客户端。
+
+        Args:
+            api_key: NCBI API Key（与 PubMed 共享）。未提供时从全局配置读取
+                     （pubmed_api_key 字段）。
+        """
+        cfg = get_config()
+        # PMC 与 PubMed 同属 NCBI E-utilities，共用同一把 API Key
+        self.api_key: str | None = api_key or cfg.resolve_api_key("pmc", "pubmed_api_key")
+
+        self._client = SouWenHttpClient(base_url=_BASE_URL, source_name="pmc")
+        rps = _KEYED_RPS if self.api_key else _NO_KEY_RPS
+        self._limiter = TokenBucketLimiter(rate=rps, burst=rps)
+
+    # ------------------------------------------------------------------
+    # async context manager
+    # ------------------------------------------------------------------
+
+    async def __aenter__(self) -> PmcClient:
+        await self._client.__aenter__()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> None:
+        await self._client.__aexit__(exc_type, exc_val, exc_tb)
+
+    # ------------------------------------------------------------------
+    # 内部工具
+    # ------------------------------------------------------------------
+
+    def _common_params(self) -> dict[str, str]:
+        """构建公共请求参数。
+
+        若配置了 API Key，将其加入参数以提升限流阈值至 10 req/s。
+        """
+        params: dict[str, str] = {}
+        if self.api_key:
+            params["api_key"] = self.api_key
+        return params
+
+    @staticmethod
+    def _normalize_pmcid(pmcid: str) -> str:
+        """将 PMCID 归一化为 ``PMC<digits>`` 形式。"""
+        s = (pmcid or "").strip()
+        if not s:
+            return ""
+        if s.upper().startswith("PMC"):
+            return "PMC" + s[3:]
+        return f"PMC{s}"
+
+    @classmethod
+    def _parse_article(cls, article_el: ET.Element) -> PaperResult:
+        """将 JATS ``<article>`` XML 元素转换为 PaperResult。
+
+        Args:
+            article_el: JATS ``<article>`` 元素。
+
+        Returns:
+            统一的 PaperResult 模型。
+
+        Raises:
+            ParseError: 解析关键字段失败。
+        """
+        try:
+            # ----- 提取 article-id：PMCID / DOI / PMID -----
+            pmcid_raw: str = ""
+            doi: str | None = None
+            pmid: str = ""
+            for aid in article_el.iter("article-id"):
+                id_type = (aid.get("pub-id-type") or "").lower()
+                text = (aid.text or "").strip()
+                if not text:
+                    continue
+                if id_type == "pmc" and not pmcid_raw:
+                    pmcid_raw = text
+                elif id_type == "doi" and not doi:
+                    doi = text
+                elif id_type == "pmid" and not pmid:
+                    pmid = text
+
+            pmcid = cls._normalize_pmcid(pmcid_raw)
+            paper_id = pmcid  # PMC 唯一标识
+
+            # ----- 标题（article-title 可能含子元素，需拼接所有文本）-----
+            title_el = article_el.find(".//title-group/article-title")
+            if title_el is None:
+                title_el = article_el.find(".//article-title")
+            title = "".join(title_el.itertext()).strip() if title_el is not None else ""
+
+            # ----- 作者列表（contrib[@contrib-type="author"]）-----
+            authors: list[Author] = []
+            for contrib in article_el.iter("contrib"):
+                if (contrib.get("contrib-type") or "").lower() != "author":
+                    continue
+                name_el = contrib.find("name")
+                if name_el is not None:
+                    surname = name_el.findtext("surname", "") or ""
+                    given = name_el.findtext("given-names", "") or ""
+                    full = f"{given} {surname}".strip()
+                else:
+                    # 团体作者
+                    coll = contrib.find("collab")
+                    full = "".join(coll.itertext()).strip() if coll is not None else ""
+
+                # 机构信息（在 contrib 内的 aff，或通过 xref 引用，简化处理只取直接子 aff）
+                affiliations: list[str] = []
+                for aff in contrib.findall("aff"):
+                    aff_text = "".join(aff.itertext()).strip()
+                    if aff_text:
+                        affiliations.append(aff_text)
+
+                if full:
+                    authors.append(
+                        Author(
+                            name=full,
+                            affiliation="; ".join(affiliations) if affiliations else None,
+                        )
+                    )
+
+            # ----- 摘要（abstract/p，可能多段）-----
+            abstract_parts: list[str] = []
+            for abs_el in article_el.findall(".//abstract"):
+                # 跳过 abstract-type="graphical" 等非主摘要
+                abs_type = (abs_el.get("abstract-type") or "").lower()
+                if abs_type and abs_type not in ("", "summary", "toc"):
+                    continue
+                # 优先按段落收集
+                paras = abs_el.findall(".//p")
+                if paras:
+                    for p in paras:
+                        text = "".join(p.itertext()).strip()
+                        if text:
+                            abstract_parts.append(text)
+                else:
+                    text = "".join(abs_el.itertext()).strip()
+                    if text:
+                        abstract_parts.append(text)
+            abstract = " ".join(abstract_parts)
+
+            # ----- 期刊名（journal-title 优先，fallback abbrev-journal-title）-----
+            journal: str | None = None
+            jt_el = article_el.find(".//journal-title")
+            if jt_el is not None:
+                journal = "".join(jt_el.itertext()).strip() or None
+            if not journal:
+                ajt_el = article_el.find(".//abbrev-journal-title")
+                if ajt_el is not None:
+                    journal = "".join(ajt_el.itertext()).strip() or None
+
+            # ----- 发表日期（优先 epub，其次 ppub，最后任意 pub-date）-----
+            year: int | None = None
+            pub_date: str | None = None
+            chosen_date_el: ET.Element | None = None
+            for pub_type in ("epub", "ppub", "pub", "collection"):
+                for d in article_el.iter("pub-date"):
+                    dtype = (d.get("pub-type") or d.get("date-type") or "").lower()
+                    if dtype == pub_type:
+                        chosen_date_el = d
+                        break
+                if chosen_date_el is not None:
+                    break
+            if chosen_date_el is None:
+                chosen_date_el = article_el.find(".//pub-date")
+
+            if chosen_date_el is not None:
+                y = chosen_date_el.findtext("year", "") or ""
+                m = chosen_date_el.findtext("month", "01") or "01"
+                d = chosen_date_el.findtext("day", "01") or "01"
+                if y and y.isdigit():
+                    try:
+                        year = int(y)
+                    except ValueError:
+                        year = None
+                    m_num = m.zfill(2) if m.isdigit() else "01"
+                    d_num = d.zfill(2) if d.isdigit() else "01"
+                    pub_date = f"{y}-{m_num}-{d_num}"
+
+            # ----- URL 构建 -----
+            if pmcid:
+                source_url = f"https://www.ncbi.nlm.nih.gov/pmc/articles/{pmcid}/"
+                pdf_url: str | None = f"https://www.ncbi.nlm.nih.gov/pmc/articles/{pmcid}/pdf/"
+            else:
+                source_url = "https://www.ncbi.nlm.nih.gov/pmc/"
+                pdf_url = None
+
+            return PaperResult(
+                title=title,
+                authors=authors,
+                abstract=abstract,
+                doi=doi,
+                year=year,
+                publication_date=pub_date,
+                source=SourceType.PMC,
+                source_url=source_url,
+                pdf_url=pdf_url,
+                citation_count=None,  # PMC efetch 不直接提供引用数
+                journal=journal,
+                open_access_url=source_url if pmcid else None,
+                raw={
+                    "pmcid": pmcid or None,
+                    "pmid": pmid or None,
+                    "paper_id": paper_id or None,
+                },
+            )
+        except ParseError:
+            raise
+        except Exception as exc:
+            raise ParseError(f"解析 PMC article 失败: {exc}") from exc
+
+    # ------------------------------------------------------------------
+    # 公开方法
+    # ------------------------------------------------------------------
+
+    async def search(
+        self,
+        query: str,
+        retmax: int = 10,
+        retstart: int = 0,
+    ) -> SearchResponse:
+        """搜索 PMC 文献（两步: esearch → efetch）。
+
+        Args:
+            query: PMC 检索式（与 PubMed 语法兼容，支持 MeSH 等）。
+            retmax: 返回条数，上限 10000。
+            retstart: 起始偏移量。
+
+        Returns:
+            SearchResponse 包含结果列表及分页信息。
+        """
+        # ---- Step 1: esearch 获取 PMCID 列表 ----
+        await self._limiter.acquire()
+
+        search_params = self._common_params()
+        search_params.update(
+            {
+                "db": "pmc",
+                "term": query,
+                "retmax": str(min(retmax, 10000)),
+                "retstart": str(retstart),
+                "retmode": "xml",
+            }
+        )
+
+        search_resp = await self._client.get("/esearch.fcgi", params=search_params)
+        try:
+            search_root = ET.fromstring(search_resp.text)
+        except ET.ParseError as exc:
+            raise ParseError(f"PMC esearch XML 解析失败: {exc}") from exc
+
+        # 总数
+        count_el = search_root.find("Count")
+        try:
+            total = int(count_el.text) if count_el is not None and count_el.text else 0
+        except ValueError:
+            total = 0
+
+        # PMCID 列表（esearch 返回的 Id 为不带 PMC 前缀的纯数字）
+        pmcids: list[str] = []
+        id_list = search_root.find("IdList")
+        if id_list is not None:
+            for id_el in id_list.findall("Id"):
+                if id_el.text:
+                    pmcids.append(id_el.text.strip())
+
+        page = (retstart // retmax) + 1 if retmax > 0 else 1
+
+        if not pmcids:
+            return SearchResponse(
+                query=query,
+                total_results=total,
+                page=page,
+                per_page=retmax,
+                results=[],
+                source=SourceType.PMC,
+            )
+
+        # ---- Step 2: efetch 获取 JATS XML 详情 ----
+        results = await self.fetch(pmcids)
+
+        return SearchResponse(
+            query=query,
+            total_results=total,
+            page=page,
+            per_page=retmax,
+            results=results,
+            source=SourceType.PMC,
+        )
+
+    async def fetch(self, pmcids: list[str]) -> list[PaperResult]:
+        """根据 PMCID 列表批量获取论文 JATS XML 详情。
+
+        Args:
+            pmcids: PMC ID 列表（可带或不带 PMC 前缀，efetch 接受纯数字）。
+
+        Returns:
+            PaperResult 列表（解析失败的条目会被跳过并记录日志）。
+        """
+        if not pmcids:
+            return []
+
+        # efetch 接受纯数字 ID（不带 PMC 前缀），逗号分隔
+        clean_ids: list[str] = []
+        for pid in pmcids:
+            s = (pid or "").strip()
+            if not s:
+                continue
+            if s.upper().startswith("PMC"):
+                s = s[3:]
+            clean_ids.append(s)
+
+        if not clean_ids:
+            return []
+
+        await self._limiter.acquire()
+
+        fetch_params = self._common_params()
+        fetch_params.update(
+            {
+                "db": "pmc",
+                "id": ",".join(clean_ids),
+                "retmode": "xml",
+            }
+        )
+
+        fetch_resp = await self._client.get("/efetch.fcgi", params=fetch_params)
+        try:
+            fetch_root = ET.fromstring(fetch_resp.text)
+        except ET.ParseError as exc:
+            raise ParseError(f"PMC efetch XML 解析失败: {exc}") from exc
+
+        # efetch 顶层为 <pmc-articleset>，内含若干 <article>
+        articles: list[ET.Element] = list(fetch_root.iter("article"))
+        if not articles and fetch_root.tag == "article":
+            articles = [fetch_root]
+
+        results: list[PaperResult] = []
+        for article_el in articles:
+            try:
+                results.append(self._parse_article(article_el))
+            except ParseError as exc:
+                logger.debug("跳过解析失败的 PMC article: %s", exc)
+
+        return results

--- a/src/souwen/paper/zenodo.py
+++ b/src/souwen/paper/zenodo.py
@@ -1,0 +1,306 @@
+"""Zenodo API 客户端
+
+官方文档: https://developers.zenodo.org/
+鉴权: 可选 Personal Access Token (Authorization: Bearer ...)
+注册: https://zenodo.org/account/settings/applications/tokens/new/
+
+文件用途：Zenodo（CERN 开放科学仓库）出版物搜索客户端，覆盖 preprint、
+期刊文章、技术报告等开放获取的科研出版物，并附带可下载文件链接。
+
+函数/类清单：
+    ZenodoClient（类）
+        - 功能：Zenodo records API 搜索客户端，仅检索 type=publication 类资源
+        - 关键属性：access_token (str|None) 可选个人访问令牌,
+                   _client (SouWenHttpClient) HTTP 客户端,
+                   _limiter (TokenBucketLimiter) 令牌桶限流器（5 req/s）
+
+    _strip_html(text: str) -> str
+        - 功能：剥离描述字段中的 HTML 标签
+        - 输入：可能含 HTML 标签的字符串
+        - 输出：纯文本字符串
+
+    _parse_record(record: dict) -> PaperResult
+        - 功能：将 Zenodo record 对象转换为统一的 PaperResult 数据模型
+        - 输入：Zenodo API 单条记录（含 metadata、files、links）
+        - 输出：PaperResult，pdf_url 取首个 .pdf 文件的下载链接
+
+    search(query: str, size: int = 10) -> SearchResponse
+        - 功能：按关键词搜索 Zenodo 出版物（按最新发布排序）
+        - 输入：query 检索关键词, size 返回条数
+        - 输出：SearchResponse 包含结果列表及总数
+
+模块依赖：
+    - SouWenHttpClient: 统一 HTTP 客户端
+    - TokenBucketLimiter: 令牌桶限流器
+    - PaperResult, SearchResponse: 统一论文数据模型
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from souwen.config import get_config
+from souwen.exceptions import ParseError
+from souwen.http_client import SouWenHttpClient
+from souwen.models import Author, PaperResult, SearchResponse
+from souwen.rate_limiter import TokenBucketLimiter
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://zenodo.org/api"
+_RECORDS_URL = "https://zenodo.org/records"
+
+# Zenodo 限流：保守 5 req/s
+_DEFAULT_RPS = 5.0
+
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+
+
+class ZenodoClient:
+    """Zenodo 开放科学仓库出版物搜索客户端。
+
+    特点:
+        - CERN 维护的开放科学仓库，覆盖 preprint、期刊文章、报告等
+        - 默认仅检索出版物（type=publication），过滤数据集/软件/海报
+        - 提供文件下载链接，可直接获取 PDF
+        - 不提供引用计数
+        - Access Token 可选，匿名访问也可用
+    """
+
+    def __init__(self, access_token: str | None = None) -> None:
+        """初始化 Zenodo 客户端。
+
+        Args:
+            access_token: Zenodo Personal Access Token（可选）。未提供时
+                          从全局配置读取，仍未配置则匿名访问。
+        """
+        cfg = get_config()
+        self.access_token: str | None = (
+            access_token or cfg.resolve_api_key("zenodo", "zenodo_access_token")
+        )
+
+        headers: dict[str, str] = {}
+        if self.access_token:
+            headers["Authorization"] = f"Bearer {self.access_token}"
+
+        self._client = SouWenHttpClient(
+            base_url=_BASE_URL,
+            headers=headers,
+            source_name="zenodo",
+        )
+        self._limiter = TokenBucketLimiter(rate=_DEFAULT_RPS, burst=_DEFAULT_RPS)
+
+    # ------------------------------------------------------------------
+    # async context manager
+    # ------------------------------------------------------------------
+
+    async def __aenter__(self) -> ZenodoClient:
+        await self._client.__aenter__()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> None:
+        await self._client.__aexit__(exc_type, exc_val, exc_tb)
+
+    # ------------------------------------------------------------------
+    # 内部工具
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _strip_html(text: str) -> str:
+        """剥离字符串中的 HTML 标签。
+
+        Zenodo description 字段常含 <p>、<br>、<a> 等 HTML 标签，
+        此处简单去除以获得纯文本摘要。
+
+        Args:
+            text: 可能含 HTML 标签的字符串。
+
+        Returns:
+            去除标签后的文本。
+        """
+        if not text:
+            return ""
+        return _HTML_TAG_RE.sub("", text).strip()
+
+    @staticmethod
+    def _parse_record(record: dict[str, Any]) -> PaperResult:
+        """将 Zenodo record 转换为 PaperResult。
+
+        Zenodo 响应结构：
+        {
+            "id": 12345,
+            "metadata": {
+                "title": "...",
+                "creators": [{"name": "Doe, John"}, ...],
+                "description": "<p>HTML abstract</p>",
+                "publication_date": "2024-01-15",
+                "doi": "10.5281/zenodo.12345",
+                "keywords": [...],
+                "license": {"id": "..."},
+                "resource_type": {"type": "publication", "subtype": "article"}
+            },
+            "files": [{"key": "paper.pdf", "links": {"self": "..."}}],
+            "links": {"html": "https://zenodo.org/records/12345"}
+        }
+
+        Args:
+            record: Zenodo API 单条 record 对象。
+
+        Returns:
+            统一的 PaperResult 模型。
+
+        Raises:
+            ParseError: 解析关键字段失败时抛出。
+        """
+        try:
+            metadata: dict[str, Any] = record.get("metadata", {}) or {}
+            record_id = record.get("id", "")
+            links: dict[str, Any] = record.get("links", {}) or {}
+
+            title: str = metadata.get("title", "") or ""
+
+            # 作者：creators[].name 通常为 "Last, First"，原样保留
+            authors: list[Author] = []
+            for creator in metadata.get("creators", []) or []:
+                name = (
+                    creator.get("name", "")
+                    if isinstance(creator, dict)
+                    else str(creator)
+                )
+                if name:
+                    authors.append(Author(name=name))
+
+            # 摘要：去除 HTML 标签
+            abstract = ZenodoClient._strip_html(metadata.get("description", "") or "") or None
+
+            # DOI
+            doi: str | None = metadata.get("doi") or None
+
+            # 出版日期：YYYY-MM-DD
+            pub_date: str | None = metadata.get("publication_date") or None
+            year: int | None = None
+            if pub_date and len(pub_date) >= 4:
+                try:
+                    year = int(pub_date[:4])
+                except ValueError:
+                    year = None
+
+            # 文件：找首个 .pdf 文件
+            pdf_url: str | None = None
+            for f in record.get("files", []) or []:
+                if not isinstance(f, dict):
+                    continue
+                key = (f.get("key") or "").lower()
+                if not key.endswith(".pdf"):
+                    continue
+                file_links = f.get("links", {}) or {}
+                pdf_url = file_links.get("self") or file_links.get("download")
+                if pdf_url:
+                    break
+
+            # 详情页 URL
+            source_url: str = (
+                links.get("html")
+                or (f"{_RECORDS_URL}/{record_id}" if record_id else _RECORDS_URL)
+            )
+
+            # license / resource_type 提取
+            license_obj = metadata.get("license") or {}
+            license_id = (
+                license_obj.get("id") if isinstance(license_obj, dict) else license_obj
+            )
+            resource_type = metadata.get("resource_type") or {}
+            resource_subtype = (
+                resource_type.get("subtype") if isinstance(resource_type, dict) else None
+            )
+
+            return PaperResult(
+                title=title,
+                authors=authors,
+                abstract=abstract,
+                doi=doi,
+                year=year,
+                publication_date=pub_date,
+                source="zenodo",  # type: ignore[arg-type]
+                source_url=source_url,
+                pdf_url=pdf_url,
+                citation_count=None,  # Zenodo 不提供引用数
+                raw={
+                    "zenodo_id": record_id,
+                    "keywords": metadata.get("keywords") or [],
+                    "access_right": metadata.get("access_right"),
+                    "license": license_id,
+                    "resource_subtype": resource_subtype,
+                },
+            )
+        except Exception as exc:
+            raise ParseError(f"解析 Zenodo record 失败: {exc}") from exc
+
+    # ------------------------------------------------------------------
+    # 公开方法
+    # ------------------------------------------------------------------
+
+    async def search(
+        self,
+        query: str,
+        size: int = 10,
+    ) -> SearchResponse:
+        """搜索 Zenodo 出版物。
+
+        默认追加 type=publication 过滤，仅返回出版物（排除数据集、
+        软件、海报、视频等非论文资源）。结果按最新发布排序。
+
+        Args:
+            query: 检索关键词，支持 Elasticsearch 查询语法。
+            size: 返回条数。
+
+        Returns:
+            SearchResponse 包含结果列表及总数。
+        """
+        await self._limiter.acquire()
+
+        params: dict[str, str | int] = {
+            "q": query,
+            "size": size,
+            "sort": "mostrecent",
+            "type": "publication",  # 关键过滤：仅出版物
+        }
+
+        resp = await self._client.get("/records", params=params)
+        data: dict[str, Any] = resp.json()
+
+        hits_obj: dict[str, Any] = data.get("hits", {}) or {}
+        records = hits_obj.get("hits", []) or []
+
+        # total 在不同 API 版本下可能为 int 或 {"value": int}
+        total_raw = hits_obj.get("total", len(records))
+        if isinstance(total_raw, dict):
+            total = int(total_raw.get("value", len(records)))
+        else:
+            try:
+                total = int(total_raw)
+            except (ValueError, TypeError):
+                total = len(records)
+
+        results: list[PaperResult] = []
+        for record in records:
+            try:
+                results.append(self._parse_record(record))
+            except ParseError as exc:
+                logger.debug("跳过解析失败的 Zenodo record: %s", exc)
+
+        return SearchResponse(
+            query=query,
+            total_results=total,
+            page=1,
+            per_page=size,
+            results=results,
+            source="zenodo",  # type: ignore[arg-type]
+        )

--- a/src/souwen/paper/zenodo.py
+++ b/src/souwen/paper/zenodo.py
@@ -77,8 +77,8 @@ class ZenodoClient:
                           从全局配置读取，仍未配置则匿名访问。
         """
         cfg = get_config()
-        self.access_token: str | None = (
-            access_token or cfg.resolve_api_key("zenodo", "zenodo_access_token")
+        self.access_token: str | None = access_token or cfg.resolve_api_key(
+            "zenodo", "zenodo_access_token"
         )
 
         headers: dict[str, str] = {}
@@ -169,11 +169,7 @@ class ZenodoClient:
             # 作者：creators[].name 通常为 "Last, First"，原样保留
             authors: list[Author] = []
             for creator in metadata.get("creators", []) or []:
-                name = (
-                    creator.get("name", "")
-                    if isinstance(creator, dict)
-                    else str(creator)
-                )
+                name = creator.get("name", "") if isinstance(creator, dict) else str(creator)
                 if name:
                     authors.append(Author(name=name))
 
@@ -206,16 +202,13 @@ class ZenodoClient:
                     break
 
             # 详情页 URL
-            source_url: str = (
-                links.get("html")
-                or (f"{_RECORDS_URL}/{record_id}" if record_id else _RECORDS_URL)
+            source_url: str = links.get("html") or (
+                f"{_RECORDS_URL}/{record_id}" if record_id else _RECORDS_URL
             )
 
             # license / resource_type 提取
             license_obj = metadata.get("license") or {}
-            license_id = (
-                license_obj.get("id") if isinstance(license_obj, dict) else license_obj
-            )
+            license_id = license_obj.get("id") if isinstance(license_obj, dict) else license_obj
             resource_type = metadata.get("resource_type") or {}
             resource_subtype = (
                 resource_type.get("subtype") if isinstance(resource_type, dict) else None

--- a/src/souwen/search.py
+++ b/src/souwen/search.py
@@ -85,6 +85,13 @@ from souwen.paper.core import CoreClient
 from souwen.paper.pubmed import PubMedClient
 from souwen.paper.zotero import ZoteroClient
 from souwen.paper.huggingface import HuggingFaceClient
+from souwen.paper.europepmc import EuropePmcClient
+from souwen.paper.pmc import PmcClient
+from souwen.paper.doaj import DoajClient
+from souwen.paper.zenodo import ZenodoClient
+from souwen.paper.hal import HalClient
+from souwen.paper.openaire import OpenAireClient
+from souwen.paper.iacr import IacrClient
 
 # ── 专利客户端 ──────────────────────────────────────────────
 from souwen.patent.patentsview import PatentsViewClient
@@ -270,6 +277,55 @@ _PAPER_SOURCES: dict[str, Any] = {
         "search",
         query=q,
         top_n=n,
+        **kw,
+    ),
+    "europepmc": lambda q, n, **kw: _run_client(
+        EuropePmcClient,
+        "search",
+        query=q,
+        page_size=n,
+        **kw,
+    ),
+    "pmc": lambda q, n, **kw: _run_client(
+        PmcClient,
+        "search",
+        query=q,
+        retmax=n,
+        **kw,
+    ),
+    "doaj": lambda q, n, **kw: _run_client(
+        DoajClient,
+        "search",
+        query=q,
+        page_size=n,
+        **kw,
+    ),
+    "zenodo": lambda q, n, **kw: _run_client(
+        ZenodoClient,
+        "search",
+        query=q,
+        size=n,
+        **kw,
+    ),
+    "hal": lambda q, n, **kw: _run_client(
+        HalClient,
+        "search",
+        query=q,
+        rows=n,
+        **kw,
+    ),
+    "openaire": lambda q, n, **kw: _run_client(
+        OpenAireClient,
+        "search",
+        query=q,
+        size=n,
+        **kw,
+    ),
+    "iacr": lambda q, n, **kw: _run_client(
+        IacrClient,
+        "search",
+        query=q,
+        max_results=n,
         **kw,
     ),
 }

--- a/src/souwen/source_registry.py
+++ b/src/souwen/source_registry.py
@@ -124,6 +124,16 @@ _reg(
     None,
     description="HuggingFace Papers 社区精选（语义搜索 + 热度排行，无需 Key）",
 )
+_reg("europepmc", "paper", "open_api", None, description="Europe PMC 欧洲生物医学文献")
+_reg("pmc", "paper", "open_api", None, description="PubMed Central 生物医学全文")
+_reg("hal", "paper", "open_api", None, description="HAL 法国开放档案（Solr API）")
+_reg(
+    "iacr",
+    "paper",
+    "scraper",
+    None,
+    description="IACR ePrint 密码学预印本（实验性 HTML 爬虫）",
+)
 
 # ── 论文：授权接口 ────────────────────────────────────────
 _reg(
@@ -141,6 +151,21 @@ _reg(
     "official_api",
     "zotero_api_key",
     description="Zotero 个人文献库搜索 (需 API Key + Library ID)",
+)
+_reg("doaj", "paper", "official_api", "doaj_api_key", description="DOAJ 开放获取期刊目录（可选 Key）")
+_reg(
+    "zenodo",
+    "paper",
+    "official_api",
+    "zenodo_access_token",
+    description="Zenodo CERN 开放科学仓库（可选 Token）",
+)
+_reg(
+    "openaire",
+    "paper",
+    "official_api",
+    "openaire_api_key",
+    description="OpenAIRE 欧盟研究基础设施（可选 Key）",
 )
 
 # ── 专利：公开接口 ────────────────────────────────────────

--- a/src/souwen/source_registry.py
+++ b/src/souwen/source_registry.py
@@ -152,7 +152,9 @@ _reg(
     "zotero_api_key",
     description="Zotero 个人文献库搜索 (需 API Key + Library ID)",
 )
-_reg("doaj", "paper", "official_api", "doaj_api_key", description="DOAJ 开放获取期刊目录（可选 Key）")
+_reg(
+    "doaj", "paper", "official_api", "doaj_api_key", description="DOAJ 开放获取期刊目录（可选 Key）"
+)
 _reg(
     "zenodo",
     "paper",

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -23,7 +23,7 @@ class TestCheckAll:
 
         get_config.cache_clear()
         results = check_all()
-        assert len(results) == 76
+        assert len(results) == 83
 
     def test_result_has_required_keys(self):
         """每条结果包含必要字段"""
@@ -104,7 +104,7 @@ class TestCheckAll:
 
     def test_source_config_matches_37(self):
         """source registry 有 76 个数据源"""
-        assert len(get_all_sources()) == 76
+        assert len(get_all_sources()) == 83
 
     def test_semantic_scholar_without_key_is_limited(self, monkeypatch):
         """Semantic Scholar 无 Key 时标记为 limited。"""

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -173,6 +173,13 @@ class TestModels:
             SourceType.PUBMED,
             SourceType.UNPAYWALL,
             SourceType.HUGGINGFACE,
+            SourceType.EUROPEPMC,
+            SourceType.PMC,
+            SourceType.DOAJ,
+            SourceType.ZENODO,
+            SourceType.HAL,
+            SourceType.OPENAIRE,
+            SourceType.IACR,
         ]
         patent_sources = [
             SourceType.PATENTSVIEW,
@@ -207,7 +214,7 @@ class TestModels:
             SourceType.WEB_ZHIPUAI,
             SourceType.WEB_ALIYUN_IQS,
         ]
-        assert len(paper_sources) == 9
+        assert len(paper_sources) == 16
         assert len(patent_sources) == 8
         assert len(web_sources) == 21
 
@@ -418,7 +425,7 @@ class TestUnifiedSearch:
         """论文数据源映射完整性"""
         from souwen.search import _PAPER_SOURCES, _DEFAULT_PAPER_SOURCES
 
-        assert len(_PAPER_SOURCES) == 9  # 9 sources (unpaywall excluded as DOI resolver)
+        assert len(_PAPER_SOURCES) == 16  # 16 sources (unpaywall excluded as DOI resolver)
         for s in _DEFAULT_PAPER_SOURCES:
             assert s in _PAPER_SOURCES, f"默认源 {s} 不在映射中"
 
@@ -497,7 +504,7 @@ class TestCLI:
         """数据源清单完整性"""
         from souwen.models import ALL_SOURCES
 
-        assert len(ALL_SOURCES["paper"]) == 9
+        assert len(ALL_SOURCES["paper"]) == 16
         assert len(ALL_SOURCES["patent"]) == 6
         total_web = sum(
             len(ALL_SOURCES[c])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,7 +29,7 @@ class TestAllSources:
 
     def test_paper_count(self):
         """paper 暴露 8 个搜索数据源"""
-        assert len(ALL_SOURCES["paper"]) == 9
+        assert len(ALL_SOURCES["paper"]) == 16
 
     def test_patent_count(self):
         """patent 暴露 6 个搜索数据源"""
@@ -47,7 +47,7 @@ class TestAllSources:
     def test_total_count(self):
         """总计暴露 66 个可选数据源"""
         total = sum(len(v) for v in ALL_SOURCES.values())
-        assert total == 66
+        assert total == 73
 
     def test_each_entry_is_tuple_of_three(self):
         """每条目是 (name, requires_key, desc) 三元组"""
@@ -82,7 +82,7 @@ class TestSourceTypeEnum:
 
     def test_has_59_values(self):
         """枚举有 59 个值"""
-        assert len(SourceType) == 62
+        assert len(SourceType) == 69
 
     def test_paper_sources_exist(self):
         """论文数据源枚举存在"""

--- a/tests/test_paper/test_new_sources.py
+++ b/tests/test_paper/test_new_sources.py
@@ -264,9 +264,7 @@ class TestZenodo:
                 "title": "No PDF Record",
                 "publication_date": "2023-05-01",
             },
-            "files": [
-                {"key": "data.csv", "links": {"self": "https://zenodo.org/data.csv"}}
-            ],
+            "files": [{"key": "data.csv", "links": {"self": "https://zenodo.org/data.csv"}}],
             "links": {"html": "https://zenodo.org/records/999"},
         }
         paper = ZenodoClient._parse_record(sample)

--- a/tests/test_paper/test_new_sources.py
+++ b/tests/test_paper/test_new_sources.py
@@ -1,0 +1,440 @@
+"""tests/test_paper/test_new_sources.py — 新增论文源解析测试
+
+覆盖 7 个新增论文搜索客户端的静态解析方法（不发起真实 HTTP）：
+EuropePMC / PMC / DOAJ / Zenodo / HAL / OpenAIRE / IACR。
+
+测试聚焦在各 ``_parse_*`` 静态/类方法上，使用代表性 fixture 数据校验
+字段映射不变量与缺失字段的容错行为。
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import defusedxml.ElementTree as ET
+import pytest
+from bs4 import BeautifulSoup
+
+from souwen.models import SourceType
+from souwen.paper.doaj import DoajClient
+from souwen.paper.europepmc import EuropePmcClient
+from souwen.paper.hal import HalClient
+from souwen.paper.iacr import IacrClient
+from souwen.paper.openaire import OpenAireClient
+from souwen.paper.pmc import PmcClient
+from souwen.paper.zenodo import ZenodoClient
+
+
+# =============================================================================
+# 1. EuropePMC
+# =============================================================================
+
+
+class TestEuropePmc:
+    SAMPLE = {
+        "id": "12345678",
+        "pmid": "12345678",
+        "source": "MED",
+        "title": "A study on machine learning in healthcare",
+        "authorList": {
+            "author": [{"fullName": "Smith J"}, {"fullName": "Doe A"}],
+        },
+        "abstractText": "Background: Machine learning has shown promise...",
+        "doi": "10.1234/test.2024.001",
+        "pubYear": "2024",
+        "firstPublicationDate": "2024-03-15",
+        "journalTitle": "Nature Medicine",
+        "citedByCount": 42,
+        "isOpenAccess": "Y",
+        "fullTextUrlList": {
+            "fullTextUrl": [
+                {"documentStyle": "pdf", "url": "https://europepmc.org/pdf/12345678"},
+                {"documentStyle": "html", "url": "https://europepmc.org/article/12345678"},
+            ]
+        },
+        "keywordList": {"keyword": ["machine learning", "healthcare"]},
+    }
+
+    def test_parse_result_basic(self):
+        paper = EuropePmcClient._parse_result(self.SAMPLE)
+
+        assert paper.title == "A study on machine learning in healthcare"
+        assert [a.name for a in paper.authors] == ["Smith J", "Doe A"]
+        assert paper.abstract.startswith("Background: Machine learning")
+        assert paper.doi == "10.1234/test.2024.001"
+        assert paper.year == 2024
+        assert paper.journal == "Nature Medicine"
+        assert paper.citation_count == 42
+        assert paper.pdf_url == "https://europepmc.org/pdf/12345678"
+        assert paper.source == SourceType.EUROPEPMC
+        # PMID 优先级用于 source_url
+        assert "12345678" in paper.source_url
+        assert paper.raw["is_open_access"] is True
+        assert "machine learning" in paper.raw["keywords"]
+
+    def test_parse_result_missing_fields(self):
+        minimal = {"id": "999", "title": "Minimal Paper"}
+        paper = EuropePmcClient._parse_result(minimal)
+
+        assert paper.title == "Minimal Paper"
+        assert paper.authors == []
+        assert paper.doi is None
+        assert paper.year is None
+        assert paper.citation_count is None
+        assert paper.pdf_url is None
+        assert paper.journal is None
+        assert paper.raw["is_open_access"] is False
+        # source_url 总有 fallback
+        assert paper.source_url.startswith("https://europepmc.org/")
+
+
+# =============================================================================
+# 2. PMC (JATS XML)
+# =============================================================================
+
+
+_PMC_XML = """<article>
+  <front>
+    <article-meta>
+      <article-id pub-id-type="pmc">PMC1234567</article-id>
+      <article-id pub-id-type="doi">10.1234/test.001</article-id>
+      <title-group><article-title>Test Paper Title</article-title></title-group>
+      <contrib-group>
+        <contrib contrib-type="author"><name><surname>Smith</surname><given-names>John</given-names></name></contrib>
+        <contrib contrib-type="author"><name><surname>Doe</surname><given-names>Jane</given-names></name></contrib>
+      </contrib-group>
+      <abstract><p>This is the abstract text.</p></abstract>
+      <pub-date pub-type="epub"><year>2024</year><month>03</month><day>15</day></pub-date>
+      <journal-title-group><journal-title>BMC Medicine</journal-title></journal-title-group>
+    </article-meta>
+  </front>
+</article>"""
+
+
+_PMC_XML_NO_ABSTRACT = """<article>
+  <front>
+    <article-meta>
+      <article-id pub-id-type="pmc">7654321</article-id>
+      <title-group><article-title>No Abstract Paper</article-title></title-group>
+      <contrib-group>
+        <contrib contrib-type="author"><name><surname>Lee</surname><given-names>Min</given-names></name></contrib>
+      </contrib-group>
+      <pub-date pub-type="epub"><year>2023</year></pub-date>
+    </article-meta>
+  </front>
+</article>"""
+
+
+class TestPmc:
+    def test_parse_article_basic(self):
+        root = ET.fromstring(_PMC_XML)
+        paper = PmcClient._parse_article(root)
+
+        assert paper.title == "Test Paper Title"
+        assert paper.doi == "10.1234/test.001"
+        assert paper.year == 2024
+        assert paper.publication_date == date(2024, 3, 15)
+        assert paper.journal == "BMC Medicine"
+        assert paper.abstract == "This is the abstract text."
+        assert len(paper.authors) == 2
+        assert paper.authors[0].name == "John Smith"
+        assert paper.authors[1].name == "Jane Doe"
+        assert paper.source == SourceType.PMC
+        assert "PMC1234567" in paper.source_url
+        assert paper.pdf_url and "PMC1234567" in paper.pdf_url
+        assert paper.raw["pmcid"] == "PMC1234567"
+
+    def test_parse_article_missing_abstract(self):
+        root = ET.fromstring(_PMC_XML_NO_ABSTRACT)
+        paper = PmcClient._parse_article(root)
+
+        assert paper.title == "No Abstract Paper"
+        assert paper.abstract == ""
+        assert paper.doi is None
+        assert paper.year == 2023
+        assert paper.journal is None
+        assert len(paper.authors) == 1
+        # PMCID 自动归一化加 PMC 前缀
+        assert paper.raw["pmcid"] == "PMC7654321"
+
+
+# =============================================================================
+# 3. DOAJ
+# =============================================================================
+
+
+class TestDoaj:
+    SAMPLE = {
+        "id": "abcdef1234567890",
+        "bibjson": {
+            "title": "Open Access Publishing Trends",
+            "author": [{"name": "Author One"}, {"name": "Author Two"}],
+            "abstract": "This paper examines trends in OA publishing...",
+            "identifier": [{"type": "doi", "id": "10.5678/doaj.test"}],
+            "year": "2024",
+            "month": "6",
+            "journal": {"title": "Journal of OA", "publisher": "OA Press"},
+            "keywords": ["open access", "publishing"],
+            "link": [{"type": "fulltext", "url": "https://example.com/paper.pdf"}],
+        },
+    }
+
+    def test_parse_result_basic(self):
+        paper = DoajClient._parse_result(self.SAMPLE)
+
+        assert paper.title == "Open Access Publishing Trends"
+        assert [a.name for a in paper.authors] == ["Author One", "Author Two"]
+        assert paper.abstract == "This paper examines trends in OA publishing..."
+        assert paper.doi == "10.5678/doaj.test"
+        assert paper.year == 2024
+        assert paper.publication_date == date(2024, 6, 1)
+        assert paper.journal == "Journal of OA"
+        assert paper.pdf_url == "https://example.com/paper.pdf"
+        assert paper.citation_count is None
+        assert paper.raw["doaj_id"] == "abcdef1234567890"
+        assert paper.raw["publisher"] == "OA Press"
+        assert paper.raw["keywords"] == ["open access", "publishing"]
+
+    def test_parse_abstract_dict_format(self):
+        sample = {
+            "id": "x1",
+            "bibjson": {
+                "title": "Dict abstract paper",
+                "abstract": {"text": "Abstract from dict"},
+            },
+        }
+        paper = DoajClient._parse_result(sample)
+        assert paper.abstract == "Abstract from dict"
+        assert paper.doi is None
+        assert paper.year is None
+        assert paper.publication_date is None
+
+
+# =============================================================================
+# 4. Zenodo
+# =============================================================================
+
+
+class TestZenodo:
+    SAMPLE = {
+        "id": 12345,
+        "metadata": {
+            "title": "Dataset and Analysis Tools",
+            "creators": [{"name": "Doe, John"}, {"name": "Smith, Jane"}],
+            "description": "<p>This is an <b>HTML</b> abstract.</p>",
+            "publication_date": "2024-01-15",
+            "doi": "10.5281/zenodo.12345",
+            "keywords": ["analysis", "tools"],
+            "resource_type": {"type": "publication", "subtype": "article"},
+        },
+        "files": [
+            {
+                "key": "paper.pdf",
+                "links": {"self": "https://zenodo.org/api/files/abc/paper.pdf"},
+            }
+        ],
+        "links": {"html": "https://zenodo.org/records/12345"},
+    }
+
+    def test_parse_record_basic(self):
+        paper = ZenodoClient._parse_record(self.SAMPLE)
+
+        assert paper.title == "Dataset and Analysis Tools"
+        assert [a.name for a in paper.authors] == ["Doe, John", "Smith, Jane"]
+        assert paper.doi == "10.5281/zenodo.12345"
+        assert paper.year == 2024
+        assert paper.publication_date == date(2024, 1, 15)
+        assert paper.pdf_url == "https://zenodo.org/api/files/abc/paper.pdf"
+        assert paper.source_url == "https://zenodo.org/records/12345"
+        assert paper.raw["zenodo_id"] == 12345
+        assert paper.raw["keywords"] == ["analysis", "tools"]
+        assert paper.raw["resource_subtype"] == "article"
+
+    def test_strip_html(self):
+        paper = ZenodoClient._parse_record(self.SAMPLE)
+        assert paper.abstract is not None
+        assert "<" not in paper.abstract
+        assert ">" not in paper.abstract
+        assert "HTML" in paper.abstract
+
+    def test_no_pdf_files(self):
+        sample = {
+            "id": 999,
+            "metadata": {
+                "title": "No PDF Record",
+                "publication_date": "2023-05-01",
+            },
+            "files": [
+                {"key": "data.csv", "links": {"self": "https://zenodo.org/data.csv"}}
+            ],
+            "links": {"html": "https://zenodo.org/records/999"},
+        }
+        paper = ZenodoClient._parse_record(sample)
+        assert paper.pdf_url is None
+        assert paper.year == 2023
+        assert paper.source_url == "https://zenodo.org/records/999"
+
+
+# =============================================================================
+# 5. HAL
+# =============================================================================
+
+
+class TestHal:
+    SAMPLE = {
+        "halId_s": "hal-03123456",
+        "title_s": ["A Study on French Archives"],
+        "authFullName_s": ["Jean Dupont", "Marie Martin"],
+        "abstract_s": ["This paper studies..."],
+        "doiId_s": "10.1234/hal.test",
+        "producedDateY_i": 2024,
+        "submittedDate_s": "2024-02-20 10:00:00",
+        "fileMain_s": "https://hal.archives-ouvertes.fr/hal-03123456/file/paper.pdf",
+        "uri_s": "https://hal.archives-ouvertes.fr/hal-03123456",
+        "docType_s": "ART",
+        "journalTitle_s": "Archives Journal",
+    }
+
+    def test_parse_doc_basic(self):
+        paper = HalClient._parse_doc(self.SAMPLE)
+
+        # 数组字段被解包为首元素
+        assert paper.title == "A Study on French Archives"
+        assert paper.abstract == "This paper studies..."
+        assert [a.name for a in paper.authors] == ["Jean Dupont", "Marie Martin"]
+        assert paper.doi == "10.1234/hal.test"
+        assert paper.year == 2024
+        assert paper.publication_date == date(2024, 2, 20)
+        assert paper.pdf_url == "https://hal.archives-ouvertes.fr/hal-03123456/file/paper.pdf"
+        assert paper.source_url == "https://hal.archives-ouvertes.fr/hal-03123456"
+        assert paper.journal == "Archives Journal"
+        assert paper.source == SourceType.HAL
+        assert paper.raw["hal_id"] == "hal-03123456"
+        assert paper.raw["doc_type"] == "ART"
+
+    def test_parse_doc_missing_arrays(self):
+        sample = {
+            "halId_s": "hal-99999",
+            "title_s": ["Minimal HAL Doc"],
+        }
+        paper = HalClient._parse_doc(sample)
+        assert paper.title == "Minimal HAL Doc"
+        assert paper.authors == []
+        assert paper.doi is None
+        assert paper.year is None
+        assert paper.publication_date is None
+        assert paper.pdf_url is None
+        assert paper.journal is None
+        # 没有 uri_s 时基于 hal_id 构造
+        assert paper.source_url == "https://hal.science/hal-99999"
+
+
+# =============================================================================
+# 6. OpenAIRE
+# =============================================================================
+
+
+class TestOpenAire:
+    SAMPLE = {
+        "metadata": {
+            "oaf:entity": {
+                "oaf:result": {
+                    "title": {"$": "EU Research Product Title", "@classid": "main title"},
+                    "creator": [
+                        {"$": "Author Alpha", "@rank": "1"},
+                        {"$": "Author Beta", "@rank": "2"},
+                    ],
+                    "description": {"$": "This is the abstract of the research product."},
+                    "pid": [{"$": "10.9999/openaire.test", "@classid": "doi"}],
+                    "dateofacceptance": {"$": "2024-06-01"},
+                    "journal": {"$": "EU Science Journal", "@issn": "1234-5678"},
+                    "children": {
+                        "instance": [
+                            {"webresource": [{"url": {"$": "https://example.com/paper.pdf"}}]}
+                        ]
+                    },
+                }
+            }
+        }
+    }
+
+    def test_extract_text_dict(self):
+        assert OpenAireClient._extract_text({"$": "hello"}) == "hello"
+        assert OpenAireClient._extract_text({"$": None}) == ""
+        assert OpenAireClient._extract_text({}) == ""
+
+    def test_extract_text_string(self):
+        assert OpenAireClient._extract_text("plain") == "plain"
+        assert OpenAireClient._extract_text(None) == ""
+        assert OpenAireClient._extract_text(123) == "123"
+
+    def test_parse_result_basic(self):
+        paper = OpenAireClient._parse_result(self.SAMPLE)
+
+        assert paper.title == "EU Research Product Title"
+        assert [a.name for a in paper.authors] == ["Author Alpha", "Author Beta"]
+        assert paper.abstract == "This is the abstract of the research product."
+        assert paper.doi == "10.9999/openaire.test"
+        assert paper.year == 2024
+        assert paper.publication_date == date(2024, 6, 1)
+        assert paper.journal == "EU Science Journal"
+        assert paper.pdf_url == "https://example.com/paper.pdf"
+        assert paper.source_url == "https://example.com/paper.pdf"
+        assert paper.source == SourceType.OPENAIRE
+
+
+# =============================================================================
+# 7. IACR
+# =============================================================================
+
+
+_IACR_HTML = """<div class="mb-4">
+  <a class="paperlink" href="/2025/1014">2025/1014</a>
+  <strong>A New Cryptographic Protocol</strong>
+  <span class="fst-italic">Alice Crypto, Bob Security</span>
+  <p class="search-abstract">We present a novel approach to...</p>
+  <small class="badge">cryptographic protocols</small>
+</div>"""
+
+
+_IACR_HTML_MINIMAL = """<div class="mb-4">
+  <a class="paperlink" href="/2024/0001">2024/0001</a>
+  <strong>Bare Title Only</strong>
+</div>"""
+
+
+class TestIacr:
+    def test_parse_result_block_basic(self):
+        soup = BeautifulSoup(_IACR_HTML, "lxml")
+        block = soup.select_one("div.mb-4")
+        paper = IacrClient._parse_result_block(block)
+
+        assert paper is not None
+        assert paper.title == "A New Cryptographic Protocol"
+        assert paper.year == 2025
+        assert paper.source == SourceType.IACR
+        assert paper.source_url == "https://eprint.iacr.org/2025/1014"
+        assert paper.pdf_url == "https://eprint.iacr.org/2025/1014.pdf"
+        assert paper.abstract == "We present a novel approach to..."
+        assert [a.name for a in paper.authors] == ["Alice Crypto", "Bob Security"]
+        assert paper.venue == "cryptographic protocols"
+        assert paper.raw["paper_id"] == "2025/1014"
+        assert paper.raw["categories"] == ["cryptographic protocols"]
+
+    def test_parse_result_block_missing_fields(self):
+        soup = BeautifulSoup(_IACR_HTML_MINIMAL, "lxml")
+        block = soup.select_one("div.mb-4")
+        paper = IacrClient._parse_result_block(block)
+
+        assert paper is not None
+        assert paper.title == "Bare Title Only"
+        assert paper.year == 2024
+        assert paper.authors == []
+        assert paper.abstract is None
+        assert paper.venue is None
+        assert paper.raw["paper_id"] == "2024/0001"
+        assert paper.raw["categories"] == []
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## 概述

对比 [openags/paper-search-mcp](https://github.com/openags/paper-search-mcp)（21 个免费学术搜索源）后，为 SouWen 补全 7 个高价值数据源。SouWen 论文搜索源从 10 个增至 16 个（+ Zotero 本地库）。

## 新增数据源

| 数据源 | API 类型 | 认证 | 说明 |
|--------|----------|------|------|
| **Europe PMC** | REST JSON | 免费 | 欧洲生物医学文献，含引用数、OA 状态、全文链接 |
| **PMC** | NCBI E-utilities | 免费（可选 Key 提速） | PubMed Central 全文，JATS XML 解析（defusedxml） |
| **DOAJ** | REST JSON | 可选 API Key | 开放获取期刊目录，bibjson 格式 |
| **Zenodo** | REST JSON | 可选 Bearer Token | CERN 开放科学仓库，`type=publication` 过滤 |
| **HAL** | Solr JSON | 免费 | 法国开放档案，数组字段自动展开 |
| **OpenAIRE** | REST JSON | 可选 API Key | 欧盟开放科研基础设施，嵌套 JSON 解析 |
| **IACR** | HTML 爬虫 | 免费 | 密码学预印本（实验性，BeautifulSoup） |

## 经 Rubber-Duck 审核排除的源

| 源 | 排除原因 |
|----|----------|
| bioRxiv / medRxiv | API 仅支持分类浏览，不支持关键词搜索 |
| Google Scholar | IP 封禁风险高，TLS 指纹检测 |
| SSRN | Cloudflare 防护，需真实浏览器 |

## 变更详情

### 新增文件（7 个客户端）
- `src/souwen/paper/europepmc.py` — EuropePmcClient (293 行)
- `src/souwen/paper/pmc.py` — PmcClient (428 行，JATS XML)
- `src/souwen/paper/doaj.py` — DoajClient (303 行)
- `src/souwen/paper/zenodo.py` — ZenodoClient (306 行)
- `src/souwen/paper/hal.py` — HalClient (266 行)
- `src/souwen/paper/openaire.py` — OpenAireClient (356 行)
- `src/souwen/paper/iacr.py` — IacrClient (269 行)
- `tests/test_paper/test_new_sources.py` — 16 个单元测试

### 修改文件
- `models.py` — SourceType 枚举 +7（EUROPEPMC, PMC, DOAJ, ZENODO, HAL, OPENAIRE, IACR）
- `config.py` — 新增 doaj_api_key / zenodo_access_token / openaire_api_key
- `search.py` — _PAPER_SOURCES 新增 7 个 lambda 入口
- `paper/__init__.py` — 导出 7 个新客户端
- `source_registry.py` — 注册 7 个源（4 open_api + 2 official_api + 1 scraper）
- `mcp_server.py` — 更新 search_papers 工具描述
- 测试文件 — 更新计数断言

## 架构设计

- 每个客户端遵循 SouWen 标准模式：`SouWenHttpClient` + `TokenBucketLimiter` + async context manager
- 新源**不加入**默认搜索集合（_DEFAULT_PAPER_SOURCES 不变），用户通过 `sources` 参数显式启用
- PMC 独立于 PubMed（不同 ID 体系 PMCID vs PMID，避免过早抽象）
- 所有配置字段可选（`str | None = None`），零配置即可使用免费源

## 测试

- 16 个新测试覆盖 7 个客户端的解析逻辑
- 全部 **674 测试通过**，ruff lint 无警告
