### PR TITLE
fix: CI artifact 版本匹配 + ConfigEditor 状态修复 + 配置写入健壮性

### DIFF
--- a/.github/workflows/build-nuitka.yml
+++ b/.github/workflows/build-nuitka.yml
@@ -229,7 +229,7 @@ jobs:
         run: move dist\${{ env.APP_NAME }}.exe dist\${{ matrix.artifact_name }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact_name }}
           path: dist/${{ matrix.artifact_name }}

--- a/.github/workflows/build-pyinstaller.yml
+++ b/.github/workflows/build-pyinstaller.yml
@@ -138,7 +138,7 @@ jobs:
           echo "✅ panel.html 大小: $(wc -c < src/souwen/server/panel.html) 字节"
 
       - name: Upload panel.html artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: panel-html
           path: src/souwen/server/panel.html
@@ -264,7 +264,7 @@ jobs:
         run: move dist\${{ env.APP_NAME }}.exe dist\${{ matrix.artifact_name }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact_name }}
           path: dist/${{ matrix.artifact_name }}

--- a/panel/src/core/components/ConfigEditor/ConfigEditorPanel.tsx
+++ b/panel/src/core/components/ConfigEditor/ConfigEditorPanel.tsx
@@ -318,7 +318,9 @@ export function ConfigEditorPanel({ className }: Props) {
         // Re-parse source YAML into visual state
         const parsed = parseYamlToFlat(yamlContent)
         setVisualValues(parsed)
-        setVisualDirty(false)
+        // Preserve dirty state: if source has unsaved changes, the visual state
+        // now reflects those unsaved changes too.
+        setVisualDirty(yamlContent !== originalYaml)
       }
       setActiveTab(tab)
     },
@@ -473,7 +475,7 @@ export function ConfigEditorPanel({ className }: Props) {
             </div>
           </div>
           <div className={styles.editorActions}>
-            {visualDirty && (
+            {(visualDirty || sourceDirty) && (
               <span className={styles.unsavedBadge}>
                 <AlertTriangle size={12} />
                 {t('config.unsavedChanges')}
@@ -482,7 +484,7 @@ export function ConfigEditorPanel({ className }: Props) {
             <button
               className={styles.saveBtn}
               onClick={() => void handleSaveVisual()}
-              disabled={saving || !visualDirty}
+              disabled={saving || (!visualDirty && !sourceDirty)}
             >
               <Save size={14} />
               {saving ? t('config.savingYaml') : t('config.saveYaml')}

--- a/src/souwen/server/routes/admin/config.py
+++ b/src/souwen/server/routes/admin/config.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import os
+import tempfile
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException
@@ -105,6 +107,7 @@ async def save_config_yaml(body: YamlConfigSaveRequest):
         # Pydantic 模型校验（dry-run）
         # parsed_dict 是嵌套结构 {paper: {...}, web: {...}, ...}，
         # 而 SouWenConfig 期望扁平字段名，需先扁平化（与 loader._load_yaml_config 一致）
+        unknown_keys: list[str] = []
         try:
             from souwen.config import SouWenConfig
 
@@ -117,8 +120,12 @@ async def save_config_yaml(body: YamlConfigSaveRequest):
                     for k, v in values.items():
                         if k in valid_fields:
                             flat_dict[k] = v
+                        else:
+                            unknown_keys.append(f"{key}.{k}")
                 elif key in valid_fields:
                     flat_dict[key] = values
+                else:
+                    unknown_keys.append(key)
 
             SouWenConfig(**flat_dict)
         except Exception as exc:
@@ -130,20 +137,65 @@ async def save_config_yaml(body: YamlConfigSaveRequest):
             target = Path("~/.config/souwen/config.yaml").expanduser()
             target.parent.mkdir(parents=True, exist_ok=True)
 
+        # 备份旧内容用于回滚
+        backup_content: str | None = None
+        if target.exists():
+            try:
+                backup_content = target.read_text(encoding="utf-8")
+            except OSError as exc:
+                raise HTTPException(status_code=500, detail=f"读取旧配置失败: {exc}")
+
+        # 原子写入：先写临时文件再 rename
         try:
-            target.write_text(body.content, encoding="utf-8")
+            _atomic_write(target, body.content)
         except OSError as exc:
             raise HTTPException(status_code=500, detail=f"写入配置文件失败: {exc}")
 
-        # 重载配置（可能失败）
+        # 重载配置（可能失败 → 回滚）
         from souwen.config import reload_config
 
         try:
             reload_config()
         except Exception as exc:
+            # 回滚到旧内容并重新加载
+            rollback_note = ""
+            try:
+                if backup_content is not None:
+                    _atomic_write(target, backup_content)
+                else:
+                    # 之前不存在配置文件，删除新写入的
+                    try:
+                        target.unlink()
+                    except OSError:
+                        pass
+                reload_config()
+                rollback_note = "，已回滚到上一版本"
+            except Exception as rollback_exc:
+                rollback_note = f"，回滚失败: {rollback_exc}"
             raise HTTPException(
-                status_code=500,
-                detail=f"配置重载失败（文件已写入）: {exc}，请手动检查配置文件或重启服务",
+                status_code=422,
+                detail=f"配置重载失败: {exc}{rollback_note}",
             )
 
-        return YamlConfigResponse(content=body.content, path=str(target))
+        return YamlConfigResponse(
+            content=body.content,
+            path=str(target),
+            unknown_keys=unknown_keys,
+        )
+
+
+def _atomic_write(target: Path, content: str) -> None:
+    """原子写入：写到同目录临时文件后 os.replace。"""
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=str(target.parent), suffix=".tmp")
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, str(target))
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise

--- a/src/souwen/server/schemas/admin.py
+++ b/src/souwen/server/schemas/admin.py
@@ -130,6 +130,10 @@ class YamlConfigResponse(BaseModel):
 
     content: str = Field(..., description="YAML 文件内容")
     path: str | None = Field(None, description="配置文件路径，None 表示返回默认模板")
+    unknown_keys: list[str] = Field(
+        default_factory=list,
+        description="保存时被忽略的未知配置键（typo 或不支持的字段），仅在 PUT 响应中可能非空",
+    )
 
 
 class YamlConfigSaveRequest(BaseModel):


### PR DESCRIPTION
## 问题来源

Post-merge 代码评审发现的 3 类问题，按严重度修复。

## 修复内容

### 🚨 Critical — CI 构建流水线

**upload-artifact@v4 → v7**（匹配 download-artifact@v8）

PR #41 升级了 `download-artifact` 到 v8，但 `upload-artifact` 仍为 v4，两者不兼容。
v8 download 期望 v7+ upload 的新格式，混用会导致 build-pyinstaller 和 build-nuitka 全部失败。

- `.github/workflows/build-nuitka.yml` — 1 处
- `.github/workflows/build-pyinstaller.yml` — 2 处

### 🔴 P1 — 前端 ConfigEditor 状态丢失

**修复 visualDirty 在 Tab 切换时被错误重置**

复现路径：Visual 编辑 → Source tab → Visual tab → Save 按钮变灰（无法保存）

修复：
- `handleTabChange`: 切换到 Visual 时基于 `yamlContent !== originalYaml` 判断 dirty 状态
- Save 按钮: `disabled={saving || (!visualDirty && !sourceDirty)}`
- 未保存标记: `visualDirty || sourceDirty`

### 🟡 P2 — 后端配置写入健壮性

1. **原子写入**: `tempfile.mkstemp` + `os.fsync` + `os.replace`，进程中断不丢配置
2. **reload 失败自动回滚**: 写入前备份旧内容，reload 异常时恢复旧文件并重新 reload
3. **未知 key 警告**: 不再静默丢弃用户拼错的 YAML key，response 中返回 `unknown_keys` 列表

## 验证
- [x] `python3 -m ruff check` — 通过
- [x] `cd panel && npm run build` — 通过 (2417 modules)
- [x] 所有 workflow YAML 语法验证通过
- [x] upload-artifact@v7 / download-artifact@v8 全部配对一致