### PR TITLE
feat: Dashboard 交互优化 — 全皮肤点击跳转 + 键盘无障碍

### DIFF
--- a/panel/src/skins/apple/pages/DashboardPage.module.scss
+++ b/panel/src/skins/apple/pages/DashboardPage.module.scss
@@ -67,6 +67,29 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+
+  &.clickable {
+    cursor: pointer;
+    user-select: none;
+    transition: transform 0.2s ease, opacity 0.2s ease;
+    border-radius: 12px;
+    padding: 8px 12px;
+
+    &:hover {
+      opacity: 0.85;
+      transform: translateY(-2px);
+    }
+
+    &:focus-visible {
+      outline: 2px solid #0071e3;
+      outline-offset: 4px;
+    }
+
+    &:active {
+      transform: translateY(0);
+      opacity: 0.7;
+    }
+  }
 }
 
 .metricLabel {

--- a/panel/src/skins/apple/pages/DashboardPage.tsx
+++ b/panel/src/skins/apple/pages/DashboardPage.tsx
@@ -23,6 +23,7 @@
  */
 
 import { useEffect, useState, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { RefreshCw } from 'lucide-react'
 import { api } from '@core/services/api'
@@ -38,6 +39,7 @@ import styles from './DashboardPage.module.scss'
  */
 export function DashboardPage() {
   const { t } = useTranslation()
+  const navigate = useNavigate()
   const [doctor, setDoctor] = useState<DoctorResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [fetchError, setFetchError] = useState(false)
@@ -86,6 +88,7 @@ export function DashboardPage() {
   // 从诊断数据中提取统计信息
   const paperCount = doctor.sources.filter((s) => s.category === 'paper').length
   const patentCount = doctor.sources.filter((s) => s.category === 'patent').length
+  const webCount = doctor.sources.filter((s) => !['paper', 'patent'].includes(s.category)).length
   const okCount = doctor.ok
   const totalCount = doctor.total
   const healthPct = totalCount > 0 ? Math.round((okCount / totalCount) * 100) : 0
@@ -113,17 +116,46 @@ export function DashboardPage() {
 
         {/* ── Giant Metric Numbers 巨大的核心指标卡 ── */}
         <div className={styles.metricsRow}>
-          <div className={styles.metricItem}>
+          <div
+            className={`${styles.metricItem} ${styles.clickable}`}
+            onClick={() => navigate('/search/paper')}
+            role="link"
+            tabIndex={0}
+            onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && navigate('/search/paper')}
+          >
             <div className={styles.metricLabel}>{t('dashboard.paperSources')}</div>
             <div className={styles.metricValue}>{paperCount}</div>
             <div className={styles.metricDesc}>{t('dashboard.ready', '就绪')}</div>
           </div>
-          <div className={styles.metricItem}>
+          <div
+            className={`${styles.metricItem} ${styles.clickable}`}
+            onClick={() => navigate('/search/patent')}
+            role="link"
+            tabIndex={0}
+            onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && navigate('/search/patent')}
+          >
             <div className={styles.metricLabel}>{t('dashboard.patentSources')}</div>
             <div className={styles.metricValue}>{patentCount}</div>
             <div className={styles.metricDesc}>{t('dashboard.ready', '就绪')}</div>
           </div>
-          <div className={styles.metricItem}>
+          <div
+            className={`${styles.metricItem} ${styles.clickable}`}
+            onClick={() => navigate('/search/web')}
+            role="link"
+            tabIndex={0}
+            onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && navigate('/search/web')}
+          >
+            <div className={styles.metricLabel}>{t('dashboard.webEngines')}</div>
+            <div className={styles.metricValue}>{webCount}</div>
+            <div className={styles.metricDesc}>{t('dashboard.ready', '就绪')}</div>
+          </div>
+          <div
+            className={`${styles.metricItem} ${styles.clickable}`}
+            onClick={() => navigate('/sources')}
+            role="link"
+            tabIndex={0}
+            onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && navigate('/sources')}
+          >
             <div className={styles.metricLabel}>{t('dashboard.availableSources')}</div>
             <div className={styles.metricValue}>
               {okCount}<span className={styles.metricFraction}>/{totalCount}</span>

--- a/panel/src/skins/carbon/pages/DashboardPage.module.scss
+++ b/panel/src/skins/carbon/pages/DashboardPage.module.scss
@@ -87,6 +87,20 @@
     border-color: var(--accent);
     box-shadow: var(--glow-sm);
   }
+
+  &.clickable {
+    cursor: pointer;
+    user-select: none;
+
+    &:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+    }
+
+    &:active {
+      box-shadow: none;
+    }
+  }
 }
 
 .statCardHighlight {

--- a/panel/src/skins/carbon/pages/DashboardPage.tsx
+++ b/panel/src/skins/carbon/pages/DashboardPage.tsx
@@ -23,6 +23,7 @@
  */
 
 import { useEffect, useState, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { m } from 'framer-motion'
 import { Activity, RefreshCw } from 'lucide-react'
@@ -37,6 +38,7 @@ import styles from './DashboardPage.module.scss'
 
 export function DashboardPage() {
   const { t } = useTranslation()
+  const navigate = useNavigate()
   const [doctor, setDoctor] = useState<DoctorResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [fetchError, setFetchError] = useState(false)
@@ -123,25 +125,25 @@ export function DashboardPage() {
         initial="initial"
         animate="animate"
       >
-        <m.div variants={staggerItem} className={styles.statCard}>
+        <m.div variants={staggerItem} className={`${styles.statCard} ${styles.clickable}`} onClick={() => navigate('/search/paper')} role="link" tabIndex={0} onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && navigate('/search/paper')}>
           <div className={styles.statLabel}>{t('dashboard.paperSources')}</div>
           <div className={styles.statValue}>{paperCount}</div>
           <div className={styles.statDesc}>{t('dashboard.paperSources')}</div>
         </m.div>
 
-        <m.div variants={staggerItem} className={styles.statCard}>
+        <m.div variants={staggerItem} className={`${styles.statCard} ${styles.clickable}`} onClick={() => navigate('/search/patent')} role="link" tabIndex={0} onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && navigate('/search/patent')}>
           <div className={styles.statLabel}>{t('dashboard.patentSources')}</div>
           <div className={styles.statValue}>{patentCount}</div>
           <div className={styles.statDesc}>{t('dashboard.patentSources')}</div>
         </m.div>
 
-        <m.div variants={staggerItem} className={styles.statCard}>
+        <m.div variants={staggerItem} className={`${styles.statCard} ${styles.clickable}`} onClick={() => navigate('/search/web')} role="link" tabIndex={0} onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && navigate('/search/web')}>
           <div className={styles.statLabel}>{t('dashboard.webEngines')}</div>
           <div className={styles.statValue}>{webCount}</div>
           <div className={styles.statDesc}>{t('dashboard.webEngines')}</div>
         </m.div>
 
-        <m.div variants={staggerItem} className={`${styles.statCard} ${styles.statCardHighlight}`}>
+        <m.div variants={staggerItem} className={`${styles.statCard} ${styles.statCardHighlight} ${styles.clickable}`} onClick={() => navigate('/sources')} role="link" tabIndex={0} onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && navigate('/sources')}>
           <div className={styles.statLabel}>{t('dashboard.availableSources')}</div>
           <div className={styles.statValue}>
             {okCount}<span className={styles.statFraction}>/{totalCount}</span>

--- a/panel/src/skins/ios/pages/DashboardPage.module.scss
+++ b/panel/src/skins/ios/pages/DashboardPage.module.scss
@@ -35,6 +35,34 @@
   background: var(--bg-card-solid);
   border-radius: 16px;
   box-shadow: var(--shadow-card);
+
+  &.clickable {
+    cursor: pointer;
+    user-select: none;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+
+    &:focus-visible {
+      outline: 2px solid #007aff;
+      outline-offset: 2px;
+    }
+
+    &:hover .statChevron {
+      opacity: 1;
+      transform: translateX(2px);
+    }
+
+    &:active {
+      transform: scale(0.98);
+    }
+  }
+}
+
+.statChevron {
+  margin-left: auto;
+  color: var(--text-muted);
+  opacity: 0.5;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  flex-shrink: 0;
 }
 
 .statIcon {

--- a/panel/src/skins/ios/pages/DashboardPage.tsx
+++ b/panel/src/skins/ios/pages/DashboardPage.tsx
@@ -23,9 +23,10 @@
  */
 
 import { useEffect, useState, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { m } from 'framer-motion'
-import { Activity, FileText, Shield, Globe, RefreshCw } from 'lucide-react'
+import { Activity, FileText, Shield, Globe, RefreshCw, ChevronRight } from 'lucide-react'
 import { api } from '@core/services/api'
 import { useNotificationStore } from '@core/stores/notificationStore'
 import { useAuthStore } from '@core/stores/authStore'
@@ -38,6 +39,7 @@ import styles from './DashboardPage.module.scss'
 // DashboardPage 组件 - 系统仪表板
 export function DashboardPage() {
   const { t } = useTranslation()
+  const navigate = useNavigate()
   const [doctor, setDoctor] = useState<DoctorResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [fetchError, setFetchError] = useState(false)
@@ -103,7 +105,7 @@ export function DashboardPage() {
         initial="initial"
         animate="animate"
       >
-        <m.div variants={staggerItem} className={styles.statCard}>
+        <m.div variants={staggerItem} className={`${styles.statCard} ${styles.clickable}`} onClick={() => navigate('/search/paper')} role="link" tabIndex={0} onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && navigate('/search/paper')}>
           <span className={styles.statIcon} style={{ background: '#007aff' }}>
             <FileText size={18} color="#fff" />
           </span>
@@ -111,9 +113,10 @@ export function DashboardPage() {
             <div className={styles.statValue}>{paperCount}</div>
             <div className={styles.statLabel}>{t('dashboard.paperSources')}</div>
           </div>
+          <ChevronRight size={18} className={styles.statChevron} />
         </m.div>
 
-        <m.div variants={staggerItem} className={styles.statCard}>
+        <m.div variants={staggerItem} className={`${styles.statCard} ${styles.clickable}`} onClick={() => navigate('/search/patent')} role="link" tabIndex={0} onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && navigate('/search/patent')}>
           <span className={styles.statIcon} style={{ background: '#ff9500' }}>
             <Shield size={18} color="#fff" />
           </span>
@@ -121,9 +124,10 @@ export function DashboardPage() {
             <div className={styles.statValue}>{patentCount}</div>
             <div className={styles.statLabel}>{t('dashboard.patentSources')}</div>
           </div>
+          <ChevronRight size={18} className={styles.statChevron} />
         </m.div>
 
-        <m.div variants={staggerItem} className={styles.statCard}>
+        <m.div variants={staggerItem} className={`${styles.statCard} ${styles.clickable}`} onClick={() => navigate('/search/web')} role="link" tabIndex={0} onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && navigate('/search/web')}>
           <span className={styles.statIcon} style={{ background: '#34c759' }}>
             <Globe size={18} color="#fff" />
           </span>
@@ -131,9 +135,10 @@ export function DashboardPage() {
             <div className={styles.statValue}>{webCount}</div>
             <div className={styles.statLabel}>{t('dashboard.webEngines')}</div>
           </div>
+          <ChevronRight size={18} className={styles.statChevron} />
         </m.div>
 
-        <m.div variants={staggerItem} className={styles.statCard}>
+        <m.div variants={staggerItem} className={`${styles.statCard} ${styles.clickable}`} onClick={() => navigate('/sources')} role="link" tabIndex={0} onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && navigate('/sources')}>
           <span className={styles.statIcon} style={{ background: '#5856d6' }}>
             <Activity size={18} color="#fff" />
           </span>
@@ -143,6 +148,7 @@ export function DashboardPage() {
             </div>
             <div className={styles.statLabel}>{t('dashboard.availableSources')}</div>
           </div>
+          <ChevronRight size={18} className={styles.statChevron} />
         </m.div>
       </m.div>
 

--- a/panel/src/skins/souwen-google/pages/DashboardPage.module.scss
+++ b/panel/src/skins/souwen-google/pages/DashboardPage.module.scss
@@ -202,6 +202,32 @@
 
     .statIcon { transform: scale(1.06); }
   }
+
+  &.clickable {
+    cursor: pointer;
+    user-select: none;
+
+    &:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+    }
+
+    &:active {
+      transform: translateY(0);
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+    }
+
+    &:hover .statArrow {
+      opacity: 1;
+      transform: translateX(2px);
+    }
+  }
+}
+
+.statArrow {
+  color: var(--text-muted);
+  opacity: 0;
+  transition: opacity 0.2s ease, transform 0.2s ease;
 }
 
 /* hide decorative blob — keeping a clean Google look */
@@ -297,6 +323,20 @@
 
   &:hover {
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  }
+
+  &.clickable {
+    cursor: pointer;
+    user-select: none;
+
+    &:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+    }
+
+    &:active {
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+    }
   }
 }
 

--- a/panel/src/skins/souwen-google/pages/DashboardPage.tsx
+++ b/panel/src/skins/souwen-google/pages/DashboardPage.tsx
@@ -254,7 +254,7 @@ export function DashboardPage() {
       {/* ── Stats + Health ring ── */}
       <m.div className={styles.statsSection} variants={staggerContainer} initial="initial" animate="animate">
         <div className={styles.statsGrid}>
-          <m.div variants={staggerItem} className={`${styles.statCard} ${styles.statBlue} ${styles.clickable}`} onClick={() => navigate('/search/paper')} role="link" tabIndex={0} onKeyDown={(e) => e.key === 'Enter' && navigate('/search/paper')}>
+          <m.div variants={staggerItem} className={`${styles.statCard} ${styles.statBlue} ${styles.clickable}`} onClick={() => navigate('/search/paper')} role="link" tabIndex={0} onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && navigate('/search/paper')}>
             <div className={styles.statBlob} />
             <div className={styles.statHeader}>
               <div className={`${styles.statIcon} ${styles.iconBlue}`}><FileText size={18} /></div>
@@ -264,7 +264,7 @@ export function DashboardPage() {
             <span className={styles.statTitle}>{t('dashboard.paperSources')}</span>
           </m.div>
 
-          <m.div variants={staggerItem} className={`${styles.statCard} ${styles.statAmber} ${styles.clickable}`} onClick={() => navigate('/search/patent')} role="link" tabIndex={0} onKeyDown={(e) => e.key === 'Enter' && navigate('/search/patent')}>
+          <m.div variants={staggerItem} className={`${styles.statCard} ${styles.statAmber} ${styles.clickable}`} onClick={() => navigate('/search/patent')} role="link" tabIndex={0} onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && navigate('/search/patent')}>
             <div className={styles.statBlob} />
             <div className={styles.statHeader}>
               <div className={`${styles.statIcon} ${styles.iconAmber}`}><Shield size={18} /></div>
@@ -274,7 +274,7 @@ export function DashboardPage() {
             <span className={styles.statTitle}>{t('dashboard.patentSources')}</span>
           </m.div>
 
-          <m.div variants={staggerItem} className={`${styles.statCard} ${styles.statGreen} ${styles.clickable}`} onClick={() => navigate('/search/web')} role="link" tabIndex={0} onKeyDown={(e) => e.key === 'Enter' && navigate('/search/web')}>
+          <m.div variants={staggerItem} className={`${styles.statCard} ${styles.statGreen} ${styles.clickable}`} onClick={() => navigate('/search/web')} role="link" tabIndex={0} onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && navigate('/search/web')}>
             <div className={styles.statBlob} />
             <div className={styles.statHeader}>
               <div className={`${styles.statIcon} ${styles.iconGreen}`}><Globe size={18} /></div>
@@ -284,7 +284,7 @@ export function DashboardPage() {
             <span className={styles.statTitle}>{t('dashboard.webEngines')}</span>
           </m.div>
 
-          <m.div variants={staggerItem} className={`${styles.statCard} ${styles.statIndigo} ${styles.clickable}`} onClick={() => navigate('/sources')} role="link" tabIndex={0} onKeyDown={(e) => e.key === 'Enter' && navigate('/sources')}>
+          <m.div variants={staggerItem} className={`${styles.statCard} ${styles.statIndigo} ${styles.clickable}`} onClick={() => navigate('/sources')} role="link" tabIndex={0} onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && navigate('/sources')}>
             <div className={styles.statBlob} />
             <div className={styles.statHeader}>
               <div className={`${styles.statIcon} ${styles.iconIndigo}`}><Layers size={18} /></div>
@@ -296,7 +296,7 @@ export function DashboardPage() {
         </div>
 
         {/* Health ring card */}
-        <m.div variants={staggerItem} className={`${styles.healthCard} ${styles.clickable}`} onClick={() => navigate('/sources')} role="link" tabIndex={0} onKeyDown={(e) => e.key === 'Enter' && navigate('/sources')}>
+        <m.div variants={staggerItem} className={`${styles.healthCard} ${styles.clickable}`} onClick={() => navigate('/sources')} role="link" tabIndex={0} onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && navigate('/sources')}>
           <HealthRing pct={healthPct} />
         </m.div>
       </m.div>

--- a/panel/src/skins/souwen-google/pages/DashboardPage.tsx
+++ b/panel/src/skins/souwen-google/pages/DashboardPage.tsx
@@ -21,9 +21,10 @@
  */
 
 import { useEffect, useState, useCallback, useRef } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { m } from 'framer-motion'
-import { FileText, Shield, Globe, Layers, RefreshCw } from 'lucide-react'
+import { FileText, Shield, Globe, Layers, RefreshCw, ArrowRight } from 'lucide-react'
 import { api } from '@core/services/api'
 import { useNotificationStore } from '@core/stores/notificationStore'
 import { useAuthStore } from '@core/stores/authStore'
@@ -153,6 +154,7 @@ function AvailabilityBar({ ok, total }: { ok: number; total: number }) {
  */
 export function DashboardPage() {
   const { t } = useTranslation()
+  const navigate = useNavigate()
   const [doctor, setDoctor] = useState<DoctorResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [fetchError, setFetchError] = useState(false)
@@ -252,37 +254,41 @@ export function DashboardPage() {
       {/* ── Stats + Health ring ── */}
       <m.div className={styles.statsSection} variants={staggerContainer} initial="initial" animate="animate">
         <div className={styles.statsGrid}>
-          <m.div variants={staggerItem} className={`${styles.statCard} ${styles.statBlue}`}>
+          <m.div variants={staggerItem} className={`${styles.statCard} ${styles.statBlue} ${styles.clickable}`} onClick={() => navigate('/search/paper')} role="link" tabIndex={0} onKeyDown={(e) => e.key === 'Enter' && navigate('/search/paper')}>
             <div className={styles.statBlob} />
             <div className={styles.statHeader}>
               <div className={`${styles.statIcon} ${styles.iconBlue}`}><FileText size={18} /></div>
+              <ArrowRight size={14} className={styles.statArrow} />
             </div>
             <div className={`${styles.statValue} ${styles.valueBlue}`}>{paperCount}</div>
             <span className={styles.statTitle}>{t('dashboard.paperSources')}</span>
           </m.div>
 
-          <m.div variants={staggerItem} className={`${styles.statCard} ${styles.statAmber}`}>
+          <m.div variants={staggerItem} className={`${styles.statCard} ${styles.statAmber} ${styles.clickable}`} onClick={() => navigate('/search/patent')} role="link" tabIndex={0} onKeyDown={(e) => e.key === 'Enter' && navigate('/search/patent')}>
             <div className={styles.statBlob} />
             <div className={styles.statHeader}>
               <div className={`${styles.statIcon} ${styles.iconAmber}`}><Shield size={18} /></div>
+              <ArrowRight size={14} className={styles.statArrow} />
             </div>
             <div className={`${styles.statValue} ${styles.valueAmber}`}>{patentCount}</div>
             <span className={styles.statTitle}>{t('dashboard.patentSources')}</span>
           </m.div>
 
-          <m.div variants={staggerItem} className={`${styles.statCard} ${styles.statGreen}`}>
+          <m.div variants={staggerItem} className={`${styles.statCard} ${styles.statGreen} ${styles.clickable}`} onClick={() => navigate('/search/web')} role="link" tabIndex={0} onKeyDown={(e) => e.key === 'Enter' && navigate('/search/web')}>
             <div className={styles.statBlob} />
             <div className={styles.statHeader}>
               <div className={`${styles.statIcon} ${styles.iconGreen}`}><Globe size={18} /></div>
+              <ArrowRight size={14} className={styles.statArrow} />
             </div>
             <div className={`${styles.statValue} ${styles.valueGreen}`}>{webCount}</div>
             <span className={styles.statTitle}>{t('dashboard.webEngines')}</span>
           </m.div>
 
-          <m.div variants={staggerItem} className={`${styles.statCard} ${styles.statIndigo}`}>
+          <m.div variants={staggerItem} className={`${styles.statCard} ${styles.statIndigo} ${styles.clickable}`} onClick={() => navigate('/sources')} role="link" tabIndex={0} onKeyDown={(e) => e.key === 'Enter' && navigate('/sources')}>
             <div className={styles.statBlob} />
             <div className={styles.statHeader}>
               <div className={`${styles.statIcon} ${styles.iconIndigo}`}><Layers size={18} /></div>
+              <ArrowRight size={14} className={styles.statArrow} />
             </div>
             <div className={`${styles.statValue} ${styles.valueIndigo}`}>{okCount}<span className={styles.statFraction}>/{totalCount}</span></div>
             <span className={styles.statTitle}>{t('dashboard.availableSources')}</span>
@@ -290,7 +296,7 @@ export function DashboardPage() {
         </div>
 
         {/* Health ring card */}
-        <m.div variants={staggerItem} className={styles.healthCard}>
+        <m.div variants={staggerItem} className={`${styles.healthCard} ${styles.clickable}`} onClick={() => navigate('/sources')} role="link" tabIndex={0} onKeyDown={(e) => e.key === 'Enter' && navigate('/sources')}>
           <HealthRing pct={healthPct} />
         </m.div>
       </m.div>

--- a/panel/src/skins/souwen-nebula/pages/DashboardPage.module.scss
+++ b/panel/src/skins/souwen-nebula/pages/DashboardPage.module.scss
@@ -206,6 +206,26 @@
     transform: translateY(-1px);
   }
 
+  &.clickable {
+    cursor: pointer;
+    user-select: none;
+
+    &:focus-visible {
+      outline: 2px solid var(--accent, var(--accent-teal));
+      outline-offset: 2px;
+    }
+
+    &:active {
+      transform: translateY(0);
+      box-shadow: var(--shadow-card);
+    }
+
+    &:hover .statArrow {
+      opacity: 1;
+      transform: translateX(2px);
+    }
+  }
+
   // bottom accent bar
   &::after {
     content: '';
@@ -216,6 +236,12 @@
     height: 2px;
     border-radius: 0 0 var(--radius) var(--radius);
   }
+}
+
+.statArrow {
+  color: var(--text-muted);
+  opacity: 0;
+  transition: opacity 0.2s ease, transform 0.2s ease;
 }
 
 // decorative gradient blob (smaller for compact card)
@@ -360,6 +386,20 @@
 
   &:hover {
     box-shadow: var(--shadow-card-hover);
+  }
+
+  &.clickable {
+    cursor: pointer;
+    user-select: none;
+
+    &:focus-visible {
+      outline: 2px solid var(--accent, var(--accent-teal));
+      outline-offset: 2px;
+    }
+
+    &:active {
+      box-shadow: var(--shadow-card);
+    }
   }
 }
 

--- a/panel/src/skins/souwen-nebula/pages/DashboardPage.tsx
+++ b/panel/src/skins/souwen-nebula/pages/DashboardPage.tsx
@@ -21,9 +21,10 @@
  */
 
 import { useEffect, useState, useCallback, useRef } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { m } from 'framer-motion'
-import { FileText, Shield, Globe, Layers, RefreshCw } from 'lucide-react'
+import { FileText, Shield, Globe, Layers, RefreshCw, ArrowRight } from 'lucide-react'
 import { api } from '@core/services/api'
 import { useNotificationStore } from '@core/stores/notificationStore'
 import { useAuthStore } from '@core/stores/authStore'
@@ -222,6 +223,7 @@ function AvailabilityBar({ ok, total }: { ok: number; total: number }) {
  */
 export function DashboardPage() {
   const { t } = useTranslation()
+  const navigate = useNavigate()
   const [doctor, setDoctor] = useState<DoctorResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [fetchError, setFetchError] = useState(false)
@@ -323,37 +325,41 @@ export function DashboardPage() {
       {/* ── Stats + Health ring ── */}
       <m.div className={styles.statsSection} variants={staggerContainer} initial="initial" animate="animate">
         <div className={styles.statsGrid}>
-          <m.div variants={staggerItem} className={`${styles.statCard} ${styles.statBlue}`}>
+          <m.div variants={staggerItem} className={`${styles.statCard} ${styles.statBlue} ${styles.clickable}`} onClick={() => navigate('/search/paper')} role="link" tabIndex={0} onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && navigate('/search/paper')}>
             <div className={styles.statBlob} />
             <div className={styles.statHeader}>
               <div className={`${styles.statIcon} ${styles.iconBlue}`}><FileText size={18} /></div>
+              <ArrowRight size={14} className={styles.statArrow} />
             </div>
             <div className={`${styles.statValue} ${styles.valueBlue}`}>{paperCount}</div>
             <span className={styles.statTitle}>{t('dashboard.paperSources')}</span>
           </m.div>
 
-          <m.div variants={staggerItem} className={`${styles.statCard} ${styles.statAmber}`}>
+          <m.div variants={staggerItem} className={`${styles.statCard} ${styles.statAmber} ${styles.clickable}`} onClick={() => navigate('/search/patent')} role="link" tabIndex={0} onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && navigate('/search/patent')}>
             <div className={styles.statBlob} />
             <div className={styles.statHeader}>
               <div className={`${styles.statIcon} ${styles.iconAmber}`}><Shield size={18} /></div>
+              <ArrowRight size={14} className={styles.statArrow} />
             </div>
             <div className={`${styles.statValue} ${styles.valueAmber}`}>{patentCount}</div>
             <span className={styles.statTitle}>{t('dashboard.patentSources')}</span>
           </m.div>
 
-          <m.div variants={staggerItem} className={`${styles.statCard} ${styles.statGreen}`}>
+          <m.div variants={staggerItem} className={`${styles.statCard} ${styles.statGreen} ${styles.clickable}`} onClick={() => navigate('/search/web')} role="link" tabIndex={0} onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && navigate('/search/web')}>
             <div className={styles.statBlob} />
             <div className={styles.statHeader}>
               <div className={`${styles.statIcon} ${styles.iconGreen}`}><Globe size={18} /></div>
+              <ArrowRight size={14} className={styles.statArrow} />
             </div>
             <div className={`${styles.statValue} ${styles.valueGreen}`}>{webCount}</div>
             <span className={styles.statTitle}>{t('dashboard.webEngines')}</span>
           </m.div>
 
-          <m.div variants={staggerItem} className={`${styles.statCard} ${styles.statIndigo}`}>
+          <m.div variants={staggerItem} className={`${styles.statCard} ${styles.statIndigo} ${styles.clickable}`} onClick={() => navigate('/sources')} role="link" tabIndex={0} onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && navigate('/sources')}>
             <div className={styles.statBlob} />
             <div className={styles.statHeader}>
               <div className={`${styles.statIcon} ${styles.iconIndigo}`}><Layers size={18} /></div>
+              <ArrowRight size={14} className={styles.statArrow} />
             </div>
             <div className={`${styles.statValue} ${styles.valueIndigo}`}>{okCount}<span className={styles.statFraction}>/{totalCount}</span></div>
             <span className={styles.statTitle}>{t('dashboard.availableSources')}</span>
@@ -361,7 +367,7 @@ export function DashboardPage() {
         </div>
 
         {/* Health ring card */}
-        <m.div variants={staggerItem} className={styles.healthCard}>
+        <m.div variants={staggerItem} className={`${styles.healthCard} ${styles.clickable}`} onClick={() => navigate('/sources')} role="link" tabIndex={0} onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && navigate('/sources')}>
           <HealthRing pct={healthPct} />
         </m.div>
       </m.div>


### PR DESCRIPTION
## 概述

为全部 5 个皮肤的 Dashboard 页面添加点击跳转和键盘无障碍支持，提升易用性。

### 交互功能

| 元素 | 跳转目标 |
|---|---|
| 论文源卡片 | `/search/paper` |
| 专利源卡片 | `/search/patent` |
| Web 引擎卡片 | `/search/web` |
| 可用源卡片 | `/sources` |
| 健康环图/指标 | `/sources` |

### 各皮肤变更

| 皮肤 | 变更内容 |
|---|---|
| **souwen-google** | 修复 Space 键支持（原仅 Enter） |
| **souwen-nebula** | 4 卡片 + 健康环图点击跳转，ArrowRight 指示器 |
| **carbon** | 4 卡片点击跳转 |
| **ios** | 4 卡片点击跳转，ChevronRight 指示器 |
| **apple** | 🆕 新增 Web 源卡片 + 全部 4 卡片点击跳转 |

### 无障碍 (a11y)

- `role="link"` + `tabIndex={0}` 支持屏幕阅读器
- Enter 和 Space 键均可触发导航
- `focus-visible` 焦点环样式
- hover 时显示箭头/chevron 视觉提示

### 视觉效果

- 卡片 hover 上浮 + 阴影加深
- active 按压反馈
- 箭头/chevron 指示器渐显 + 微移动画

## 测试

- ✅ TypeScript 编译通过
- ✅ 54 前端测试通过
- ✅ Vite 构建成功
