### PR TITLE
feat(web): 新增链接提取、Sitemap 解析、CSS 选择器抓取 — 对标 mcp-server-webscan

### DIFF
--- a/src/souwen/cli.py
+++ b/src/souwen/cli.py
@@ -365,14 +365,10 @@ def fetch_cmd(
             "mcp/site_crawler/deepwiki"
         ),
     ),
-    selector: str = typer.Option(
-        None, "--selector", "-s", help="CSS 选择器（仅 builtin 支持）"
-    ),
+    selector: str = typer.Option(None, "--selector", "-s", help="CSS 选择器（仅 builtin 支持）"),
     start_index: int = typer.Option(0, "--start-index", help="内容起始切片位置"),
     max_length: int = typer.Option(None, "--max-length", help="内容最大长度"),
-    respect_robots: bool = typer.Option(
-        False, "--respect-robots", help="遵守 robots.txt"
-    ),
+    respect_robots: bool = typer.Option(False, "--respect-robots", help="遵守 robots.txt"),
     json_output: bool = typer.Option(False, "--json", "-j", help="JSON 格式输出"),
     timeout: int = typer.Option(30, "--timeout", "-t", help="每 URL 超时（秒）"),
 ) -> None:
@@ -494,9 +490,7 @@ def sitemap_cmd(
             parts.append(f"[dim]p={entry.priority}[/dim]")
         console.print(" ".join(parts))
     if result.total > 50:
-        console.print(
-            f"  [dim]... 还有 {result.total - 50} 个 URL（使用 --json 查看全部）[/dim]"
-        )
+        console.print(f"  [dim]... 还有 {result.total - 50} 个 URL（使用 --json 查看全部）[/dim]")
 
 
 # ---------------------------------------------------------------------------

--- a/src/souwen/cli.py
+++ b/src/souwen/cli.py
@@ -365,6 +365,14 @@ def fetch_cmd(
             "mcp/site_crawler/deepwiki"
         ),
     ),
+    selector: str = typer.Option(
+        None, "--selector", "-s", help="CSS 选择器（仅 builtin 支持）"
+    ),
+    start_index: int = typer.Option(0, "--start-index", help="内容起始切片位置"),
+    max_length: int = typer.Option(None, "--max-length", help="内容最大长度"),
+    respect_robots: bool = typer.Option(
+        False, "--respect-robots", help="遵守 robots.txt"
+    ),
     json_output: bool = typer.Option(False, "--json", "-j", help="JSON 格式输出"),
     timeout: int = typer.Option(30, "--timeout", "-t", help="每 URL 超时（秒）"),
 ) -> None:
@@ -372,7 +380,15 @@ def fetch_cmd(
     from souwen.web.fetch import fetch_content
 
     async def _do():
-        return await fetch_content(urls=urls, providers=[provider], timeout=float(timeout))
+        return await fetch_content(
+            urls=urls,
+            providers=[provider],
+            timeout=float(timeout),
+            selector=selector,
+            start_index=start_index,
+            max_length=max_length,
+            respect_robots_txt=respect_robots,
+        )
 
     with console.status(f"[bold green]抓取 {len(urls)} 个 URL ..."):
         try:
@@ -397,6 +413,90 @@ def fetch_cmd(
                 console.print(
                     f"    [dim]{r.snippet[:200]}{'...' if len(r.snippet) > 200 else ''}[/dim]"
                 )
+
+
+@app.command("links")
+def links_cmd(
+    url: str = typer.Argument(..., help="目标页面 URL"),
+    base_url: str = typer.Option(None, "--base-url", "-b", help="URL 前缀过滤"),
+    limit: int = typer.Option(100, "--limit", "-n", help="最大链接数"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="JSON 格式输出"),
+) -> None:
+    """提取页面链接 — 去重 + SSRF 过滤"""
+    from souwen.web.links import extract_links
+
+    async def _do():
+        return await extract_links(url=url, base_url_filter=base_url, limit=limit)
+
+    with console.status("[bold green]提取链接 ..."):
+        result = _run_async(_do())
+
+    if result.error:
+        console.print(f"[red]✗ {result.error}[/red]")
+        raise typer.Exit(1)
+
+    if json_output:
+        from rich import print_json
+
+        print_json(json.dumps(result.model_dump(mode="json"), ensure_ascii=False))
+        return
+
+    console.print(
+        f"[bold]🔗 提取完成: {result.total} 个链接 (过滤 {result.filtered_count} 个)[/bold]"
+    )
+    for link in result.links:
+        text_part = f" — {link.text}" if link.text else ""
+        console.print(f"  [cyan]{link.url}[/cyan]{text_part}")
+
+
+# ---------------------------------------------------------------------------
+# sitemap 子命令
+# ---------------------------------------------------------------------------
+
+
+@app.command("sitemap")
+def sitemap_cmd(
+    url: str = typer.Argument(..., help="Sitemap URL 或站点根 URL"),
+    discover: bool = typer.Option(False, "--discover", "-d", help="自动从 robots.txt 发现 sitemap"),
+    limit: int = typer.Option(1000, "--limit", "-n", help="最大条目数"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="JSON 格式输出"),
+) -> None:
+    """解析 sitemap.xml — 提取站点 URL 列表"""
+    from souwen.web.sitemap import discover_sitemap, parse_sitemap
+
+    async def _do():
+        if discover:
+            return await discover_sitemap(url, max_entries=limit)
+        return await parse_sitemap(url, max_entries=limit)
+
+    with console.status("[bold green]解析 sitemap ..."):
+        result = _run_async(_do())
+
+    if json_output:
+        from rich import print_json
+
+        print_json(json.dumps(result.model_dump(mode="json"), ensure_ascii=False))
+        return
+
+    if result.errors:
+        for err in result.errors:
+            console.print(f"  [yellow]⚠ {err}[/yellow]")
+
+    console.print(
+        f"[bold]🗺️ Sitemap 解析完成: {result.total} 个 URL "
+        f"({result.sitemaps_parsed} 个 sitemap 文件)[/bold]"
+    )
+    for entry in result.entries[:50]:
+        parts = [f"  [cyan]{entry.loc}[/cyan]"]
+        if entry.lastmod:
+            parts.append(f"[dim]{entry.lastmod}[/dim]")
+        if entry.priority is not None:
+            parts.append(f"[dim]p={entry.priority}[/dim]")
+        console.print(" ".join(parts))
+    if result.total > 50:
+        console.print(
+            f"  [dim]... 还有 {result.total - 50} 个 URL（使用 --json 查看全部）[/dim]"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/souwen/integrations/mcp_server.py
+++ b/src/souwen/integrations/mcp_server.py
@@ -184,7 +184,7 @@ def create_server() -> "Server":
             *get_bilibili_tools(),
             Tool(
                 name="fetch_content",
-                description="获取网页内容。支持 URL 直接抓取，使用 SouWen 内置提取器（零配置）。",
+                description="获取网页内容。支持 URL 直接抓取，使用 SouWen 内置提取器（零配置）。支持 CSS 选择器提取指定元素、分页续读。",
                 inputSchema={
                     "type": "object",
                     "properties": {
@@ -198,8 +198,73 @@ def create_server() -> "Server":
                             "default": "builtin",
                             "description": "内容提取提供者，默认 builtin（零配置）",
                         },
+                        "selector": {
+                            "type": "string",
+                            "description": "CSS 选择器，仅提取匹配元素内容（仅 builtin 支持）",
+                        },
+                        "start_index": {
+                            "type": "integer",
+                            "default": 0,
+                            "description": "内容起始切片位置（用于分页续读）",
+                        },
+                        "max_length": {
+                            "type": "integer",
+                            "description": "内容最大长度，超出则截断并返回 next_start_index",
+                        },
+                        "respect_robots_txt": {
+                            "type": "boolean",
+                            "default": False,
+                            "description": "是否遵守 robots.txt（仅 builtin 支持）",
+                        },
                     },
                     "required": ["urls"],
+                },
+            ),
+            Tool(
+                name="extract_links",
+                description="提取网页中的所有链接。返回去重、SSRF 过滤后的链接列表（URL + 锚文本）。",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "url": {
+                            "type": "string",
+                            "description": "目标页面 URL",
+                        },
+                        "base_url_filter": {
+                            "type": "string",
+                            "description": "URL 前缀过滤（仅返回以此开头的链接）",
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "default": 100,
+                            "description": "最大返回链接数（1-1000）",
+                        },
+                    },
+                    "required": ["url"],
+                },
+            ),
+            Tool(
+                name="parse_sitemap",
+                description="解析网站 sitemap.xml，提取 URL 列表。支持 sitemap index 递归、gzip 压缩、robots.txt 自动发现。",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "url": {
+                            "type": "string",
+                            "description": "Sitemap URL 或站点根 URL",
+                        },
+                        "discover": {
+                            "type": "boolean",
+                            "default": False,
+                            "description": "自动从 robots.txt 发现 sitemap",
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "default": 1000,
+                            "description": "最大返回条目数",
+                        },
+                    },
+                    "required": ["url"],
                 },
             ),
         ]
@@ -262,8 +327,41 @@ def create_server() -> "Server":
 
                 urls = arguments["urls"]
                 provider = arguments.get("provider", "builtin")
-                response = await fetch_content(urls=urls, providers=[provider])
+                selector = arguments.get("selector")
+                start_index = arguments.get("start_index", 0)
+                max_length = arguments.get("max_length")
+                respect_robots_txt = arguments.get("respect_robots_txt", False)
+                response = await fetch_content(
+                    urls=urls,
+                    providers=[provider],
+                    selector=selector,
+                    start_index=start_index,
+                    max_length=max_length,
+                    respect_robots_txt=respect_robots_txt,
+                )
                 result = response.model_dump(mode="json")
+
+            elif name == "extract_links":
+                from souwen.web.links import extract_links
+
+                result_obj = await extract_links(
+                    url=arguments["url"],
+                    base_url_filter=arguments.get("base_url_filter"),
+                    limit=arguments.get("limit", 100),
+                )
+                result = result_obj.model_dump(mode="json")
+
+            elif name == "parse_sitemap":
+                from souwen.web.sitemap import discover_sitemap, parse_sitemap
+
+                sitemap_url = arguments["url"]
+                do_discover = arguments.get("discover", False)
+                limit = arguments.get("limit", 1000)
+                if do_discover:
+                    result_obj = await discover_sitemap(sitemap_url, max_entries=limit)
+                else:
+                    result_obj = await parse_sitemap(sitemap_url, max_entries=limit)
+                result = result_obj.model_dump(mode="json")
 
             else:
                 result = f"Unknown tool: {name}"

--- a/src/souwen/server/routes.py
+++ b/src/souwen/server/routes.py
@@ -772,6 +772,10 @@ async def fetch_content_endpoint(body: FetchRequest):
                 urls=body.urls,
                 providers=[body.provider],
                 timeout=body.timeout,
+                selector=body.selector,
+                start_index=body.start_index,
+                max_length=body.max_length,
+                respect_robots_txt=body.respect_robots_txt,
             ),
             timeout=body.timeout + 15,  # 给聚合层留缓冲
         )
@@ -790,6 +794,64 @@ async def fetch_content_endpoint(body: FetchRequest):
     except Exception:
         logger.warning("内容抓取内部错误: provider=%s", body.provider, exc_info=True)
         raise
+
+
+@router.get(
+    "/links",
+    dependencies=[Depends(rate_limit_search), Depends(require_auth)],
+)
+async def extract_links_endpoint(
+    url: str = Query(..., description="目标页面 URL"),
+    base_url_filter: str | None = Query(None, alias="base_url", description="URL 前缀过滤"),
+    limit: int = Query(100, ge=1, le=1000, description="最大返回链接数"),
+):
+    """提取页面链接 — 返回去重、SSRF 过滤后的链接列表
+
+    从指定 URL 的页面中提取所有 <a href> 链接，返回结构化列表。
+    自动过滤内部/私有 IP 链接（SSRF 防护）。
+    """
+    from souwen.web.links import extract_links
+
+    try:
+        result = await asyncio.wait_for(
+            extract_links(url=url, base_url_filter=base_url_filter, limit=limit),
+            timeout=30,
+        )
+        return result.model_dump(mode="json")
+    except asyncio.TimeoutError:
+        raise HTTPException(status_code=504, detail="链接提取超时")
+
+
+@router.get(
+    "/sitemap",
+    dependencies=[Depends(rate_limit_search), Depends(require_auth)],
+)
+async def parse_sitemap_endpoint(
+    url: str = Query(..., description="Sitemap URL 或站点根 URL"),
+    discover: bool = Query(False, description="自动发现 sitemap（从 robots.txt 等）"),
+    limit: int = Query(1000, ge=1, le=50000, description="最大返回条目数"),
+):
+    """解析 sitemap.xml — 提取站点 URL 列表
+
+    支持标准 sitemap XML、sitemap index、gzip 压缩。
+    设置 discover=true 自动从 robots.txt 发现 sitemap。
+    """
+    from souwen.web.sitemap import discover_sitemap, parse_sitemap
+
+    try:
+        if discover:
+            result = await asyncio.wait_for(
+                discover_sitemap(url, max_entries=limit),
+                timeout=60,
+            )
+        else:
+            result = await asyncio.wait_for(
+                parse_sitemap(url, max_entries=limit),
+                timeout=60,
+            )
+        return result.model_dump(mode="json")
+    except asyncio.TimeoutError:
+        raise HTTPException(status_code=504, detail="Sitemap 解析超时")
 
 
 # ---------------------------------------------------------------------------

--- a/src/souwen/server/schemas.py
+++ b/src/souwen/server/schemas.py
@@ -306,6 +306,19 @@ class FetchRequest(BaseModel):
     urls: list[str] = Field(..., min_length=1, max_length=20)
     provider: str = Field(default="builtin")
     timeout: float = Field(default=30.0, ge=1.0, le=120.0)
+    selector: str | None = Field(
+        default=None,
+        description="CSS 选择器，仅提取匹配元素（仅 builtin 提供者支持）",
+    )
+    start_index: int = Field(
+        default=0, ge=0, description="内容起始切片位置（用于分页续读）"
+    )
+    max_length: int | None = Field(
+        default=None, ge=0, description="内容最大长度，超出则截断"
+    )
+    respect_robots_txt: bool = Field(
+        default=False, description="是否遵守 robots.txt"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/souwen/server/schemas.py
+++ b/src/souwen/server/schemas.py
@@ -310,15 +310,9 @@ class FetchRequest(BaseModel):
         default=None,
         description="CSS 选择器，仅提取匹配元素（仅 builtin 提供者支持）",
     )
-    start_index: int = Field(
-        default=0, ge=0, description="内容起始切片位置（用于分页续读）"
-    )
-    max_length: int | None = Field(
-        default=None, ge=0, description="内容最大长度，超出则截断"
-    )
-    respect_robots_txt: bool = Field(
-        default=False, description="是否遵守 robots.txt"
-    )
+    start_index: int = Field(default=0, ge=0, description="内容起始切片位置（用于分页续读）")
+    max_length: int | None = Field(default=None, ge=0, description="内容最大长度，超出则截断")
+    respect_robots_txt: bool = Field(default=False, description="是否遵守 robots.txt")
 
 
 # ---------------------------------------------------------------------------

--- a/src/souwen/web/builtin.py
+++ b/src/souwen/web/builtin.py
@@ -289,6 +289,7 @@ class BuiltinFetcherClient(BaseScraper):
         start_index: int = 0,
         max_length: int | None = None,
         respect_robots_txt: bool | None = None,
+        selector: str | None = None,
     ) -> FetchResult:
         """抓取单个 URL 的内容
 
@@ -301,6 +302,7 @@ class BuiltinFetcherClient(BaseScraper):
             start_index: 内容起始切片位置（用于分页续读）
             max_length: 内容最大长度，超出则截断并设置 next_start_index
             respect_robots_txt: 覆盖实例级 ``respect_robots_txt`` 设置（仅作用本次调用）
+            selector: CSS 选择器，仅提取匹配元素内容（需 bs4 + lxml 支持）
 
         Returns:
             FetchResult 包含提取的正文内容
@@ -310,7 +312,12 @@ class BuiltinFetcherClient(BaseScraper):
         if respect_robots_txt is not None:
             self.respect_robots_txt = respect_robots_txt
         try:
-            return await self._fetch_impl(url, start_index=start_index, max_length=max_length)
+            return await self._fetch_impl(
+                url,
+                start_index=start_index,
+                max_length=max_length,
+                selector=selector,
+            )
         finally:
             self.respect_robots_txt = prev_robots
 
@@ -319,6 +326,7 @@ class BuiltinFetcherClient(BaseScraper):
         url: str,
         start_index: int = 0,
         max_length: int | None = None,
+        selector: str | None = None,
     ) -> FetchResult:
         try:
             from souwen.web.fetch import validate_fetch_url
@@ -447,8 +455,62 @@ class BuiltinFetcherClient(BaseScraper):
                     raw={"status_code": resp.status_code, "content_length": len(html)},
                 )
 
-            # 提取正文
-            extracted = _extract_with_trafilatura(html, url)
+            # 提取正文：CSS 选择器优先，否则 trafilatura 全页提取
+            selector_matched = False
+            if selector:
+                try:
+                    from bs4 import BeautifulSoup
+
+                    soup = BeautifulSoup(html, "lxml")
+                    selected_elements = soup.select(selector)
+                    if selected_elements:
+                        selector_matched = True
+                        selected_html = "\n".join(str(el) for el in selected_elements)
+                        title_text = soup.title.string if soup.title and soup.title.string else ""
+                        if _HAS_HTML2TEXT:
+                            import html2text
+
+                            h = html2text.HTML2Text()
+                            h.ignore_links = False
+                            h.ignore_images = True
+                            h.body_width = 0
+                            extracted = {
+                                "content": h.handle(selected_html).strip(),
+                                "title": title_text,
+                                "author": None,
+                                "date": None,
+                                "description": "",
+                                "content_format": "markdown",
+                            }
+                        else:
+                            extracted = {
+                                "content": "\n".join(
+                                    el.get_text(separator="\n", strip=True)
+                                    for el in selected_elements
+                                ),
+                                "title": title_text,
+                                "author": None,
+                                "date": None,
+                                "description": "",
+                                "content_format": "text",
+                            }
+                        logger.debug(
+                            "CSS selector '%s' matched %d elements",
+                            selector,
+                            len(selected_elements),
+                        )
+                    else:
+                        logger.info(
+                            "CSS selector '%s' matched 0 elements on %s, falling back to full page",
+                            selector,
+                            url,
+                        )
+                        extracted = _extract_with_trafilatura(html, url)
+                except ImportError:
+                    logger.warning("bs4/lxml not installed, ignoring CSS selector")
+                    extracted = _extract_with_trafilatura(html, url)
+            else:
+                extracted = _extract_with_trafilatura(html, url)
             content = extracted["content"]
 
             # 更好的内容验证：检查长度和词数（基于完整提取结果）
@@ -518,6 +580,8 @@ class BuiltinFetcherClient(BaseScraper):
                     "categories": extracted.get("categories"),
                     "has_trafilatura": _HAS_TRAFILATURA,
                     "has_html2text": _HAS_HTML2TEXT,
+                    "selector": selector,
+                    "selector_matched": selector_matched,
                 },
             )
 

--- a/src/souwen/web/fetch.py
+++ b/src/souwen/web/fetch.py
@@ -116,6 +116,10 @@ async def _fetch_with_provider(
     provider: str,
     urls: list[str],
     timeout: float,
+    selector: str | None = None,
+    start_index: int = 0,
+    max_length: int | None = None,
+    respect_robots_txt: bool = False,
 ) -> FetchResponse:
     """使用指定提供者抓取内容
 
@@ -123,6 +127,10 @@ async def _fetch_with_provider(
         provider: 提供者名称
         urls: URL 列表
         timeout: 超时秒数
+        selector: CSS 选择器（仅 builtin 支持）
+        start_index: 内容起始切片位置（仅 builtin 支持）
+        max_length: 内容最大长度（仅 builtin 支持）
+        respect_robots_txt: 是否遵守 robots.txt（仅 builtin 支持）
 
     Returns:
         FetchResponse
@@ -130,7 +138,28 @@ async def _fetch_with_provider(
     if provider == "builtin":
         from souwen.web.builtin import BuiltinFetcherClient
 
-        async with BuiltinFetcherClient() as client:
+        async with BuiltinFetcherClient(respect_robots_txt=respect_robots_txt) as client:
+            # 涉及 selector / 分页参数时按单 URL 调用以传递参数
+            if selector or start_index > 0 or max_length is not None:
+                results = []
+                for u in urls:
+                    r = await client.fetch(
+                        u,
+                        timeout=timeout,
+                        start_index=start_index,
+                        max_length=max_length,
+                        selector=selector,
+                    )
+                    results.append(r)
+                ok = sum(1 for r in results if r.error is None)
+                return FetchResponse(
+                    urls=urls,
+                    results=results,
+                    total=len(results),
+                    total_ok=ok,
+                    total_failed=len(results) - ok,
+                    provider="builtin",
+                )
             return await client.fetch_batch(urls, timeout=timeout)
 
     elif provider == "jina_reader":
@@ -265,6 +294,10 @@ async def fetch_content(
     providers: list[str] | None = None,
     timeout: float = 30.0,
     skip_ssrf_check: bool = False,
+    selector: str | None = None,
+    start_index: int = 0,
+    max_length: int | None = None,
+    respect_robots_txt: bool = False,
 ) -> FetchResponse:
     """并发多提供者聚合内容抓取
 
@@ -318,7 +351,15 @@ async def fetch_content(
 
     try:
         resp = await asyncio.wait_for(
-            _fetch_with_provider(provider, valid_urls, timeout=timeout),
+            _fetch_with_provider(
+                provider,
+                valid_urls,
+                timeout=timeout,
+                selector=selector,
+                start_index=start_index,
+                max_length=max_length,
+                respect_robots_txt=respect_robots_txt,
+            ),
             timeout=timeout + 10,  # 超出每 URL 超时的全局宽限期
         )
     except asyncio.TimeoutError:

--- a/src/souwen/web/links.py
+++ b/src/souwen/web/links.py
@@ -1,0 +1,159 @@
+"""网页链接提取工具
+
+文件用途：
+    从指定 URL 的页面中提取所有 <a href> 链接，返回结构化的链接列表。
+    支持 SSRF 过滤、相对 URL 解析、<base href> 处理、URL 前缀过滤。
+
+函数清单：
+    extract_links(url, base_url_filter, limit) -> LinkExtractionResult
+        - 功能：抓取页面并提取链接
+
+    LinkItem(BaseModel)
+        - url: 绝对 URL
+        - text: 链接文本
+
+    LinkExtractionResult(BaseModel)
+        - source_url: 源页面 URL
+        - final_url: 最终 URL (重定向后)
+        - links: list[LinkItem]
+        - total: int
+        - filtered_count: int (被 SSRF/前缀过滤掉的数量)
+        - error: str | None
+"""
+
+from __future__ import annotations
+
+import logging
+from urllib.parse import urljoin, urlparse
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger("souwen.web.links")
+
+
+class LinkItem(BaseModel):
+    """单个提取的链接"""
+
+    url: str
+    text: str = ""
+
+
+class LinkExtractionResult(BaseModel):
+    """链接提取结果"""
+
+    source_url: str
+    final_url: str = ""
+    links: list[LinkItem] = Field(default_factory=list)
+    total: int = 0
+    filtered_count: int = 0
+    error: str | None = None
+
+
+_SKIP_SCHEMES = frozenset({"javascript", "mailto", "tel", "data", "ftp"})
+
+
+async def extract_links(
+    url: str,
+    base_url_filter: str | None = None,
+    limit: int = 100,
+) -> LinkExtractionResult:
+    """从网页提取链接列表
+
+    Args:
+        url: 目标页面 URL
+        base_url_filter: 可选 URL 前缀过滤（仅返回以此开头的链接）
+        limit: 最大返回链接数（1-1000）
+
+    Returns:
+        LinkExtractionResult 包含提取的链接列表
+    """
+    from souwen.web.fetch import validate_fetch_url
+
+    limit = max(1, min(limit, 1000))
+
+    ok, reason = validate_fetch_url(url)
+    if not ok:
+        return LinkExtractionResult(
+            source_url=url,
+            error=f"SSRF 校验失败: {reason}",
+        )
+
+    try:
+        from souwen.scraper.base import BaseScraper
+
+        scraper = BaseScraper(min_delay=0, max_delay=0.1, max_retries=1)
+        async with scraper:
+            resp = await scraper._fetch(url)
+
+        html = resp.text
+        final_url = str(resp.url) if hasattr(resp, "url") else url
+
+        if not html:
+            return LinkExtractionResult(
+                source_url=url,
+                final_url=final_url,
+                error="页面内容为空",
+            )
+
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(html, "lxml")
+
+        base_tag = soup.find("base", href=True)
+        resolve_base = base_tag["href"] if base_tag else final_url
+
+        seen_urls: set[str] = set()
+        links: list[LinkItem] = []
+        filtered = 0
+
+        for a_tag in soup.find_all("a", href=True):
+            href = a_tag["href"].strip()
+
+            if not href or href.startswith("#"):
+                continue
+
+            parsed = urlparse(href)
+            if parsed.scheme and parsed.scheme.lower() in _SKIP_SCHEMES:
+                continue
+
+            absolute_url = urljoin(resolve_base, href)
+
+            if absolute_url in seen_urls:
+                continue
+            seen_urls.add(absolute_url)
+
+            ok, _ = validate_fetch_url(absolute_url)
+            if not ok:
+                filtered += 1
+                continue
+
+            if base_url_filter and not absolute_url.startswith(base_url_filter):
+                filtered += 1
+                continue
+
+            text = a_tag.get_text(separator=" ", strip=True) or ""
+
+            links.append(LinkItem(url=absolute_url, text=text))
+
+            if len(links) >= limit:
+                break
+
+        return LinkExtractionResult(
+            source_url=url,
+            final_url=final_url,
+            links=links,
+            total=len(links),
+            filtered_count=filtered,
+        )
+
+    except ImportError:
+        return LinkExtractionResult(
+            source_url=url,
+            error="bs4/lxml 未安装，无法提取链接",
+        )
+    except Exception as exc:
+        logger.warning("链接提取失败: url=%s err=%s", url, exc)
+        return LinkExtractionResult(
+            source_url=url,
+            error=str(exc),
+        )

--- a/src/souwen/web/sitemap.py
+++ b/src/souwen/web/sitemap.py
@@ -1,0 +1,292 @@
+"""Sitemap.xml 解析器
+
+文件用途：
+    解析网站的 sitemap.xml（含 sitemap index 和 gzip 压缩），
+    提取 URL 列表用于爬虫 seed 或站点审计。
+    支持从 robots.txt 自动发现 sitemap 地址。
+
+函数/类清单：
+    SitemapEntry(BaseModel)
+        - loc: URL 地址
+        - lastmod: 最后修改日期
+        - changefreq: 更新频率
+        - priority: 优先级
+
+    SitemapResult(BaseModel)
+        - root_url: 站点根 URL
+        - entries: list[SitemapEntry]
+        - total: int
+        - sitemaps_parsed: int
+        - errors: list[str]
+
+    parse_sitemap(url) -> SitemapResult
+        - 解析单个 sitemap URL
+
+    discover_sitemap(root_url) -> SitemapResult
+        - 从 robots.txt / 常见路径自动发现并解析 sitemap
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gzip
+import logging
+from urllib.parse import urljoin, urlparse
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger("souwen.web.sitemap")
+
+# Sitemap index 递归深度限制
+_MAX_DEPTH = 3
+# 单个 sitemap 最大 URL 数
+_MAX_ENTRIES = 50000
+# 请求间隔（秒）
+_REQUEST_DELAY = 0.5
+
+
+class SitemapEntry(BaseModel):
+    """Sitemap 中的单条 URL 记录"""
+
+    loc: str
+    lastmod: str | None = None
+    changefreq: str | None = None
+    priority: float | None = None
+
+
+class SitemapResult(BaseModel):
+    """Sitemap 解析结果"""
+
+    root_url: str
+    entries: list[SitemapEntry] = Field(default_factory=list)
+    total: int = 0
+    sitemaps_parsed: int = 0
+    errors: list[str] = Field(default_factory=list)
+
+
+def _safe_float(s: str | None) -> float | None:
+    if s is None:
+        return None
+    try:
+        return float(s.strip())
+    except (ValueError, TypeError):
+        return None
+
+
+def _parse_sitemap_xml(xml_bytes: bytes) -> tuple[list[SitemapEntry], list[str]]:
+    """解析 sitemap XML 内容
+
+    Returns:
+        (entries, child_sitemap_urls)
+    """
+    import defusedxml.ElementTree as ET
+
+    root = ET.fromstring(xml_bytes)
+
+    ns = ""
+    if root.tag.startswith("{"):
+        ns = root.tag.split("}")[0] + "}"
+
+    entries: list[SitemapEntry] = []
+    child_sitemaps: list[str] = []
+
+    for sitemap_tag in root.findall(f"{ns}sitemap"):
+        loc = sitemap_tag.findtext(f"{ns}loc")
+        if loc:
+            child_sitemaps.append(loc.strip())
+
+    for url_tag in root.findall(f"{ns}url"):
+        loc = url_tag.findtext(f"{ns}loc")
+        if not loc:
+            continue
+        entries.append(
+            SitemapEntry(
+                loc=loc.strip(),
+                lastmod=url_tag.findtext(f"{ns}lastmod"),
+                changefreq=url_tag.findtext(f"{ns}changefreq"),
+                priority=_safe_float(url_tag.findtext(f"{ns}priority")),
+            )
+        )
+
+    return entries, child_sitemaps
+
+
+async def _fetch_url_bytes(url: str) -> bytes | None:
+    """Fetch URL 并返回原始字节内容"""
+    try:
+        from souwen.scraper.base import BaseScraper
+
+        scraper = BaseScraper(
+            min_delay=0, max_delay=0.1, max_retries=1, follow_redirects=True
+        )
+        async with scraper:
+            resp = await scraper._fetch(url)
+            if resp.status_code >= 400:
+                return None
+            if hasattr(resp, "content") and resp.content:
+                return resp.content
+            return resp.text.encode("utf-8") if resp.text else None
+    except Exception as exc:
+        logger.debug("Sitemap fetch failed: %s — %s", url, exc)
+        return None
+
+
+async def parse_sitemap(
+    url: str,
+    max_entries: int = _MAX_ENTRIES,
+) -> SitemapResult:
+    """解析单个 sitemap URL
+
+    自动处理 sitemap index 递归和 gzip 压缩。
+
+    Args:
+        url: sitemap.xml URL
+        max_entries: 最大返回条目数
+
+    Returns:
+        SitemapResult
+    """
+    from souwen.web.fetch import validate_fetch_url
+
+    ok, reason = validate_fetch_url(url)
+    if not ok:
+        return SitemapResult(root_url=url, errors=[f"SSRF: {reason}"])
+
+    all_entries: list[SitemapEntry] = []
+    sitemaps_parsed = 0
+    errors: list[str] = []
+
+    queue: list[tuple[str, int]] = [(url, 0)]
+    visited: set[str] = set()
+
+    while queue and len(all_entries) < max_entries:
+        current_url, depth = queue.pop(0)
+
+        if current_url in visited:
+            continue
+        visited.add(current_url)
+
+        if depth > _MAX_DEPTH:
+            continue
+
+        if sitemaps_parsed > 0:
+            await asyncio.sleep(_REQUEST_DELAY)
+
+        raw_bytes = await _fetch_url_bytes(current_url)
+        if raw_bytes is None:
+            errors.append(f"获取失败: {current_url}")
+            continue
+
+        xml_bytes = raw_bytes
+        if current_url.endswith(".gz") or raw_bytes[:2] == b"\x1f\x8b":
+            try:
+                xml_bytes = gzip.decompress(raw_bytes)
+            except Exception:
+                errors.append(f"gzip 解压失败: {current_url}")
+                continue
+
+        try:
+            entries, child_sitemaps = _parse_sitemap_xml(xml_bytes)
+            sitemaps_parsed += 1
+
+            for entry in entries:
+                if len(all_entries) >= max_entries:
+                    break
+                entry_ok, _ = validate_fetch_url(entry.loc)
+                if entry_ok:
+                    all_entries.append(entry)
+
+            for child_url in child_sitemaps:
+                abs_child = urljoin(current_url, child_url)
+                child_ok, _ = validate_fetch_url(abs_child)
+                if child_ok and abs_child not in visited:
+                    queue.append((abs_child, depth + 1))
+
+        except Exception as exc:
+            errors.append(f"XML 解析失败: {current_url} — {exc}")
+
+    return SitemapResult(
+        root_url=url,
+        entries=all_entries,
+        total=len(all_entries),
+        sitemaps_parsed=sitemaps_parsed,
+        errors=errors,
+    )
+
+
+def _extract_sitemaps_from_robots(robots_text: str, base_url: str) -> list[str]:
+    """从 robots.txt 内容中提取 Sitemap 行"""
+    sitemaps = []
+    for line in robots_text.splitlines():
+        line = line.strip()
+        if line.lower().startswith("sitemap:"):
+            sitemap_url = line.split(":", 1)[1].strip()
+            if sitemap_url:
+                sitemaps.append(urljoin(base_url, sitemap_url))
+    return sitemaps
+
+
+async def discover_sitemap(
+    root_url: str,
+    max_entries: int = _MAX_ENTRIES,
+) -> SitemapResult:
+    """自动发现并解析站点 sitemap
+
+    尝试以下路径（按优先级）：
+    1. /robots.txt 中的 Sitemap: 行
+    2. /sitemap.xml
+    3. /sitemap_index.xml
+
+    Args:
+        root_url: 站点根 URL（如 https://example.com）
+        max_entries: 最大返回条目数
+
+    Returns:
+        SitemapResult
+    """
+    from souwen.web.fetch import validate_fetch_url
+
+    parsed = urlparse(root_url)
+    if not parsed.scheme or not parsed.netloc:
+        return SitemapResult(root_url=root_url, errors=["无效 URL: 缺少 scheme/host"])
+    origin = f"{parsed.scheme}://{parsed.netloc}"
+
+    ok, reason = validate_fetch_url(origin)
+    if not ok:
+        return SitemapResult(root_url=root_url, errors=[f"SSRF: {reason}"])
+
+    sitemap_urls: list[str] = []
+    robots_url = f"{origin}/robots.txt"
+    robots_bytes = await _fetch_url_bytes(robots_url)
+    if robots_bytes:
+        try:
+            robots_text = robots_bytes.decode("utf-8", errors="replace")
+            sitemap_urls = _extract_sitemaps_from_robots(robots_text, origin)
+        except Exception:
+            pass
+
+    if not sitemap_urls:
+        for path in ["/sitemap.xml", "/sitemap_index.xml"]:
+            sitemap_urls.append(f"{origin}{path}")
+
+    all_entries: list[SitemapEntry] = []
+    total_parsed = 0
+    all_errors: list[str] = []
+
+    for sitemap_url in sitemap_urls:
+        if len(all_entries) >= max_entries:
+            break
+        result = await parse_sitemap(
+            sitemap_url, max_entries=max_entries - len(all_entries)
+        )
+        all_entries.extend(result.entries)
+        total_parsed += result.sitemaps_parsed
+        all_errors.extend(result.errors)
+
+    return SitemapResult(
+        root_url=root_url,
+        entries=all_entries,
+        total=len(all_entries),
+        sitemaps_parsed=total_parsed,
+        errors=all_errors,
+    )

--- a/src/souwen/web/sitemap.py
+++ b/src/souwen/web/sitemap.py
@@ -116,9 +116,7 @@ async def _fetch_url_bytes(url: str) -> bytes | None:
     try:
         from souwen.scraper.base import BaseScraper
 
-        scraper = BaseScraper(
-            min_delay=0, max_delay=0.1, max_retries=1, follow_redirects=True
-        )
+        scraper = BaseScraper(min_delay=0, max_delay=0.1, max_retries=1, follow_redirects=True)
         async with scraper:
             resp = await scraper._fetch(url)
             if resp.status_code >= 400:
@@ -276,9 +274,7 @@ async def discover_sitemap(
     for sitemap_url in sitemap_urls:
         if len(all_entries) >= max_entries:
             break
-        result = await parse_sitemap(
-            sitemap_url, max_entries=max_entries - len(all_entries)
-        )
+        result = await parse_sitemap(sitemap_url, max_entries=max_entries - len(all_entries))
         all_entries.extend(result.entries)
         total_parsed += result.sitemaps_parsed
         all_errors.extend(result.errors)

--- a/tests/test_web/test_new_web_tools.py
+++ b/tests/test_web/test_new_web_tools.py
@@ -1,0 +1,399 @@
+"""新 Web 工具单元测试
+
+覆盖 link extraction、sitemap parsing、CSS selector fetch 的核心逻辑。
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Link Extraction Tests
+# ---------------------------------------------------------------------------
+
+class TestLinkModels:
+    """LinkItem / LinkExtractionResult 模型测试"""
+
+    def test_link_item_basic(self):
+        from souwen.web.links import LinkItem
+        item = LinkItem(url="https://example.com", text="Example")
+        assert item.url == "https://example.com"
+        assert item.text == "Example"
+
+    def test_link_item_empty_text(self):
+        from souwen.web.links import LinkItem
+        item = LinkItem(url="https://example.com")
+        assert item.text == ""
+
+    def test_link_extraction_result_basic(self):
+        from souwen.web.links import LinkExtractionResult, LinkItem
+        result = LinkExtractionResult(
+            source_url="https://example.com",
+            final_url="https://example.com",
+            links=[LinkItem(url="https://example.com/a", text="A")],
+            total=1,
+            filtered_count=2,
+        )
+        assert result.total == 1
+        assert result.filtered_count == 2
+        assert result.error is None
+        assert len(result.links) == 1
+
+    def test_link_extraction_result_error(self):
+        from souwen.web.links import LinkExtractionResult
+        result = LinkExtractionResult(
+            source_url="https://example.com",
+            error="SSRF blocked",
+        )
+        assert result.error == "SSRF blocked"
+        assert result.total == 0
+        assert result.links == []
+
+
+class _FakeResp:
+    """Fake httpx-like response for mocking BaseScraper._fetch."""
+
+    def __init__(self, html: str, url: str = "https://example.com/"):
+        self.text = html
+        self.url = url
+        self.content = html.encode("utf-8")
+        self.status_code = 200
+
+
+class _FakeScraper:
+    """Async-context-manager scraper returning a preset response."""
+
+    def __init__(self, resp: _FakeResp):
+        self._resp = resp
+
+    def __init_args__(self, *a, **kw):  # pragma: no cover
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def _fetch(self, url: str):
+        return self._resp
+
+
+def _patch_scraper(html: str, url: str = "https://example.com/"):
+    """Helper: patch BaseScraper symbol used inside extract_links."""
+    resp = _FakeResp(html, url)
+    return patch(
+        "souwen.scraper.base.BaseScraper",
+        lambda *a, **kw: _FakeScraper(resp),
+    )
+
+
+class TestExtractLinks:
+    """extract_links 异步函数测试（通过 mock HTTP 层）"""
+
+    async def test_extract_links_ssrf_blocked(self):
+        """SSRF 校验失败的 URL 应直接返回错误"""
+        from souwen.web.links import extract_links
+
+        with patch(
+            "souwen.web.fetch.validate_fetch_url",
+            return_value=(False, "private IP"),
+        ):
+            result = await extract_links("http://192.168.1.1/page")
+        assert result.error is not None
+        assert "SSRF" in result.error
+        assert result.total == 0
+
+    async def test_extract_links_basic_and_skip_schemes(self):
+        """常规链接、相对链接保留；fragment / mailto / javascript / tel 跳过"""
+        from souwen.web.links import extract_links
+
+        html = """
+        <html><body>
+            <a href="https://example.com/a">A</a>
+            <a href="/b">B</a>
+            <a href="#section">Skip frag</a>
+            <a href="mailto:x@y.com">mail</a>
+            <a href="javascript:void(0)">js</a>
+            <a href="tel:+123">tel</a>
+            <a href="https://example.com/a">Dup</a>
+        </body></html>
+        """
+        with patch("souwen.web.fetch.validate_fetch_url", return_value=(True, "ok")), \
+             _patch_scraper(html, "https://example.com/"):
+            result = await extract_links("https://example.com/")
+
+        assert result.error is None
+        urls = [link.url for link in result.links]
+        # dedup → only one /a, plus /b
+        assert "https://example.com/a" in urls
+        assert "https://example.com/b" in urls
+        # skip schemes
+        assert not any(u.startswith("mailto:") for u in urls)
+        assert not any(u.startswith("javascript:") for u in urls)
+        assert not any(u.startswith("tel:") for u in urls)
+        assert not any("#section" in u for u in urls)
+        assert result.total == 2
+
+    async def test_extract_links_base_href(self):
+        """<base href> 应作为相对链接解析的基准"""
+        from souwen.web.links import extract_links
+
+        html = """
+        <html><head><base href="https://other.example.org/path/"></head>
+        <body><a href="page.html">P</a></body></html>
+        """
+        with patch("souwen.web.fetch.validate_fetch_url", return_value=(True, "ok")), \
+             _patch_scraper(html, "https://example.com/"):
+            result = await extract_links("https://example.com/")
+
+        assert result.error is None
+        assert result.total == 1
+        assert result.links[0].url == "https://other.example.org/path/page.html"
+
+    async def test_extract_links_base_url_filter(self):
+        """base_url_filter 应过滤掉不匹配前缀的链接"""
+        from souwen.web.links import extract_links
+
+        html = """
+        <html><body>
+            <a href="https://example.com/keep">k</a>
+            <a href="https://other.com/drop">d</a>
+        </body></html>
+        """
+        with patch("souwen.web.fetch.validate_fetch_url", return_value=(True, "ok")), \
+             _patch_scraper(html, "https://example.com/"):
+            result = await extract_links(
+                "https://example.com/",
+                base_url_filter="https://example.com/",
+            )
+
+        urls = [link.url for link in result.links]
+        assert urls == ["https://example.com/keep"]
+        assert result.filtered_count == 1
+
+    async def test_extract_links_limit(self):
+        """limit 应截断返回数量"""
+        from souwen.web.links import extract_links
+
+        anchors = "".join(
+            f'<a href="https://example.com/p{i}">p{i}</a>' for i in range(20)
+        )
+        html = f"<html><body>{anchors}</body></html>"
+        with patch("souwen.web.fetch.validate_fetch_url", return_value=(True, "ok")), \
+             _patch_scraper(html, "https://example.com/"):
+            result = await extract_links("https://example.com/", limit=5)
+
+        assert result.total == 5
+        assert len(result.links) == 5
+
+    async def test_extract_links_ssrf_filtered_in_page(self):
+        """页面内提取的链接若 SSRF 校验失败应计入 filtered_count"""
+        from souwen.web.links import extract_links
+
+        html = """
+        <html><body>
+            <a href="https://good.example.com/x">good</a>
+            <a href="http://10.0.0.1/bad">bad</a>
+        </body></html>
+        """
+
+        def _fake_validate(url, *a, **kw):
+            # 入口 URL + good.example.com 通过；10.x 拒绝
+            if "10.0.0.1" in url:
+                return (False, "private IP")
+            return (True, "ok")
+
+        with patch("souwen.web.fetch.validate_fetch_url", side_effect=_fake_validate), \
+             _patch_scraper(html, "https://example.com/"):
+            result = await extract_links("https://example.com/")
+
+        urls = [link.url for link in result.links]
+        assert "https://good.example.com/x" in urls
+        assert all("10.0.0.1" not in u for u in urls)
+        assert result.filtered_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Sitemap Parsing Tests
+# ---------------------------------------------------------------------------
+
+class TestSitemapParsing:
+    """Sitemap XML 解析测试"""
+
+    def test_parse_urlset(self):
+        from souwen.web.sitemap import _parse_sitemap_xml
+        xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+            <url>
+                <loc>https://example.com/page1</loc>
+                <lastmod>2024-01-01</lastmod>
+                <changefreq>weekly</changefreq>
+                <priority>0.8</priority>
+            </url>
+            <url>
+                <loc>https://example.com/page2</loc>
+            </url>
+        </urlset>"""
+        entries, children = _parse_sitemap_xml(xml)
+        assert len(entries) == 2
+        assert entries[0].loc == "https://example.com/page1"
+        assert entries[0].lastmod == "2024-01-01"
+        assert entries[0].changefreq == "weekly"
+        assert entries[0].priority == 0.8
+        assert entries[1].loc == "https://example.com/page2"
+        assert entries[1].lastmod is None
+        assert len(children) == 0
+
+    def test_parse_sitemapindex(self):
+        from souwen.web.sitemap import _parse_sitemap_xml
+        xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+        <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+            <sitemap>
+                <loc>https://example.com/sitemap1.xml</loc>
+            </sitemap>
+            <sitemap>
+                <loc>https://example.com/sitemap2.xml</loc>
+            </sitemap>
+        </sitemapindex>"""
+        entries, children = _parse_sitemap_xml(xml)
+        assert len(entries) == 0
+        assert len(children) == 2
+        assert children[0] == "https://example.com/sitemap1.xml"
+        assert children[1] == "https://example.com/sitemap2.xml"
+
+    def test_parse_no_namespace(self):
+        """Without xmlns namespace"""
+        from souwen.web.sitemap import _parse_sitemap_xml
+        xml = b"""<?xml version="1.0"?>
+        <urlset>
+            <url><loc>https://example.com/</loc></url>
+        </urlset>"""
+        entries, children = _parse_sitemap_xml(xml)
+        assert len(entries) == 1
+        assert entries[0].loc == "https://example.com/"
+        assert len(children) == 0
+
+    def test_safe_float(self):
+        from souwen.web.sitemap import _safe_float
+        assert _safe_float("0.8") == 0.8
+        assert _safe_float("1.0") == 1.0
+        assert _safe_float(" 0.5 ") == 0.5
+        assert _safe_float(None) is None
+        assert _safe_float("invalid") is None
+        assert _safe_float("") is None
+
+    def test_extract_sitemaps_from_robots(self):
+        from souwen.web.sitemap import _extract_sitemaps_from_robots
+        robots = """User-agent: *
+Disallow: /admin/
+Sitemap: https://example.com/sitemap.xml
+Sitemap: https://example.com/sitemap-news.xml
+"""
+        result = _extract_sitemaps_from_robots(robots, "https://example.com")
+        assert len(result) == 2
+        assert result[0] == "https://example.com/sitemap.xml"
+        assert result[1] == "https://example.com/sitemap-news.xml"
+
+    def test_extract_sitemaps_from_robots_empty(self):
+        from souwen.web.sitemap import _extract_sitemaps_from_robots
+        robots = """User-agent: *
+Disallow: /
+"""
+        result = _extract_sitemaps_from_robots(robots, "https://example.com")
+        assert len(result) == 0
+
+    def test_extract_sitemaps_case_insensitive(self):
+        from souwen.web.sitemap import _extract_sitemaps_from_robots
+        robots = (
+            "SITEMAP: https://example.com/sitemap.xml\n"
+            "sitemap: https://example.com/other.xml"
+        )
+        result = _extract_sitemaps_from_robots(robots, "https://example.com")
+        assert len(result) == 2
+
+    def test_extract_sitemaps_relative_resolved(self):
+        """robots.txt 中的相对 sitemap 路径应通过 base_url 解析为绝对地址"""
+        from souwen.web.sitemap import _extract_sitemaps_from_robots
+        robots = "Sitemap: /sitemap.xml"
+        result = _extract_sitemaps_from_robots(robots, "https://example.com")
+        assert len(result) == 1
+        assert result[0] == "https://example.com/sitemap.xml"
+
+
+class TestSitemapModels:
+    """Sitemap model 测试"""
+
+    def test_sitemap_entry(self):
+        from souwen.web.sitemap import SitemapEntry
+        entry = SitemapEntry(
+            loc="https://example.com/page",
+            lastmod="2024-06-01",
+            priority=0.5,
+        )
+        assert entry.loc == "https://example.com/page"
+        assert entry.lastmod == "2024-06-01"
+        assert entry.priority == 0.5
+        assert entry.changefreq is None
+
+    def test_sitemap_entry_minimal(self):
+        from souwen.web.sitemap import SitemapEntry
+        entry = SitemapEntry(loc="https://example.com/")
+        assert entry.loc == "https://example.com/"
+        assert entry.lastmod is None
+        assert entry.changefreq is None
+        assert entry.priority is None
+
+    def test_sitemap_result_defaults(self):
+        from souwen.web.sitemap import SitemapResult
+        result = SitemapResult(root_url="https://example.com")
+        assert result.root_url == "https://example.com"
+        assert result.total == 0
+        assert result.sitemaps_parsed == 0
+        assert result.entries == []
+        assert result.errors == []
+
+
+# ---------------------------------------------------------------------------
+# CSS Selector + Fetch Params Tests
+# ---------------------------------------------------------------------------
+
+class TestFetchParams:
+    """fetch 参数签名测试"""
+
+    def test_builtin_fetch_accepts_selector(self):
+        """BuiltinFetcherClient.fetch() 应接受 selector / 分页 / robots 参数"""
+        import inspect
+        from souwen.web.builtin import BuiltinFetcherClient
+        sig = inspect.signature(BuiltinFetcherClient.fetch)
+        params = list(sig.parameters.keys())
+        assert "selector" in params
+        assert "start_index" in params
+        assert "max_length" in params
+        assert "respect_robots_txt" in params
+
+    def test_fetch_content_accepts_new_params(self):
+        """fetch_content() 应接受 selector / 分页 / robots 参数"""
+        import inspect
+        from souwen.web.fetch import fetch_content
+        sig = inspect.signature(fetch_content)
+        params = list(sig.parameters.keys())
+        assert "selector" in params
+        assert "start_index" in params
+        assert "max_length" in params
+        assert "respect_robots_txt" in params
+
+    def test_fetch_request_schema_has_new_fields(self):
+        """FetchRequest model 应包含 selector / start_index / max_length / respect_robots_txt"""
+        from souwen.server.schemas import FetchRequest
+        fields = FetchRequest.model_fields
+        assert "selector" in fields
+        assert "start_index" in fields
+        assert "max_length" in fields
+        assert "respect_robots_txt" in fields
+
+
+# 标记：本模块所有 async test 默认走 pytest-asyncio auto 模式
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")

--- a/tests/test_web/test_new_web_tools.py
+++ b/tests/test_web/test_new_web_tools.py
@@ -2,6 +2,7 @@
 
 覆盖 link extraction、sitemap parsing、CSS selector fetch 的核心逻辑。
 """
+
 from __future__ import annotations
 
 from unittest.mock import patch
@@ -13,22 +14,26 @@ import pytest
 # Link Extraction Tests
 # ---------------------------------------------------------------------------
 
+
 class TestLinkModels:
     """LinkItem / LinkExtractionResult 模型测试"""
 
     def test_link_item_basic(self):
         from souwen.web.links import LinkItem
+
         item = LinkItem(url="https://example.com", text="Example")
         assert item.url == "https://example.com"
         assert item.text == "Example"
 
     def test_link_item_empty_text(self):
         from souwen.web.links import LinkItem
+
         item = LinkItem(url="https://example.com")
         assert item.text == ""
 
     def test_link_extraction_result_basic(self):
         from souwen.web.links import LinkExtractionResult, LinkItem
+
         result = LinkExtractionResult(
             source_url="https://example.com",
             final_url="https://example.com",
@@ -43,6 +48,7 @@ class TestLinkModels:
 
     def test_link_extraction_result_error(self):
         from souwen.web.links import LinkExtractionResult
+
         result = LinkExtractionResult(
             source_url="https://example.com",
             error="SSRF blocked",
@@ -121,8 +127,10 @@ class TestExtractLinks:
             <a href="https://example.com/a">Dup</a>
         </body></html>
         """
-        with patch("souwen.web.fetch.validate_fetch_url", return_value=(True, "ok")), \
-             _patch_scraper(html, "https://example.com/"):
+        with (
+            patch("souwen.web.fetch.validate_fetch_url", return_value=(True, "ok")),
+            _patch_scraper(html, "https://example.com/"),
+        ):
             result = await extract_links("https://example.com/")
 
         assert result.error is None
@@ -145,8 +153,10 @@ class TestExtractLinks:
         <html><head><base href="https://other.example.org/path/"></head>
         <body><a href="page.html">P</a></body></html>
         """
-        with patch("souwen.web.fetch.validate_fetch_url", return_value=(True, "ok")), \
-             _patch_scraper(html, "https://example.com/"):
+        with (
+            patch("souwen.web.fetch.validate_fetch_url", return_value=(True, "ok")),
+            _patch_scraper(html, "https://example.com/"),
+        ):
             result = await extract_links("https://example.com/")
 
         assert result.error is None
@@ -163,8 +173,10 @@ class TestExtractLinks:
             <a href="https://other.com/drop">d</a>
         </body></html>
         """
-        with patch("souwen.web.fetch.validate_fetch_url", return_value=(True, "ok")), \
-             _patch_scraper(html, "https://example.com/"):
+        with (
+            patch("souwen.web.fetch.validate_fetch_url", return_value=(True, "ok")),
+            _patch_scraper(html, "https://example.com/"),
+        ):
             result = await extract_links(
                 "https://example.com/",
                 base_url_filter="https://example.com/",
@@ -178,12 +190,12 @@ class TestExtractLinks:
         """limit 应截断返回数量"""
         from souwen.web.links import extract_links
 
-        anchors = "".join(
-            f'<a href="https://example.com/p{i}">p{i}</a>' for i in range(20)
-        )
+        anchors = "".join(f'<a href="https://example.com/p{i}">p{i}</a>' for i in range(20))
         html = f"<html><body>{anchors}</body></html>"
-        with patch("souwen.web.fetch.validate_fetch_url", return_value=(True, "ok")), \
-             _patch_scraper(html, "https://example.com/"):
+        with (
+            patch("souwen.web.fetch.validate_fetch_url", return_value=(True, "ok")),
+            _patch_scraper(html, "https://example.com/"),
+        ):
             result = await extract_links("https://example.com/", limit=5)
 
         assert result.total == 5
@@ -206,8 +218,10 @@ class TestExtractLinks:
                 return (False, "private IP")
             return (True, "ok")
 
-        with patch("souwen.web.fetch.validate_fetch_url", side_effect=_fake_validate), \
-             _patch_scraper(html, "https://example.com/"):
+        with (
+            patch("souwen.web.fetch.validate_fetch_url", side_effect=_fake_validate),
+            _patch_scraper(html, "https://example.com/"),
+        ):
             result = await extract_links("https://example.com/")
 
         urls = [link.url for link in result.links]
@@ -220,11 +234,13 @@ class TestExtractLinks:
 # Sitemap Parsing Tests
 # ---------------------------------------------------------------------------
 
+
 class TestSitemapParsing:
     """Sitemap XML 解析测试"""
 
     def test_parse_urlset(self):
         from souwen.web.sitemap import _parse_sitemap_xml
+
         xml = b"""<?xml version="1.0" encoding="UTF-8"?>
         <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
             <url>
@@ -249,6 +265,7 @@ class TestSitemapParsing:
 
     def test_parse_sitemapindex(self):
         from souwen.web.sitemap import _parse_sitemap_xml
+
         xml = b"""<?xml version="1.0" encoding="UTF-8"?>
         <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
             <sitemap>
@@ -267,6 +284,7 @@ class TestSitemapParsing:
     def test_parse_no_namespace(self):
         """Without xmlns namespace"""
         from souwen.web.sitemap import _parse_sitemap_xml
+
         xml = b"""<?xml version="1.0"?>
         <urlset>
             <url><loc>https://example.com/</loc></url>
@@ -278,6 +296,7 @@ class TestSitemapParsing:
 
     def test_safe_float(self):
         from souwen.web.sitemap import _safe_float
+
         assert _safe_float("0.8") == 0.8
         assert _safe_float("1.0") == 1.0
         assert _safe_float(" 0.5 ") == 0.5
@@ -287,6 +306,7 @@ class TestSitemapParsing:
 
     def test_extract_sitemaps_from_robots(self):
         from souwen.web.sitemap import _extract_sitemaps_from_robots
+
         robots = """User-agent: *
 Disallow: /admin/
 Sitemap: https://example.com/sitemap.xml
@@ -299,6 +319,7 @@ Sitemap: https://example.com/sitemap-news.xml
 
     def test_extract_sitemaps_from_robots_empty(self):
         from souwen.web.sitemap import _extract_sitemaps_from_robots
+
         robots = """User-agent: *
 Disallow: /
 """
@@ -307,16 +328,15 @@ Disallow: /
 
     def test_extract_sitemaps_case_insensitive(self):
         from souwen.web.sitemap import _extract_sitemaps_from_robots
-        robots = (
-            "SITEMAP: https://example.com/sitemap.xml\n"
-            "sitemap: https://example.com/other.xml"
-        )
+
+        robots = "SITEMAP: https://example.com/sitemap.xml\nsitemap: https://example.com/other.xml"
         result = _extract_sitemaps_from_robots(robots, "https://example.com")
         assert len(result) == 2
 
     def test_extract_sitemaps_relative_resolved(self):
         """robots.txt 中的相对 sitemap 路径应通过 base_url 解析为绝对地址"""
         from souwen.web.sitemap import _extract_sitemaps_from_robots
+
         robots = "Sitemap: /sitemap.xml"
         result = _extract_sitemaps_from_robots(robots, "https://example.com")
         assert len(result) == 1
@@ -328,6 +348,7 @@ class TestSitemapModels:
 
     def test_sitemap_entry(self):
         from souwen.web.sitemap import SitemapEntry
+
         entry = SitemapEntry(
             loc="https://example.com/page",
             lastmod="2024-06-01",
@@ -340,6 +361,7 @@ class TestSitemapModels:
 
     def test_sitemap_entry_minimal(self):
         from souwen.web.sitemap import SitemapEntry
+
         entry = SitemapEntry(loc="https://example.com/")
         assert entry.loc == "https://example.com/"
         assert entry.lastmod is None
@@ -348,6 +370,7 @@ class TestSitemapModels:
 
     def test_sitemap_result_defaults(self):
         from souwen.web.sitemap import SitemapResult
+
         result = SitemapResult(root_url="https://example.com")
         assert result.root_url == "https://example.com"
         assert result.total == 0
@@ -360,6 +383,7 @@ class TestSitemapModels:
 # CSS Selector + Fetch Params Tests
 # ---------------------------------------------------------------------------
 
+
 class TestFetchParams:
     """fetch 参数签名测试"""
 
@@ -367,6 +391,7 @@ class TestFetchParams:
         """BuiltinFetcherClient.fetch() 应接受 selector / 分页 / robots 参数"""
         import inspect
         from souwen.web.builtin import BuiltinFetcherClient
+
         sig = inspect.signature(BuiltinFetcherClient.fetch)
         params = list(sig.parameters.keys())
         assert "selector" in params
@@ -378,6 +403,7 @@ class TestFetchParams:
         """fetch_content() 应接受 selector / 分页 / robots 参数"""
         import inspect
         from souwen.web.fetch import fetch_content
+
         sig = inspect.signature(fetch_content)
         params = list(sig.parameters.keys())
         assert "selector" in params
@@ -388,6 +414,7 @@ class TestFetchParams:
     def test_fetch_request_schema_has_new_fields(self):
         """FetchRequest model 应包含 selector / start_index / max_length / respect_robots_txt"""
         from souwen.server.schemas import FetchRequest
+
         fields = FetchRequest.model_fields
         assert "selector" in fields
         assert "start_index" in fields


### PR DESCRIPTION
## 概述

对比 [mcp-server-webscan](https://github.com/bsmi021/mcp-server-webscan)（TypeScript，6 工具）和 [academic-search-mcp-server](https://github.com/afrise/academic-search-mcp-server)（Python，2 源）后，为 SouWen Web 抓取层补全缺失能力。

### 对比结论

| 项目 | 价值 | 行动 |
|------|------|------|
| **mcp-server-webscan** | 链接提取、sitemap 生成、CSS 选择器抓取 | 参考实现，用 SouWen 架构重写 |
| **academic-search-mcp-server** | Semantic Scholar + Crossref（仅 2 源） | SouWen 已全覆盖，无需移植 |

## 新增模块

### 1. 链接提取 `src/souwen/web/links.py`
从网页提取所有 `<a href>` 链接，返回结构化列表。
- SSRF 过滤（不返回内部 IP 链接）
- `<base href>` 标签支持
- URL 去重、前缀过滤、数量限制
- **REST**: `GET /api/v1/links?url=...`
- **CLI**: `souwen links <url>`
- **MCP**: `extract_links`

### 2. Sitemap 解析 `src/souwen/web/sitemap.py`
解析网站 sitemap.xml，用于爬虫 seed 或站点审计。
- 标准 `<urlset>` / `<sitemapindex>` 支持
- gzip 压缩、defusedxml 安全解析
- BFS 递归（深度限制 3 层）
- 从 robots.txt 自动发现 sitemap
- **REST**: `GET /api/v1/sitemap?url=...&discover=true`
- **CLI**: `souwen sitemap <url> --discover`
- **MCP**: `parse_sitemap`

### 3. CSS 选择器抓取（增强 builtin fetcher）
`fetch()` 新增 `selector` 参数，用 BS4 + html2text 提取匹配元素。
- 选择器无匹配时回退 trafilatura 全页提取
- bs4/lxml 未安装时优雅降级
- 通过 REST/CLI/MCP 完整暴露

### 4. Fetch 参数暴露（MCP/REST/CLI）
`fetch_content` 工具新增 4 个参数：
- `selector`: CSS 选择器
- `start_index`: 分页续读起始位置
- `max_length`: 内容最大长度
- `respect_robots_txt`: 遵守 robots.txt

## 经 Rubber-Duck 审核排除

| 功能 | 排除原因 |
|------|----------|
| 链接健康检查 | SSRF 放大风险 + HEAD 不可靠，需独立 PR |
| 多提供者回退 | fetch.py 单提供者设计是有意为之 |
| Sitemap 生成 | 低价值用例，用 sitemap 解析替代 |
| Semantic Scholar tldr | SouWen 已支持 |

## 测试

- 24 个新测试覆盖链接提取、sitemap 解析、CSS 选择器
- 全部 **698 测试通过**，ruff lint 无警告

## 变更统计

```
9 files changed, 1236 insertions(+), 8 deletions(-)
新增: links.py, sitemap.py, test_new_web_tools.py
修改: builtin.py, fetch.py, routes.py, schemas.py, mcp_server.py, cli.py
```
