### PR TITLE
feat(config): 配置保存前自动生成 .bak 持久化备份

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ CLAUDE.md
 check-*.png
 verify-*.png
 local/
+
+# Config backups
+*.yaml.bak

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ local/
 
 # Config backups
 *.yaml.bak
+*.yml.bak

--- a/src/souwen/server/routes/admin/config.py
+++ b/src/souwen/server/routes/admin/config.py
@@ -156,7 +156,7 @@ async def save_config_yaml(body: YamlConfigSaveRequest):
                 # 镜像源文件权限，避免 .bak 权限漂移泄露敏感配置
                 try:
                     src_mode = target.stat().st_mode
-                    os.chmod(bak_path, src_mode & 0o7777)
+                    os.chmod(bak_path, src_mode & 0o777)
                 except OSError:
                     pass
             except OSError as exc:

--- a/src/souwen/server/routes/admin/config.py
+++ b/src/souwen/server/routes/admin/config.py
@@ -145,6 +145,14 @@ async def save_config_yaml(body: YamlConfigSaveRequest):
             except OSError as exc:
                 raise HTTPException(status_code=500, detail=f"读取旧配置失败: {exc}")
 
+        # 持久化 .bak 备份（即使进程崩溃也可手动恢复）
+        if backup_content is not None:
+            bak_path = target.with_suffix(target.suffix + ".bak")
+            try:
+                _atomic_write(bak_path, backup_content)
+            except OSError:
+                pass  # .bak 写入失败不阻塞主流程
+
         # 原子写入：先写临时文件再 rename
         try:
             _atomic_write(target, body.content)

--- a/src/souwen/server/routes/admin/config.py
+++ b/src/souwen/server/routes/admin/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import tempfile
 from pathlib import Path
@@ -11,6 +12,8 @@ from fastapi import APIRouter, HTTPException
 
 from souwen.server.routes._common import _is_secret_field
 from souwen.server.schemas import ConfigReloadResponse, YamlConfigResponse, YamlConfigSaveRequest
+
+log = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -150,8 +153,14 @@ async def save_config_yaml(body: YamlConfigSaveRequest):
             bak_path = target.with_suffix(target.suffix + ".bak")
             try:
                 _atomic_write(bak_path, backup_content)
-            except OSError:
-                pass  # .bak 写入失败不阻塞主流程
+                # 镜像源文件权限，避免 .bak 权限漂移泄露敏感配置
+                try:
+                    src_mode = target.stat().st_mode
+                    os.chmod(bak_path, src_mode & 0o7777)
+                except OSError:
+                    pass
+            except OSError as exc:
+                log.warning("Failed to write config backup %s: %s", bak_path, exc)
 
         # 原子写入：先写临时文件再 rename
         try:


### PR DESCRIPTION
## 概述

每次通过在线编辑器保存配置时，自动将旧配置持久化为 `.bak` 文件，作为进程崩溃或回滚失败时的最后恢复手段。

## 变更

### `src/souwen/server/routes/admin/config.py`
在 `save_config_yaml` 中，原子写入新配置之前，先将 `backup_content` 原子写入 `souwen.yaml.bak`（同目录）：

```python
if backup_content is not None:
    bak_path = target.with_suffix(target.suffix + ".bak")
    try:
        _atomic_write(bak_path, backup_content)
    except OSError:
        pass  # .bak 写入失败不阻塞主流程
```

设计要点：
- **原子写入**：.bak 本身也通过 `_atomic_write`（tempfile + fsync + os.replace）写入，不会出现半截备份
- **静默降级**：.bak 写入失败（磁盘满、权限等）不影响主保存流程
- **单份备份**：只保留最近一次的旧配置，每次保存覆盖（避免 .bak 无限增长）
- **手动恢复**：`cp souwen.yaml.bak souwen.yaml && systemctl restart souwen`

### `.gitignore`
添加 `*.yaml.bak` 避免备份文件误提交。

## 恢复三层防线

| 层级 | 机制 | 覆盖场景 |
|------|------|----------|
| L1 | 内存回滚 | reload_config() 失败 → 自动恢复旧文件并重载 |
| L2 | .bak 持久化 | 进程崩溃 / 回滚失败 → 手动 `cp .bak` 恢复 |
| L3 | 原子写入 | 写入中断 → 文件要么是旧版要么是新版，不会损坏 |

## 验证
- [x] `python3 -m ruff check` — 通过