### PR TITLE
feat: 插件系统 — entry_points 自动发现 + fetch handler 注册表

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,28 +132,37 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
 
-      - name: 安装依赖（含 web2pdf 插件）
+      - name: 安装依赖
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev,web2pdf]"
+          pip install -e ".[dev]"
+
+      - name: 安装 web2pdf 插件（可选，PyPI 上可能尚未发布）
+        run: pip install "superweb2pdf[capture]>=0.2.0" || echo "superweb2pdf not available on PyPI, skipping"
+        continue-on-error: true
 
       - name: 运行插件相关测试
         run: pytest tests/test_plugin.py tests/test_fetch_handlers.py -v --tb=short
 
-      - name: 验证 entry_point 插件发现
+      - name: 安装最小示例插件
+        run: pip install -e examples/minimal-plugin
+
+      - name: 验证 entry_point 插件发现机制
         run: |
           python -c "
           from souwen.plugin import discover_entrypoint_plugins
           loaded, errors = discover_entrypoint_plugins()
-          assert 'superweb2pdf' in loaded, f'superweb2pdf not found in {loaded}'
           assert not errors, f'Plugin errors: {errors}'
-          print(f'Plugin discovery OK: {loaded}')
+          assert 'example_echo' in loaded, f'example_echo (minimal-plugin) not found in {loaded}'
+          if 'superweb2pdf' not in loaded:
+              print(f'WARN: superweb2pdf not installed (optional); loaded plugins: {loaded}')
+          else:
+              print(f'Plugin discovery OK (incl. superweb2pdf): {loaded}')
+          print(f'entry_point mechanism verified via minimal-plugin: {loaded}')
           "
 
-      - name: 安装并测试最小示例插件
-        run: |
-          pip install -e examples/minimal-plugin
-          pytest examples/minimal-plugin/tests/ -v --tb=short
+      - name: 测试最小示例插件
+        run: pytest examples/minimal-plugin/tests/ -v --tb=short
 
   server-test:
     name: 服务端测试

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,45 @@ jobs:
           from souwen.doctor import check_all
           print('全部数据源 + doctor 导入成功 ✅')
           "
+          python -c "from souwen.plugin import discover_entrypoint_plugins, load_plugins; print('plugin OK')"
+          python -c "from souwen.web.fetch import register_fetch_handler, get_fetch_handlers; print('fetch_handlers OK')"
+          python -c "from souwen.registry.views import external_plugins; print('external_plugins OK')"
+
+  plugin-test:
+    name: 插件系统测试
+    needs: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: 安装依赖（含 web2pdf 插件）
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,web2pdf]"
+
+      - name: 运行插件相关测试
+        run: pytest tests/test_plugin.py tests/test_fetch_handlers.py -v --tb=short
+
+      - name: 验证 entry_point 插件发现
+        run: |
+          python -c "
+          from souwen.plugin import discover_entrypoint_plugins
+          loaded, errors = discover_entrypoint_plugins()
+          assert 'superweb2pdf' in loaded, f'superweb2pdf not found in {loaded}'
+          assert not errors, f'Plugin errors: {errors}'
+          print(f'Plugin discovery OK: {loaded}')
+          "
+
+      - name: 安装并测试最小示例插件
+        run: |
+          pip install -e examples/minimal-plugin
+          pytest examples/minimal-plugin/tests/ -v --tb=short
 
   server-test:
     name: 服务端测试

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [Unreleased] — Plugin System
+
+### Architecture
+- 新增插件系统：通过 setuptools entry_points 或配置文件发现外部数据源
+- Fetch dispatch 重构：20 个 if/elif 分支 → handler 注册表模式
+- 支持双模式加载：运行时发现 (`pip install superweb2pdf`) 和打包嵌入 (`pip install "souwen[web2pdf]"`)
+
+### Features
+- `src/souwen/plugin.py`：插件发现与加载模块
+- `register_fetch_handler()`：外部 fetch provider 注册 API
+- `_reg_external()`：外部适配器注册（重名自动跳过）
+- `SOUWEN_PLUGINS` 环境变量 / `plugins` 配置字段支持手动指定插件
+- `web2pdf` optional dependency：`pip install "souwen[web2pdf]"`
+
+### Docs
+- 新增 `docs/plugin-integration-spec.md`：插件对接规范
+- 新增 `examples/minimal-plugin/`：最小示例插件
+- 更新 `docs/architecture.md`、`docs/adding-a-source.md`
+
+### Tests
+- 新增 `tests/test_plugin.py`（37 tests）：插件系统全覆盖
+- 新增 `tests/test_fetch_handlers.py`（9 tests）：handler 注册表测试
+- 更新 `tests/registry/test_consistency.py`：外部插件一致性检查
+
+### CI
+- 新增 `plugin-test` job：安装 web2pdf extra，验证 entry_point 发现
+- import-check 步骤扩展：插件模块导入验证
+
 ## v0.9.0 — v1 过渡版（2026-04-22）
 
 **架构级改造**：建立数据源单一事实源（registry），引入 facade 门面层，按 v1 的 10 个 domain 重组目录。保持所有 v0 入口（Python import / CLI 命令 / REST 路径）完全兼容。

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,8 @@ WORKDIR /app
 
 # 步骤 1：复制项目配置和版本信息，安装核心依赖
 # 注：curl_cffi 位于 [tls] extras，用于专利爬虫/反爬指纹，必须同时安装
+# 可选插件：追加 web2pdf 启用 SuperWeb2PDF 网页截图转 PDF
+#   pip install ".[server,tls,web2pdf]"  # 需额外安装 playwright chromium
 COPY pyproject.toml README.md LICENSE ./
 COPY src/souwen/__init__.py ./src/souwen/__init__.py
 RUN pip install ".[server,tls]"

--- a/README.en.md
+++ b/README.en.md
@@ -160,6 +160,14 @@ src/souwen/
 └── server/            FastAPI application
 ```
 
+## 🧩 Plugin System
+
+SouWen supports extending data sources and fetch providers via external Python packages.
+Plugins integrate through setuptools `entry_points` or the `plugins` field in `souwen.yaml`,
+without modifying SouWen's codebase.
+
+- Integration spec: [docs/plugin-integration-spec.md](docs/plugin-integration-spec.md)
+
 ## 🚢 Deployment
 
 **Docker** (recommended):

--- a/README.en.md
+++ b/README.en.md
@@ -194,12 +194,14 @@ docker run -p 8000:8000 \
 - [docs/anti-scraping.md](docs/anti-scraping.md) — TLS fingerprinting / WARP / rate limiting
 - [docs/appearance.md](docs/appearance.md) — Multi-skin frontend
 - [docs/adding-a-source.md](docs/adding-a-source.md) — Adding a new source guide
+- [docs/plugin-integration-spec.md](docs/plugin-integration-spec.md) — External plugin integration spec
 - [docs/contributing.md](docs/contributing.md) — Developer guide
 - [CHANGELOG.md](CHANGELOG.md) — Changelog
 
 ## 🤝 Contributing
 
 - Add a data source: see [docs/adding-a-source.md](docs/adding-a-source.md) (just add one `_reg(...)` call in `registry/sources.py`)
+- Build an external plugin: see [docs/plugin-integration-spec.md](docs/plugin-integration-spec.md)
 - Code style: `ruff format && ruff check`
 - Tests: `pytest tests/`
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,13 @@ src/souwen/
 └── server/            FastAPI 应用
 ```
 
+## 🧩 插件系统
+
+SouWen 支持通过外部 Python 包扩展数据源和 fetch provider。插件通过 setuptools
+`entry_points` 或 `souwen.yaml` 的 `plugins` 字段接入，无需修改 SouWen 主仓代码。
+
+- 对接规范：[docs/plugin-integration-spec.md](docs/plugin-integration-spec.md)
+
 ## 🚢 部署
 
 **Docker**（推荐）：
@@ -186,12 +193,14 @@ docker run -p 8000:8000 \
 - [docs/anti-scraping.md](docs/anti-scraping.md) — TLS 指纹 / WARP / 限流
 - [docs/appearance.md](docs/appearance.md) — 多皮肤前端
 - [docs/adding-a-source.md](docs/adding-a-source.md) — 新增数据源指南
+- [docs/plugin-integration-spec.md](docs/plugin-integration-spec.md) — 外部插件对接规范
 - [docs/contributing.md](docs/contributing.md) — 开发者指南
 - [CHANGELOG.md](CHANGELOG.md) — 版本变更
 
 ## 🤝 贡献
 
 - 新增数据源：参考 [docs/adding-a-source.md](docs/adding-a-source.md)（`registry/sources.py` 加一条 `_reg(...)` 即可）
+- 开发外部插件：参考 [docs/plugin-integration-spec.md](docs/plugin-integration-spec.md)
 - 代码风格：`ruff format && ruff check`
 - 测试：`pytest tests/`
 

--- a/docs/adding-a-source.md
+++ b/docs/adding-a-source.md
@@ -228,9 +228,17 @@ curl 'http://localhost:8000/api/v1/search/paper?q=transformer&sources=my_source&
 - **`extra_domains` 滥用**：V1 初期仅允许 `{"fetch"}`。需要跨更多域请先在 `local/` 写 RFC 讨论。
 - **没在 `souwen.example.yaml` 加注释**：用户找不到字段是 V1 之后最高频的工单来源，请补上。
 
+## 7. 替代方案：作为外部插件发布
+
+如果数据源不打算合入主仓（私有、实验性或商业插件），可以作为独立 Python 包发布。
+SouWen 通过 setuptools entry_points 或配置文件自动发现外部插件。
+
+完整对接规范见 [plugin-integration-spec.md](./plugin-integration-spec.md)。
+
 ## 交叉引用
 
 - 配置字段总览：[configuration.md](./configuration.md)
 - 反爬 / 代理 / WARP：[anti-scraping.md](./anti-scraping.md)
 - 后端 API 契约（`/api/v1/sources` 自动列出新源）：[api-reference.md](./api-reference.md)
 - 通用贡献流程 / V0 兼容规则：[contributing.md](./contributing.md)
+- 外部插件对接规范：[plugin-integration-spec.md](./plugin-integration-spec.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -183,7 +183,73 @@ client_cls = adapter.client_loader()  # 此刻才 importlib.import_module
 
 如需 API Key，加第 3 处：`SouWenConfig` 加字段。完整流程见 [adding-a-source.md](adding-a-source.md)。
 
-## 8. 结构一致性测试（护栏）
+## 8. 插件系统（外部扩展）
+
+注册表除了承载内置的 80+ 个 `_reg()`，还能在运行时**通过外部插件**追加新的
+`SourceAdapter`，让第三方 / 私有源在不改主仓代码的前提下被 SouWen 发现。
+
+### 加载流程
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  registry/__init__.py 导入                                       │
+│      ↓                                                           │
+│  1. import sources       —— 触发 80+ 个 _reg()，填满 _REGISTRY  │
+│      ↓                                                           │
+│  2. plugin.load_plugins()                                        │
+│       ├─ discover_entrypoint_plugins()                           │
+│       │     扫描 importlib.metadata entry_points(group=          │
+│       │     "souwen.plugins")，逐个 ep.load() → _coerce_to_     │
+│       │     adapters() → _reg_external()                         │
+│       └─ load_config_plugins(config.plugins)                     │
+│             解析 "module:attr" 字符串列表，同上                  │
+│      ↓                                                           │
+│  3. _reg_external(adapter)                                       │
+│       与已有源重名 → 记 warning 跳过（不抛）                    │
+│       否则插入 _REGISTRY 并加入 _EXTERNAL_PLUGINS                │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+外部插件名出现在 `external_plugins()` 视图里，便于 CLI / `/sources` 端点审计。
+
+### 与内置注册的关键差异
+
+| 维度 | 内置 `_reg()` | 外部 `_reg_external()` |
+|---|---|---|
+| 声明位置 | `registry/sources.py` | 第三方包的 entry point |
+| 重名 | 抛 `ValueError`（启动失败） | 记 warning 跳过 |
+| 一致性测试 | 必跑 `tests/registry/test_consistency.py` | 不强制 |
+| 暴露视图 | 同上 | 额外出现在 `external_plugins()` |
+
+### Fetch Handler 注册表
+
+`fetch` 域的派发不在 registry 层，而在 [`souwen.web.fetch`](../src/souwen/web/fetch.py)
+的独立 dict `_FETCH_HANDLERS: dict[str, FetchHandler]`：
+
+```python
+FetchHandler = Callable[..., Awaitable[FetchResponse]]
+
+_FETCH_HANDLERS["builtin"]      = _handle_builtin
+_FETCH_HANDLERS["jina_reader"]  = _handle_jina_reader
+# ... 20 个内置 provider
+```
+
+外部插件通过 `register_fetch_handler(provider, handler)` 加入这张表，让
+`facade.fetch_content(providers=["my_source"])` 能派发到自己的实现。
+
+> 设计原因：fetch 调用的入参形态（`urls`/`timeout`/各种 provider 私有 kwarg）
+> 与 `MethodSpec` 的统一入参不完全对齐，单独一张 handler 表更直接。
+> SourceAdapter 负责"出现在 registry / `souwen sources`"，handler 负责"能被
+> facade 真正派发"，二者互补。
+
+### 对接规范
+
+完整的插件对接契约（SourceAdapter / MethodSpec / Client / Fetch handler / 配置 /
+打包 / 测试）见 [docs/plugin-integration-spec.md](plugin-integration-spec.md)。
+
+---
+
+## 9. 结构一致性测试（护栏）
 
 `tests/registry/test_consistency.py` 含 21 项硬断言，CI 每次 PR 必跑：
 
@@ -202,7 +268,7 @@ client_cls = adapter.client_loader()  # 此刻才 importlib.import_module
 - 每个 domain 至少有一个源支持 search / archive_lookup
 - fetch 提供者 ≥ 10 个
 
-## 9. 公开 API 入口
+## 10. 公开 API 入口
 
 注册表是单一事实源，但提供多条便捷入口：
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,7 +22,7 @@
 ├────────────────────────────────────────────────────────────────┤
 │ 注册表层 Registry —— 单一事实源                                │
 │   souwen.registry.adapter    SourceAdapter / MethodSpec        │
-│   souwen.registry.sources    83 个 _reg(...) 声明（权威）      │
+│   souwen.registry.sources    91 个 _reg(...) 声明（权威）      │
 │   souwen.registry.loader     字符串懒加载（避免启动 import）  │
 │   souwen.registry.views      by_domain / by_capability / ...   │
 ├────────────────────────────────────────────────────────────────┤
@@ -105,7 +105,7 @@ _reg(SourceAdapter(
 
 ### 懒加载
 
-注册表模块导入时**不**加载 80+ 个 Client：
+注册表模块导入时**不**加载 90+ 个 Client：
 
 ```python
 client_loader=lazy("souwen.paper.openalex:OpenAlexClient")
@@ -185,8 +185,21 @@ client_cls = adapter.client_loader()  # 此刻才 importlib.import_module
 
 ## 8. 插件系统（外部扩展）
 
-注册表除了承载内置的 80+ 个 `_reg()`，还能在运行时**通过外部插件**追加新的
+注册表除了承载内置的 90+ 个 `_reg()`，还能在运行时**通过外部插件**追加新的
 `SourceAdapter`，让第三方 / 私有源在不改主仓代码的前提下被 SouWen 发现。
+
+### 双模式加载
+
+插件可以通过两种方式部署，二者使用同一套 entry_points 机制：
+
+| 模式 | 安装命令 | 适用场景 |
+|---|---|---|
+| **运行时发现** | `pip install superweb2pdf` | 已发布 PyPI 包；与 SouWen 解耦升级 |
+| **打包嵌入** | `pip install "souwen[web2pdf]"` | Docker / 一键部署；插件依赖随 SouWen extras 自动拉取 |
+
+Docker 镜像示例：`pip install ".[server,tls,web2pdf]"`。
+两种模式都依赖同一个 `[project.entry-points."souwen.plugins"]` 声明，
+SouWen 启动时统一通过 `importlib.metadata` 扫描发现。
 
 ### 加载流程
 
@@ -194,7 +207,7 @@ client_cls = adapter.client_loader()  # 此刻才 importlib.import_module
 ┌─────────────────────────────────────────────────────────────────┐
 │  registry/__init__.py 导入                                       │
 │      ↓                                                           │
-│  1. import sources       —— 触发 80+ 个 _reg()，填满 _REGISTRY  │
+│  1. import sources       —— 触发 90+ 个 _reg()，填满 _REGISTRY  │
 │      ↓                                                           │
 │  2. plugin.load_plugins()                                        │
 │       ├─ discover_entrypoint_plugins()                           │

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,7 +22,7 @@
 ├────────────────────────────────────────────────────────────────┤
 │ 注册表层 Registry —— 单一事实源                                │
 │   souwen.registry.adapter    SourceAdapter / MethodSpec        │
-│   souwen.registry.sources    91 个 _reg(...) 声明（权威）      │
+│   souwen.registry.sources    90 个 _reg(...) 声明（权威）      │
 │   souwen.registry.loader     字符串懒加载（避免启动 import）  │
 │   souwen.registry.views      by_domain / by_capability / ...   │
 ├────────────────────────────────────────────────────────────────┤

--- a/docs/plugin-integration-spec.md
+++ b/docs/plugin-integration-spec.md
@@ -56,7 +56,7 @@ my-source = "my_plugin:plugin"
 
 ```toml
 [project.optional-dependencies]
-web2pdf = ["superweb2pdf>=0.1.0"]
+web2pdf = ["superweb2pdf[capture]>=0.2.0"]
 ```
 
 无论哪种模式，启动时 SouWen 都通过 `importlib.metadata.entry_points(group="souwen.plugins")`

--- a/docs/plugin-integration-spec.md
+++ b/docs/plugin-integration-spec.md
@@ -1,0 +1,590 @@
+# SouWen 插件对接规范 (Plugin Integration Spec)
+
+> 本文是 SouWen 外部插件的**对接契约**：定义插件如何被发现、如何声明数据源 / fetch
+> provider、Client 与 handler 的方法签名，以及配置、错误处理、打包和测试要求。
+> 本文不涉及任何具体插件的实现细节——具体插件请见各自仓库的 README。
+
+---
+
+## 1. 概述与目标
+
+SouWen 的所有数据源都通过 [`SourceAdapter`](../src/souwen/registry/adapter.py) 在
+`registry/sources.py` 集中声明（"单一事实源"）。**插件机制**允许第三方在 SouWen 主仓
+之外贡献新的 `SourceAdapter` 与 fetch handler，常见场景：
+
+- 接入私有 / 内部 / 商业搜索 API
+- 为 `fetch` 域加入新的抓取后端（如自建无头浏览器、内部缓存、PDF 渲染）
+- 临时实验某个新源，稳定后再合并到上游
+
+**一个完整的插件 = 一个 `SourceAdapter`（+ 可选的 `FetchHandler` 注册）**。
+插件加载完全异常隔离：单个插件失败 / 重名只记 warning，不影响 SouWen 启动。
+
+---
+
+## 2. 插件发现机制
+
+插件被加载到 registry 有两条路径，**二选一或并用**：
+
+| 路径 | 触发方式 | 适用场景 |
+|---|---|---|
+| **Entry Points 自动发现** | `pip install` 后即生效 | 公开发布到 PyPI / Git；零配置体验 |
+| **配置 / 环境变量手动指定** | `souwen.yaml` 的 `plugins` 字段或 `SOUWEN_PLUGINS` 环境变量 | 私有脚本、单文件实验、临时调试 |
+
+### Entry Point 分组
+
+固定为 **`souwen.plugins`**（见 [`src/souwen/plugin.py`](../src/souwen/plugin.py) 的
+`ENTRY_POINT_GROUP` 常量）：
+
+```toml
+[project.entry-points."souwen.plugins"]
+my-source = "my_plugin:plugin"
+```
+
+### Entry Point 目标可以是三种形态
+
+| 形态 | 示例 | 用途 |
+|---|---|---|
+| `SourceAdapter` 实例 | `plugin = SourceAdapter(...)` | 单源插件 |
+| 零参 callable 返回 `SourceAdapter` | `def make() -> SourceAdapter` | 需要运行时构造 |
+| 零参 callable 返回 `list[SourceAdapter]` | `def make_all() -> list[SourceAdapter]` | 一次注册多个源 |
+
+### 加载流程
+
+```
+registry/__init__.py 导入
+    ↓
+1. import sources       —— 触发内置 _reg()，填满 _REGISTRY
+    ↓
+2. plugin.load_plugins(config)
+    ├─ discover_entrypoint_plugins()
+    │     扫描 importlib.metadata entry_points(group="souwen.plugins")
+    └─ load_config_plugins(config.plugins + SOUWEN_PLUGINS)
+          解析 "module:attr" 字符串列表
+    ↓
+3. _reg_external(adapter)
+    重名 → warning 跳过；否则插入 _REGISTRY 并加入 _EXTERNAL_PLUGINS
+```
+
+外部插件名出现在 `external_plugins()` 视图中，可用于 CLI / `/sources` 端点审计。
+
+---
+
+## 3. SourceAdapter 合约
+
+`SourceAdapter` 是 `frozen=True, slots=True` 的不可变 dataclass。
+
+### 必填字段
+
+| 字段 | 类型 | 约束 |
+|---|---|---|
+| `name` | `str` | **全局唯一**；建议小写 + 下划线；避免与内置源冲突 |
+| `domain` | `str` | 必须 ∈ `DOMAINS` 或等于 `FETCH_DOMAIN` |
+| `integration` | `str` | 必须 ∈ `INTEGRATIONS`：`open_api` / `official_api` / `self_hosted` / `scraper` |
+| `description` | `str` | UI / `souwen sources` 展示文案，建议 ≤ 80 字 |
+| `config_field` | `str \| None` | 对应 `SouWenConfig` 字段名；零配置插件传 `None` |
+| `client_loader` | `Callable[[], type]` | **必须用 `lazy("module:Class")`**（见 §11） |
+| `methods` | `Mapping[str, MethodSpec]` | `capability → MethodSpec`，至少一项 |
+
+### 可选字段
+
+| 字段 | 默认 | 约束 |
+|---|---|---|
+| `extra_domains` | `frozenset()` | 跨域能力；当前仅允许 `frozenset({"fetch"})` |
+| `default_enabled` | `True` | UI 默认是否勾选 |
+| `default_for` | `frozenset()` | 形如 `{"web:search"}`；外部插件**不建议**抢占默认位 |
+| `tags` | `frozenset()` | 见下表 |
+| `needs_config` | `None` | 是否"必须配置才能工作"；建议显式声明（`True` / `False`） |
+
+### 推荐 tag
+
+| Tag | 作用 |
+|---|---|
+| `"external_plugin"` | **强烈建议所有外部插件加上**，便于审计与故障排查 |
+| `"high_risk"` | 高风控源，会被 `high_risk_sources()` 视图收录 |
+
+> ⚠️ 不要使用 `v0_category:*` / `v0_all_sources:exclude` 等内置兼容标签——这些仅用于
+> 内置源对旧版 `ALL_SOURCES` 的向下兼容。
+
+### 校验时机
+
+`_reg_external()` 在注册时进行 dataclass 字段类型校验；语义校验（如 capability 是否
+在标准集中、`MethodSpec.method_name` 是否存在于 Client）由插件自己负责。
+
+### 常量速查
+
+```python
+from souwen.registry.adapter import (
+    DOMAINS,        # {"paper","patent","web","social","video","knowledge",
+                    #  "developer","cn_tech","office","archive"}
+    FETCH_DOMAIN,   # "fetch"
+    CAPABILITIES,   # {"search","search_news","search_images","search_videos",
+                    #  "search_articles","search_users","get_detail","get_trending",
+                    #  "get_transcript","fetch","archive_lookup","archive_save"}
+    INTEGRATIONS,   # {"open_api","scraper","official_api","self_hosted"}
+)
+```
+
+非标准 capability 用命名空间形式：`"my_source:semantic_search"`，不会进入门面自动派发。
+
+---
+
+## 4. MethodSpec 合约
+
+```python
+@dataclass(frozen=True, slots=True)
+class MethodSpec:
+    method_name: str                                       # Client 上的方法名
+    param_map: Mapping[str, str] = {}                      # 入参重命名
+    pre_call: Callable[[dict], dict] | None = None         # 复杂变换逃生舱
+```
+
+| 字段 | 约束 |
+|---|---|
+| `method_name` | Client 类上必须存在 `async def <method_name>(self, **kwargs)` |
+| `param_map` | `{统一参数名: Client 实参名}`；典型如 `{"limit": "per_page"}` |
+| `pre_call` | 接收 dict 返回 dict；用于 `param_map` 不能表达的复杂入参变换 |
+
+### 派发规则
+
+门面层调用顺序：
+
+1. 收集统一参数（如 `query`, `limit`）
+2. 若有 `pre_call`，先 `kwargs = pre_call(kwargs)`
+3. 应用 `param_map` 重命名
+4. `await client.<method_name>(**kwargs)`
+
+---
+
+## 5. Client 合约
+
+Client 是真正执行业务的类，由 `client_loader()` 解析得到。
+
+### 强制约定
+
+- **必须**实现 `async __aenter__(self) -> Self`
+- **必须**实现 `async __aexit__(self, *args) -> None`
+- **必须**实现 `methods` 中声明的每个方法
+- 方法签名应接受经 `param_map` / `pre_call` 重命名后的统一入参
+
+### 模板
+
+```python
+from typing import Any
+from souwen.config import get_config
+
+
+class MyClient:
+    def __init__(self) -> None:
+        self._config = get_config()
+        self._source_config = self._config.get_source_config("my_source")
+
+    async def __aenter__(self) -> "MyClient":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
+    async def search(self, query: str, limit: int = 10) -> dict:
+        ...
+```
+
+### 数据模型
+
+按 capability 选择返回模型，定义在 `souwen.models`：
+
+| Capability | 返回模型 |
+|---|---|
+| `search` (paper / patent) | `SearchResponse[PaperResult]` 等 |
+| `search` (web) | `SearchResponse[WebSearchResult]` |
+| `fetch` | `FetchResult` / `FetchResponse` |
+| `archive_lookup` | `WaybackCDXResponse` |
+| `archive_save` | `ArchiveSaveResponse` |
+
+完整字段见 [`src/souwen/models.py`](../src/souwen/models.py)。
+
+### 配置访问
+
+```python
+config = get_config()
+
+# 1. 顶层 flat key
+api_key = getattr(config, "my_source_api_key", None)
+
+# 2. 频道级（推荐）：sources.my_source.{enabled, proxy, base_url, api_key, headers, params}
+sc = config.get_source_config("my_source")
+if not sc.enabled:
+    raise RuntimeError("my_source disabled")
+
+# 3. 优先级辅助函数（频道 > flat）
+api_key = config.resolve_api_key("my_source", "my_source_api_key")
+base_url = config.resolve_base_url("my_source", "https://api.example.com")
+```
+
+`SourceChannelConfig` 字段（[`src/souwen/config/models.py`](../src/souwen/config/models.py)）：
+
+| 字段 | 类型 | 默认 | 说明 |
+|---|---|---|---|
+| `enabled` | `bool` | `True` | 该源是否启用 |
+| `proxy` | `str` | `"inherit"` | `inherit` / `none` / `warp` / 显式 URL |
+| `http_backend` | `str` | `"auto"` | `auto` / `httpx` / `curl_cffi` |
+| `base_url` | `str \| None` | `None` | 覆盖默认 base URL |
+| `api_key` | `str \| None` | `None` | 频道级 API Key（优先级高于 flat key） |
+| `headers` | `dict[str, str]` | `{}` | 追加自定义 header |
+| `params` | `dict[str, str\|int\|float\|bool]` | `{}` | 自定义参数（plugin 自由解释） |
+
+---
+
+## 6. Fetch Provider 合约
+
+如果插件要作为 fetch provider（`souwen fetch --provider=my-source`），仅声明
+`SourceAdapter` 不足以让门面派发——还需要把异步抓取函数注册到
+`souwen.web.fetch._FETCH_HANDLERS`。
+
+### Handler 签名
+
+```python
+from typing import Any
+from souwen.models import FetchResponse
+
+FetchHandler = Callable[..., Awaitable[FetchResponse]]
+
+async def my_handler(
+    urls: list[str],
+    timeout: float = 30.0,
+    **kwargs: Any,
+) -> FetchResponse:
+    ...
+```
+
+- `urls`：要抓取的 URL 列表
+- `timeout`：单 URL 超时（秒）
+- `**kwargs`：provider 私有参数（`selector` / `start_index` / `max_length` /
+  `respect_robots_txt` 等）；不识别的 kwarg 必须忽略，不应抛错
+
+### 注册
+
+```python
+from souwen.web.fetch import register_fetch_handler
+
+register_fetch_handler("my-source", my_handler, override=False)
+```
+
+| 参数 | 含义 |
+|---|---|
+| `provider: str` | provider 名（CLI `--provider` 与 `fetch_content(provider=)` 用） |
+| `handler: FetchHandler` | 满足 §6 签名的异步函数 |
+| `override: bool = False` | 是否允许覆盖同名 handler；默认拒绝并记 warning |
+
+### 注册时机
+
+最稳妥的做法是在插件包 `__init__.py` 顶层调用：
+
+```python
+# my_plugin/__init__.py
+from souwen.registry.adapter import MethodSpec, SourceAdapter
+from souwen.registry.loader import lazy
+from souwen.web.fetch import register_fetch_handler
+from .handler import my_handler
+
+plugin = SourceAdapter(...)
+register_fetch_handler("my-source", my_handler)
+```
+
+entry point `ep.load()` 会执行该模块顶层代码，handler 即被注册。
+
+### 何时只用 SourceAdapter（不需要 handler）
+
+- 插件只做**搜索**类 capability，不在 `fetch` 域、不实现 `fetch` capability
+- 不希望插件出现在 `fetch_content(provider=...)` 列表里
+
+简言之：`SourceAdapter` 让源出现在 registry，`register_fetch_handler` 让源能被
+facade fetch 派发，二者互不依赖；fetch provider 通常需要两个都做。
+
+### 错误处理约定
+
+- 抓取类**禁止外抛异常**：把错误装进 `FetchResult.error: str` 返回
+- 单 URL 失败不应拖累 batch 内其他 URL（建议在 handler 内独立 try/except 每个 URL）
+
+---
+
+## 7. 配置规范
+
+### `souwen.yaml`
+
+```yaml
+sources:
+  my-source:
+    enabled: true
+    api_key: "sk-..."
+    proxy: warp
+    params:
+      mode: fast
+      max_pages: 50
+
+# 手动指定额外插件（entry point 之外）
+plugins:
+  - "my_plugin:plugin"
+  - "experimental.thing:make_adapter"
+```
+
+### 环境变量
+
+```bash
+# 逗号分隔
+export SOUWEN_PLUGINS="my_plugin:plugin,other_pkg.mod:make_adapter"
+
+# 或 JSON 数组
+export SOUWEN_PLUGINS='["my_plugin:plugin","other_pkg.mod:make_adapter"]'
+```
+
+`SOUWEN_PLUGINS` 与 `souwen.yaml` 的 `plugins` 字段会被合并，去重后一并加载。
+
+### 字符串路径格式
+
+`"module.path:attribute"`，attribute 三种合法形态见 §2。
+
+---
+
+## 8. 错误处理与隔离
+
+| 错误类型 | SouWen 行为 |
+|---|---|
+| 插件 import 失败 | 记 warning，跳过；继续加载其他插件 |
+| Entry point `ep.load()` 抛异常 | 同上 |
+| `name` 与已注册源冲突 | 记 warning，跳过；不覆盖已有源 |
+| `_reg_external` 字段类型不合法 | 抛 `TypeError`，被外层 catch 后记 warning |
+| Fetch handler 重名注册（`override=False`） | 记 warning，保留旧 handler |
+
+`load_plugins()` 返回值：
+
+```python
+{"loaded": ["my-source", "..."], "errors": [{"path": "...", "reason": "..."}]}
+```
+
+可在启动日志或 `/api/v1/plugins` 端点（如有）中暴露给运维。
+
+### Client / Handler 运行时异常
+
+- 抓取类：禁止外抛，错误装入 `FetchResult.error`
+- 搜索类：可抛 `souwen.core.exceptions` 中的标准异常
+  （`ConfigError` / `RateLimitError` / `SourceUnavailableError` / `AuthError`），
+  门面层会做异常隔离，不影响其他源
+
+---
+
+## 9. 打包规范
+
+### `pyproject.toml` 模板
+
+```toml
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "my-souwen-plugin"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "souwen>=1.0.0",
+]
+
+[project.entry-points."souwen.plugins"]
+my-source = "my_plugin:plugin"
+
+[tool.hatch.build.targets.wheel]
+packages = ["my_plugin"]
+```
+
+### 依赖版本约束
+
+- **`souwen>=1.0.0`**：本规范对应的 SouWen 主版本；遵循 SemVer
+- **不要把 SouWen 列为 `==` 精确依赖**，避免与宿主 SouWen 版本冲突
+- 重 IO 依赖（playwright、selenium、ffmpeg-python 等）应放进 `[project.optional-dependencies]`，
+  让用户按需 `pip install my-plugin[browser]`
+
+### 推荐包结构
+
+```
+my-souwen-plugin/
+├── pyproject.toml
+├── README.md
+├── my_plugin/
+│   ├── __init__.py            # 暴露 plugin: SourceAdapter；可在此注册 fetch handler
+│   ├── client.py              # Client 类（async context manager）
+│   └── handler.py             # （可选）fetch handler
+└── tests/
+    └── test_plugin.py
+```
+
+### 多源插件
+
+一个包注册多个源有两种写法：
+
+```toml
+# 方式 A：多个 entry point
+[project.entry-points."souwen.plugins"]
+source-a = "my_plugin:adapter_a"
+source-b = "my_plugin:adapter_b"
+
+# 方式 B：单 entry point 返回 list
+[project.entry-points."souwen.plugins"]
+my_plugin = "my_plugin:get_all_adapters"
+```
+
+```python
+def get_all_adapters() -> list[SourceAdapter]:
+    return [adapter_a, adapter_b]
+```
+
+---
+
+## 10. 测试清单
+
+每个插件应至少覆盖以下场景：
+
+### 契约校验
+
+```python
+from souwen.registry.adapter import SourceAdapter
+from my_plugin import plugin
+
+def test_plugin_is_source_adapter():
+    assert isinstance(plugin, SourceAdapter)
+
+def test_plugin_name():
+    assert plugin.name == "my-source"
+
+def test_client_loader_resolves():
+    cls = plugin.client_loader()
+    assert hasattr(cls, plugin.methods["search"].method_name)
+```
+
+### 注册可用性
+
+```python
+import pytest
+from souwen.registry import views
+from my_plugin import plugin
+
+@pytest.fixture
+def registered_plugin():
+    ok = views._reg_external(plugin)
+    assert ok, "plugin failed to register (name conflict?)"
+    yield plugin
+    views._REGISTRY.pop(plugin.name, None)
+    views._EXTERNAL_PLUGINS.discard(plugin.name)
+
+
+def test_appears_in_registry(registered_plugin):
+    assert views.get(plugin.name) is registered_plugin
+    assert plugin.name in views.external_plugins()
+```
+
+### 端到端派发（可选）
+
+```python
+@pytest.mark.asyncio
+async def test_search_via_facade(registered_plugin, httpx_mock):
+    from souwen.facade.search import search
+    httpx_mock.add_response(url="https://api.example.com/search", json={...})
+    resp = await search("hello", domain="web", sources=[plugin.name], limit=3)
+    assert len(resp[0].results) > 0
+```
+
+### Fetch handler（如适用）
+
+```python
+import pytest
+from souwen.web.fetch import get_fetch_handlers
+
+def test_fetch_handler_registered():
+    import my_plugin  # noqa: F401  触发顶层注册
+    assert "my-source" in get_fetch_handlers()
+```
+
+---
+
+## 11. API 参考
+
+### `souwen.registry.adapter`
+
+| 名字 | 类型 | 用途 |
+|---|---|---|
+| `SourceAdapter` | dataclass | 插件主体声明 |
+| `MethodSpec` | dataclass | capability → Client 方法适配 |
+| `DOMAINS` | `frozenset[str]` | 10 个业务域 |
+| `FETCH_DOMAIN` | `str` | `"fetch"`（横切域） |
+| `CAPABILITIES` | `frozenset[str]` | 12 个标准 capability |
+| `INTEGRATIONS` | `frozenset[str]` | 4 种集成方式 |
+
+### `souwen.registry.loader`
+
+| 名字 | 签名 | 用途 |
+|---|---|---|
+| `lazy(import_path)` | `(str) -> Callable[[], type]` | 字符串懒加载 Client 类 |
+
+### `souwen.registry.views`
+
+| 名字 | 用途 |
+|---|---|
+| `external_plugins() -> list[str]` | 所有外部插件名（按字母序） |
+| `get(name) -> SourceAdapter \| None` | 按名取 adapter |
+| `by_domain(domain) -> list[SourceAdapter]` | 某 domain 全部 adapter |
+| `_reg_external(adapter) -> bool` | 内部 API；测试 / 手动加载用，重名返回 False |
+
+### `souwen.web.fetch`
+
+| 名字 | 签名 | 用途 |
+|---|---|---|
+| `register_fetch_handler(provider, handler, *, override=False)` | `(str, FetchHandler, bool) -> None` | 注册 fetch handler |
+| `get_fetch_handlers() -> dict[str, FetchHandler]` | — | 内省全部已注册 handler |
+| `FetchHandler` | `Callable[..., Awaitable[FetchResponse]]` | handler 类型签名 |
+
+### `souwen.plugin`
+
+| 名字 | 签名 | 用途 |
+|---|---|---|
+| `ENTRY_POINT_GROUP` | `"souwen.plugins"` | entry point 分组名 |
+| `discover_entrypoint_plugins(group=ENTRY_POINT_GROUP)` | `() -> (loaded, errors)` | 扫描 entry points 并注册 |
+| `load_config_plugins(plugin_paths)` | `(list[str]) -> (loaded, errors)` | 加载 `"module:attr"` 字符串列表 |
+| `load_plugins(config=None)` | `(SouWenConfig\|None) -> {"loaded": [...], "errors": [...]}` | 总入口（registry 启动时自动调用） |
+
+### `souwen.config`
+
+| 名字 | 用途 |
+|---|---|
+| `get_config() -> SouWenConfig` | 单例配置访问 |
+| `SouWenConfig.get_source_config(name) -> SourceChannelConfig` | 频道级配置 |
+| `SouWenConfig.resolve_api_key(name, legacy_field) -> str \| None` | 频道 api_key 优先于 flat key |
+| `SouWenConfig.resolve_base_url(name, default) -> str` | 频道 base_url 覆盖 |
+
+### `souwen.models`
+
+`FetchResult` / `FetchResponse` / `SearchResponse` / `PaperResult` /
+`WebSearchResult` / `WaybackCDXResponse` 等——见 [`src/souwen/models.py`](../src/souwen/models.py)。
+
+---
+
+## 12. 常见陷阱
+
+- **`client_loader` 直接传 lambda / 类对象**：会让 registry 在导入期就 import 你的
+  Client，破坏启动延迟优化。**始终用 `lazy("module:Class")`**。
+- **`name` 与内置源冲突**：`_reg_external` 会记 warning 后跳过，插件不生效。
+  发布前用 `souwen sources` 检查冲突。
+- **fetch provider 忘了注册 handler**：能在 `souwen sources` 看到，但
+  `souwen fetch --provider=...` 报"未知提供者"。
+- **Client `__aexit__` 不实现**：facade 用 `async with` 调度，缺失会 AttributeError。
+- **抓取类异常外抛**：违反 §6 / §8 约定，会触发上层异常隔离但用户看不到具体原因。
+- **修改可变默认参**：`SourceAdapter` 是 `frozen=True`，所有 `frozenset()` /
+  `Mapping` 都不可变。
+
+---
+
+## 13. 交叉引用
+
+- 架构总览：[architecture.md](architecture.md)
+- 添加内置源（仓内贡献）：[adding-a-source.md](adding-a-source.md)
+- 数据模型：[`src/souwen/models.py`](../src/souwen/models.py)
+- 配置字段：[configuration.md](configuration.md)
+- 反爬 / TLS 指纹（写 scraper 类插件时）：[anti-scraping.md](anti-scraping.md)

--- a/docs/plugin-integration-spec.md
+++ b/docs/plugin-integration-spec.md
@@ -380,7 +380,7 @@ export SOUWEN_PLUGINS='["my_plugin:plugin","other_pkg.mod:make_adapter"]'
 `load_plugins()` 返回值：
 
 ```python
-{"loaded": ["my-source", "..."], "errors": [{"path": "...", "reason": "..."}]}
+{"loaded": ["my-source", "..."], "errors": [{"source": "...", "name": "...", "error": "..."}]}
 ```
 
 可在启动日志或 `/api/v1/plugins` 端点（如有）中暴露给运维。

--- a/docs/plugin-integration-spec.md
+++ b/docs/plugin-integration-spec.md
@@ -40,6 +40,28 @@ SouWen 的所有数据源都通过 [`SourceAdapter`](../src/souwen/registry/adap
 my-source = "my_plugin:plugin"
 ```
 
+### 双模式加载（运行时发现 vs 打包嵌入）
+
+同一份 entry_points 声明支持两种部署形态，二者使用**完全相同**的发现机制：
+
+| 模式 | 安装方式 | 适用场景 |
+|---|---|---|
+| **运行时发现** | `pip install superweb2pdf` 单独安装第三方包 | 已发布到 PyPI；插件随宿主升级解耦；社区分发 |
+| **打包嵌入（optional dependency）** | `pip install "souwen[web2pdf]"` | Docker 镜像 / 一键部署；插件依赖随 SouWen extras 自动安装 |
+
+**Docker / 多 extras**：`pip install ".[server,tls,web2pdf]"`。
+
+要把插件挂到 SouWen 的 optional dependencies 上，宿主项目在 `pyproject.toml`
+中追加（仅 SouWen 主仓维护者关心）：
+
+```toml
+[project.optional-dependencies]
+web2pdf = ["superweb2pdf>=0.1.0"]
+```
+
+无论哪种模式，启动时 SouWen 都通过 `importlib.metadata.entry_points(group="souwen.plugins")`
+扫描发现。**插件作者通常只需声明 entry_points**，是否打包嵌入由宿主决定。
+
 ### Entry Point 目标可以是三种形态
 
 | 形态 | 示例 | 用途 |
@@ -585,6 +607,7 @@ def test_fetch_handler_registered():
 
 - 架构总览：[architecture.md](architecture.md)
 - 添加内置源（仓内贡献）：[adding-a-source.md](adding-a-source.md)
+- **最小示例插件**：[`examples/minimal-plugin/`](../examples/minimal-plugin/) —— 可直接 `pip install -e .` 体验
 - 数据模型：[`src/souwen/models.py`](../src/souwen/models.py)
 - 配置字段：[configuration.md](configuration.md)
 - 反爬 / TLS 指纹（写 scraper 类插件时）：[anti-scraping.md](anti-scraping.md)

--- a/examples/minimal-plugin/README.md
+++ b/examples/minimal-plugin/README.md
@@ -1,0 +1,29 @@
+# souwen-example-plugin — 最小示例插件
+
+演示如何为 SouWen 编写外部插件。此插件仅回显 URL，不依赖任何第三方服务。
+
+## 安装
+
+```bash
+cd examples/minimal-plugin
+pip install -e .
+```
+
+## 验证
+
+```bash
+python -c "from souwen.registry import all_adapters; print([n for n in all_adapters() if 'example' in n])"
+```
+
+## 结构
+
+```
+souwen_example_plugin/
+├── __init__.py      # 声明 SourceAdapter (entry point)
+├── client.py        # 实现 Client 合约
+└── handler.py       # 可选：注册 fetch handler
+```
+
+## 对接规范
+
+完整规范见 SouWen 文档：[plugin-integration-spec.md](../../docs/plugin-integration-spec.md)

--- a/examples/minimal-plugin/pyproject.toml
+++ b/examples/minimal-plugin/pyproject.toml
@@ -9,6 +9,9 @@ description = "SouWen 最小插件示例 / Minimal SouWen plugin example"
 requires-python = ">=3.10"
 dependencies = []  # souwen is a runtime peer dependency, not declared here
 
+[project.optional-dependencies]
+dev = ["pytest>=8", "pytest-asyncio>=0.23"]
+
 [project.entry-points."souwen.plugins"]
 example_echo = "souwen_example_plugin:plugin"
 

--- a/examples/minimal-plugin/pyproject.toml
+++ b/examples/minimal-plugin/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "souwen-example-plugin"
+version = "0.1.0"
+description = "SouWen 最小插件示例 / Minimal SouWen plugin example"
+requires-python = ">=3.10"
+dependencies = []  # souwen is a runtime peer dependency, not declared here
+
+[project.entry-points."souwen.plugins"]
+example_echo = "souwen_example_plugin:plugin"
+
+[tool.setuptools.packages.find]
+include = ["souwen_example_plugin*"]

--- a/examples/minimal-plugin/souwen_example_plugin/__init__.py
+++ b/examples/minimal-plugin/souwen_example_plugin/__init__.py
@@ -1,0 +1,23 @@
+"""SouWen 最小插件示例。
+
+演示如何创建一个 SouWen 外部插件，注册数据源和 fetch handler。
+此插件仅返回 echo 结果，不依赖任何第三方服务。
+"""
+
+from __future__ import annotations
+
+from souwen.registry.adapter import MethodSpec, SourceAdapter
+from souwen.registry.loader import lazy
+
+plugin = SourceAdapter(
+    name="example_echo",
+    domain="fetch",
+    integration="self_hosted",
+    description="示例插件：echo 返回原始 URL（仅用于演示插件对接规范）",
+    config_field=None,
+    client_loader=lazy("souwen_example_plugin.client:EchoClient"),
+    methods={"fetch": MethodSpec("fetch")},
+    needs_config=False,
+    default_enabled=False,  # 示例插件默认不启用
+    tags=frozenset({"external_plugin", "example"}),
+)

--- a/examples/minimal-plugin/souwen_example_plugin/__init__.py
+++ b/examples/minimal-plugin/souwen_example_plugin/__init__.py
@@ -21,3 +21,10 @@ plugin = SourceAdapter(
     default_enabled=False,  # 示例插件默认不启用
     tags=frozenset({"external_plugin", "example"}),
 )
+
+# Auto-register fetch handler when loaded by SouWen's plugin discovery
+try:
+    from .handler import register
+    register()
+except Exception:
+    pass  # handler registration is optional

--- a/examples/minimal-plugin/souwen_example_plugin/client.py
+++ b/examples/minimal-plugin/souwen_example_plugin/client.py
@@ -1,0 +1,42 @@
+"""Echo 客户端 — 仅回显 URL，演示 Client 合约。"""
+
+from __future__ import annotations
+
+from souwen.models import FetchResponse, FetchResult
+
+
+class EchoClient:
+    """最小 fetch 客户端实现。"""
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        pass
+
+    async def fetch(
+        self,
+        urls: list[str],
+        timeout: float = 30.0,
+        **kwargs,
+    ) -> FetchResponse:
+        results = [
+            FetchResult(
+                url=u,
+                final_url=u,
+                source="example_echo",
+                title=f"Echo: {u}",
+                content=f"# Echo\n\nURL: {u}\n\n此内容由示例插件生成。",
+                content_format="markdown",
+                snippet=f"Echo response for {u}",
+            )
+            for u in urls
+        ]
+        return FetchResponse(
+            urls=urls,
+            results=results,
+            total=len(results),
+            total_ok=len(results),
+            total_failed=0,
+            provider="example_echo",
+        )

--- a/examples/minimal-plugin/souwen_example_plugin/handler.py
+++ b/examples/minimal-plugin/souwen_example_plugin/handler.py
@@ -1,0 +1,40 @@
+"""可选：注册 fetch handler 以支持 `souwen fetch -p example_echo`。"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from souwen.models import FetchResponse, FetchResult
+
+
+async def example_echo_handler(
+    urls: list[str],
+    timeout: float = 30.0,
+    **kwargs: Any,
+) -> FetchResponse:
+    results = [
+        FetchResult(
+            url=u,
+            final_url=u,
+            source="example_echo",
+            title=f"Echo: {u}",
+            content=f"# Echo\n\nURL: {u}",
+            content_format="markdown",
+            snippet=f"Echo response for {u}",
+        )
+        for u in urls
+    ]
+    return FetchResponse(
+        urls=urls,
+        results=results,
+        total=len(results),
+        total_ok=len(results),
+        total_failed=0,
+        provider="example_echo",
+    )
+
+
+def register() -> None:
+    """注册 fetch handler — 插件 __init__.py 或 conftest 中调用。"""
+    from souwen.web.fetch import register_fetch_handler
+    register_fetch_handler("example_echo", example_echo_handler)

--- a/examples/minimal-plugin/tests/test_contract.py
+++ b/examples/minimal-plugin/tests/test_contract.py
@@ -1,0 +1,58 @@
+"""验证示例插件满足 SouWen 插件对接规范。"""
+
+import pytest
+from souwen.registry.adapter import SourceAdapter
+from souwen_example_plugin import plugin
+from souwen_example_plugin.client import EchoClient
+
+
+class TestPluginContract:
+    def test_plugin_is_source_adapter(self):
+        assert isinstance(plugin, SourceAdapter)
+
+    def test_required_fields(self):
+        assert plugin.name == "example_echo"
+        assert plugin.domain == "fetch"
+        assert plugin.integration in ("open_api", "scraper", "official_api", "self_hosted")
+        assert plugin.description
+        assert plugin.client_loader is not None
+        assert "fetch" in plugin.methods
+
+    def test_client_loader_resolves(self):
+        cls = plugin.client_loader()
+        assert cls is EchoClient
+
+
+class TestClientContract:
+    @pytest.fixture
+    def client(self):
+        return EchoClient()
+
+    @pytest.mark.asyncio
+    async def test_async_context_manager(self, client):
+        async with client as c:
+            assert c is client
+
+    @pytest.mark.asyncio
+    async def test_fetch_returns_response(self, client):
+        from souwen.models import FetchResponse
+        resp = await client.fetch(["https://example.com"], timeout=10)
+        assert isinstance(resp, FetchResponse)
+        assert resp.total == 1
+        assert resp.total_ok == 1
+        assert resp.results[0].url == "https://example.com"
+        assert resp.results[0].error is None
+
+
+class TestHandlerContract:
+    def test_handler_is_async(self):
+        import asyncio
+        from souwen_example_plugin.handler import example_echo_handler
+        assert asyncio.iscoroutinefunction(example_echo_handler)
+
+    @pytest.mark.asyncio
+    async def test_handler_returns_fetch_response(self):
+        from souwen.models import FetchResponse
+        from souwen_example_plugin.handler import example_echo_handler
+        resp = await example_echo_handler(["https://example.com"])
+        assert isinstance(resp, FetchResponse)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,8 @@ scraper = ["curl-cffi>=0.14.0"]
 server = ["fastapi>=0.111", "uvicorn[standard]>=0.29"]
 # MCP 服务器协议支持
 mcp = ["mcp>=1.0"]
+# SuperWeb2PDF 网页截图转 PDF（可选外挂插件，pip install souwen[web2pdf]）
+web2pdf = ["superweb2pdf[capture]>=0.2.0"]
 # 开发工具：单元测试、覆盖率、代码检查
 dev = ["pytest>=8.0", "pytest-asyncio>=0.23", "pytest-httpx>=0.30", "pytest-cov>=4", "ruff>=0.4"]
 

--- a/src/souwen/config/loader.py
+++ b/src/souwen/config/loader.py
@@ -173,7 +173,18 @@ def get_config() -> SouWenConfig:
                     continue
             kwargs[field_name] = val
 
-    return SouWenConfig(**kwargs)
+    cfg = SouWenConfig(**kwargs)
+
+    # 配置加载完成后，加载 config.plugins 中手动指定的插件
+    if cfg.plugins:
+        try:
+            from souwen.plugin import load_config_plugins
+
+            load_config_plugins(cfg.plugins)
+        except Exception:  # noqa: BLE001 — 插件加载不能拖垮配置
+            logger.warning("配置插件加载失败,已跳过", exc_info=True)
+
+    return cfg
 
 
 def reload_config() -> SouWenConfig:

--- a/src/souwen/config/loader.py
+++ b/src/souwen/config/loader.py
@@ -132,9 +132,21 @@ def get_config() -> SouWenConfig:
                 except (ValueError, TypeError):
                     logger.warning("环境变量 %s=%r 无法转为整数,已忽略", env_key, val)
                     continue
-            # proxy_pool / cors_origins / trusted_proxies: 逗号分隔字符串 → list[str]
-            elif field_name in ("proxy_pool", "cors_origins", "trusted_proxies"):
-                val = [p.strip() for p in val.split(",") if p.strip()]
+            # proxy_pool / cors_origins / trusted_proxies / plugins: 逗号分隔字符串 或 JSON 数组 → list[str]
+            elif field_name in ("proxy_pool", "cors_origins", "trusted_proxies", "plugins"):
+                stripped = val.strip()
+                if stripped.startswith("["):
+                    try:
+                        parsed = json.loads(stripped)
+                    except json.JSONDecodeError:
+                        logger.warning("环境变量 %s JSON 解析失败,已忽略", env_key)
+                        continue
+                    if not isinstance(parsed, list):
+                        logger.warning("环境变量 %s 应为 JSON 数组,已忽略", env_key)
+                        continue
+                    val = [str(p).strip() for p in parsed if str(p).strip()]
+                else:
+                    val = [p.strip() for p in val.split(",") if p.strip()]
             # http_backend: JSON 字符串 → dict[str, str]
             elif field_name == "http_backend":
                 try:

--- a/src/souwen/config/models.py
+++ b/src/souwen/config/models.py
@@ -236,6 +236,12 @@ class SouWenConfig(BaseModel):
     # ===== 数据源频道配置 =====
     sources: dict[str, SourceChannelConfig] = Field(default_factory=dict)
 
+    # ===== 插件系统 =====
+    plugins: list[str] = Field(
+        default_factory=list,
+        description="手动指定的插件列表，格式为 'module.path:attribute'",
+    )
+
     @field_validator("proxy")
     @classmethod
     def _check_proxy(cls, v: str | None) -> str | None:

--- a/src/souwen/plugin.py
+++ b/src/souwen/plugin.py
@@ -1,0 +1,228 @@
+"""SouWen 插件系统 — 外部数据源发现与加载
+
+提供两条加载路径：
+
+1. **Entry Points 自动发现**：第三方包在 `pyproject.toml` 里声明
+   ```toml
+   [project.entry-points."souwen.plugins"]
+   my_source = "my_pkg.plugin:adapter"
+   ```
+   即可被自动发现并注册。
+
+2. **配置文件手动指定**：在 `souwen.yaml` 或 `SOUWEN_PLUGINS` 环境变量里
+   列出 `"module.path:attribute"` 形式的字符串。
+
+每个入口可以解析为：
+  - 单个 `SourceAdapter` 实例
+  - 返回 `SourceAdapter` 的零参 callable（工厂函数）
+  - `SourceAdapter` 列表/元组（一次注册多个源）
+
+加载失败（导入异常、类型不符、与内置源重名等）只记录警告，
+**绝不**让宿主程序崩溃。
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from collections.abc import Iterable
+from importlib import metadata
+from typing import TYPE_CHECKING, Any
+
+from souwen.registry.adapter import SourceAdapter
+from souwen.registry.views import _reg_external
+
+if TYPE_CHECKING:
+    from souwen.config.models import SouWenConfig
+
+logger = logging.getLogger("souwen.plugin")
+
+ENTRY_POINT_GROUP = "souwen.plugins"
+
+
+def _coerce_to_adapters(obj: Any) -> list[SourceAdapter]:
+    """把入口对象统一转成 `list[SourceAdapter]`。
+
+    支持的形态：
+      - SourceAdapter 实例
+      - 零参 callable，调用后返回上述任一形态
+      - list/tuple，元素为 SourceAdapter
+
+    类型不符时抛 TypeError，由调用方捕获。
+    """
+    if callable(obj) and not isinstance(obj, SourceAdapter):
+        obj = obj()
+
+    if isinstance(obj, SourceAdapter):
+        return [obj]
+
+    if isinstance(obj, (list, tuple)):
+        adapters: list[SourceAdapter] = []
+        for item in obj:
+            if not isinstance(item, SourceAdapter):
+                raise TypeError(
+                    f"插件返回的列表包含非 SourceAdapter 元素: {type(item).__name__}"
+                )
+            adapters.append(item)
+        return adapters
+
+    raise TypeError(
+        f"插件入口必须是 SourceAdapter / 返回它的 callable / 其列表，得到 {type(obj).__name__}"
+    )
+
+
+def _register_adapters(
+    adapters: Iterable[SourceAdapter],
+    *,
+    source_label: str,
+    loaded: list[str],
+    errors: list[dict[str, str]],
+) -> None:
+    """逐个注册 adapter，捕获每个的异常单独处理。"""
+    for adapter in adapters:
+        try:
+            ok = _reg_external(adapter)
+        except Exception as exc:  # noqa: BLE001 — 第三方代码未知异常
+            logger.warning(
+                "注册插件源 %r (来自 %s) 失败: %s", adapter.name, source_label, exc
+            )
+            errors.append({"source": source_label, "name": adapter.name, "error": str(exc)})
+            continue
+        if ok:
+            loaded.append(adapter.name)
+            logger.info("已加载插件源 %r (来自 %s)", adapter.name, source_label)
+
+
+def _resolve_dotted_path(path: str) -> Any:
+    """解析 `"module.path:attribute"` 字符串为 Python 对象。"""
+    if ":" not in path:
+        raise ValueError(f"插件路径必须是 'module.path:attribute' 形式，得到 {path!r}")
+    module_path, _, attr = path.partition(":")
+    if not module_path or not attr:
+        raise ValueError(f"插件路径格式非法: {path!r}")
+    module = importlib.import_module(module_path)
+    try:
+        return getattr(module, attr)
+    except AttributeError as exc:
+        raise AttributeError(f"模块 {module_path!r} 没有属性 {attr!r}") from exc
+
+
+def discover_entrypoint_plugins(
+    group: str = ENTRY_POINT_GROUP,
+) -> tuple[list[str], list[dict[str, str]]]:
+    """通过 entry points 发现并注册插件。
+
+    Args:
+        group: entry point 分组名，默认 `"souwen.plugins"`。
+
+    Returns:
+        `(loaded_names, errors)` 二元组。
+    """
+    loaded: list[str] = []
+    errors: list[dict[str, str]] = []
+
+    try:
+        eps = metadata.entry_points()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("读取 entry points 失败: %s", exc)
+        return loaded, errors
+
+    # Python 3.10+: EntryPoints 对象有 .select()；旧版本是 dict
+    if hasattr(eps, "select"):
+        candidates = list(eps.select(group=group))
+    else:  # pragma: no cover — 兼容老接口
+        candidates = list(eps.get(group, []))  # type: ignore[union-attr]
+
+    for ep in candidates:
+        ep_name = getattr(ep, "name", "<unknown>")
+        label = f"entry_point:{ep_name}"
+        try:
+            obj = ep.load()
+            adapters = _coerce_to_adapters(obj)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("加载插件 entry point %r 失败: %s", ep_name, exc)
+            errors.append({"source": label, "name": ep_name, "error": str(exc)})
+            continue
+        _register_adapters(adapters, source_label=label, loaded=loaded, errors=errors)
+
+    return loaded, errors
+
+
+def load_config_plugins(
+    plugin_paths: list[str],
+) -> tuple[list[str], list[dict[str, str]]]:
+    """从 `"module.path:attribute"` 字符串列表加载插件。
+
+    用于处理 YAML 配置 / 环境变量里手动声明的插件。
+    """
+    loaded: list[str] = []
+    errors: list[dict[str, str]] = []
+
+    for path in plugin_paths or []:
+        if not isinstance(path, str) or not path.strip():
+            logger.warning("跳过非法的插件路径: %r", path)
+            continue
+        path = path.strip()
+        label = f"config:{path}"
+        try:
+            obj = _resolve_dotted_path(path)
+            adapters = _coerce_to_adapters(obj)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("加载配置插件 %r 失败: %s", path, exc)
+            errors.append({"source": label, "name": path, "error": str(exc)})
+            continue
+        _register_adapters(adapters, source_label=label, loaded=loaded, errors=errors)
+
+    return loaded, errors
+
+
+def load_plugins(config: SouWenConfig | None = None) -> dict[str, Any]:
+    """加载所有插件（entry points + 配置文件指定）。
+
+    这是面向 `souwen.registry` 的统一入口，应该在内置源注册完成后调用。
+
+    Args:
+        config: 可选的 `SouWenConfig`。提供则会读取其 `plugins` 字段。
+            为 None 时只做 entry points 发现，避免在 registry 初始化期间
+            循环导入 config 模块。
+
+    Returns:
+        ``{"loaded": [...名称], "errors": [...]}``。即使全部失败也不抛异常。
+    """
+    all_loaded: list[str] = []
+    all_errors: list[dict[str, str]] = []
+
+    try:
+        loaded, errors = discover_entrypoint_plugins()
+        all_loaded.extend(loaded)
+        all_errors.extend(errors)
+    except Exception as exc:  # noqa: BLE001 — 兜底，绝不让插件系统拖垮宿主
+        logger.warning("entry points 插件发现整体失败: %s", exc)
+        all_errors.append({"source": "entry_points", "name": "<discover>", "error": str(exc)})
+
+    if config is not None:
+        try:
+            paths = list(getattr(config, "plugins", []) or [])
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("读取 config.plugins 失败: %s", exc)
+            paths = []
+        if paths:
+            try:
+                loaded, errors = load_config_plugins(paths)
+                all_loaded.extend(loaded)
+                all_errors.extend(errors)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("配置插件加载整体失败: %s", exc)
+                all_errors.append(
+                    {"source": "config", "name": "<load>", "error": str(exc)}
+                )
+
+    return {"loaded": all_loaded, "errors": all_errors}
+
+
+__all__ = [
+    "ENTRY_POINT_GROUP",
+    "discover_entrypoint_plugins",
+    "load_config_plugins",
+    "load_plugins",
+]

--- a/src/souwen/plugin.py
+++ b/src/souwen/plugin.py
@@ -60,9 +60,7 @@ def _coerce_to_adapters(obj: Any) -> list[SourceAdapter]:
         adapters: list[SourceAdapter] = []
         for item in obj:
             if not isinstance(item, SourceAdapter):
-                raise TypeError(
-                    f"插件返回的列表包含非 SourceAdapter 元素: {type(item).__name__}"
-                )
+                raise TypeError(f"插件返回的列表包含非 SourceAdapter 元素: {type(item).__name__}")
             adapters.append(item)
         return adapters
 
@@ -83,9 +81,7 @@ def _register_adapters(
         try:
             ok = _reg_external(adapter)
         except Exception as exc:  # noqa: BLE001 — 第三方代码未知异常
-            logger.warning(
-                "注册插件源 %r (来自 %s) 失败: %s", adapter.name, source_label, exc
-            )
+            logger.warning("注册插件源 %r (来自 %s) 失败: %s", adapter.name, source_label, exc)
             errors.append({"source": source_label, "name": adapter.name, "error": str(exc)})
             continue
         if ok:
@@ -213,9 +209,7 @@ def load_plugins(config: SouWenConfig | None = None) -> dict[str, Any]:
                 all_errors.extend(errors)
             except Exception as exc:  # noqa: BLE001
                 logger.warning("配置插件加载整体失败: %s", exc)
-                all_errors.append(
-                    {"source": "config", "name": "<load>", "error": str(exc)}
-                )
+                all_errors.append({"source": "config", "name": "<load>", "error": str(exc)})
 
     return {"loaded": all_loaded, "errors": all_errors}
 

--- a/src/souwen/registry/__init__.py
+++ b/src/souwen/registry/__init__.py
@@ -42,6 +42,7 @@ from souwen.registry.views import (
     by_domain_and_capability,
     defaults_for,
     enum_values,
+    external_plugins,
     fetch_providers,
     get,
     high_risk_sources,
@@ -50,6 +51,18 @@ from souwen.registry.views import (
 # 触发 sources.py 的 import，填充 _REGISTRY。
 # 这一步**必须**在所有视图符号 import 之后，因为 sources.py 里会调用 views._reg。
 from souwen.registry import sources as _sources  # noqa: F401,E402
+
+# 内置源注册完毕后加载外部插件（entry points + 配置文件指定）。
+# 注意：此处不传 config，避免在 registry 初始化期间触发 config 模块导入循环；
+# 配置文件里 plugins: 字段由 souwen.config 在加载完成后通过 load_plugins(config) 触发。
+try:
+    from souwen.plugin import load_plugins as _load_plugins  # noqa: E402
+
+    _load_plugins()
+except Exception as _exc:  # noqa: BLE001
+    import logging as _logging
+
+    _logging.getLogger("souwen.plugin").warning("插件系统初始化失败,已跳过: %s", _exc)
 
 __all__ = [
     # 常量与数据类
@@ -74,4 +87,5 @@ __all__ = [
     "high_risk_sources",
     "enum_values",
     "as_all_sources_dict",
+    "external_plugins",
 ]

--- a/src/souwen/registry/views.py
+++ b/src/souwen/registry/views.py
@@ -14,13 +14,19 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from typing import Any
 
 from souwen.registry.adapter import FETCH_DOMAIN, SourceAdapter
 
+logger = logging.getLogger("souwen.registry")
+
 # ── 内部注册表（由 sources.py 填充）─────────────────────────
 _REGISTRY: dict[str, SourceAdapter] = {}
+
+#: 通过外部插件加载的源名集合（用于审计/查询）
+_EXTERNAL_PLUGINS: set[str] = set()
 
 
 def _reg(adapter: SourceAdapter) -> None:
@@ -28,6 +34,31 @@ def _reg(adapter: SourceAdapter) -> None:
     if adapter.name in _REGISTRY:
         raise ValueError(f"重复注册数据源: {adapter.name!r}（已存在 {_REGISTRY[adapter.name]!r}）")
     _REGISTRY[adapter.name] = adapter
+
+
+def _reg_external(adapter: SourceAdapter) -> bool:
+    """注册一个外部插件 adapter。
+
+    与 `_reg` 不同：发生重名冲突时 **不抛异常**，仅记录警告并跳过，
+    保证宿主程序不会因为第三方插件冲突而崩溃。
+
+    Returns:
+        True 表示注册成功；False 表示与已有源冲突，已跳过。
+    """
+    if adapter.name in _REGISTRY:
+        logger.warning(
+            "插件源 %r 与已有数据源同名，已跳过（请重命名插件以避免冲突）",
+            adapter.name,
+        )
+        return False
+    _REGISTRY[adapter.name] = adapter
+    _EXTERNAL_PLUGINS.add(adapter.name)
+    return True
+
+
+def external_plugins() -> list[str]:
+    """返回通过外部插件加载的源名（按字母序）。"""
+    return sorted(_EXTERNAL_PLUGINS)
 
 
 # ── 查询 API ────────────────────────────────────────────────
@@ -209,6 +240,7 @@ def as_all_sources_dict() -> dict[str, list[tuple[str, bool, str]]]:
 def _reset_registry() -> None:
     """仅供测试：清空注册表。生产代码不要调用。"""
     _REGISTRY.clear()
+    _EXTERNAL_PLUGINS.clear()
 
 
 def _load_default_sources() -> None:
@@ -244,7 +276,8 @@ __all__ = [
     "high_risk_sources",
     "enum_values",
     "as_all_sources_dict",
+    "external_plugins",
 ]
 
 # 注：保留下列符号供 sources.py 内部使用，但不公开
-_public_internal: tuple[Callable[..., Any], ...] = (_reg,)  # type: ignore[assignment]
+_public_internal: tuple[Callable[..., Any], ...] = (_reg, _reg_external)  # type: ignore[assignment]

--- a/src/souwen/web/fetch.py
+++ b/src/souwen/web/fetch.py
@@ -55,12 +55,48 @@ import asyncio
 import ipaddress
 import logging
 import socket
+from collections.abc import Awaitable, Callable
+from typing import Any
 from urllib.parse import urlparse
 
 from souwen.config import get_config
 from souwen.models import FetchResponse, FetchResult
 
 logger = logging.getLogger("souwen.web.fetch")
+
+
+FetchHandler = Callable[..., Awaitable[FetchResponse]]
+"""Fetch handler signature: ``async (urls: list[str], timeout: float, **kwargs) -> FetchResponse``."""
+
+_FETCH_HANDLERS: dict[str, FetchHandler] = {}
+
+
+def register_fetch_handler(
+    provider: str,
+    handler: FetchHandler,
+    *,
+    override: bool = False,
+) -> None:
+    """注册某个 provider 的抓取处理函数。
+
+    External plugins call this to add their fetch capabilities. Built-in providers
+    are registered at module import time.
+
+    Args:
+        provider: Provider name (must match registry SourceAdapter name)
+        handler: Async callable ``(urls, timeout, **kwargs) -> FetchResponse``
+        override: If True, allows overriding existing handlers
+    """
+    if provider in _FETCH_HANDLERS and not override:
+        logger.warning("Fetch handler %r already registered, skipping", provider)
+        return
+    _FETCH_HANDLERS[provider] = handler
+    logger.debug("Registered fetch handler: %s", provider)
+
+
+def get_fetch_handlers() -> dict[str, FetchHandler]:
+    """Return a shallow copy of the fetch handler registry (for introspection)."""
+    return dict(_FETCH_HANDLERS)
 
 
 def _extract_arxiv_paper_id(url: str) -> str | None:
@@ -142,235 +178,285 @@ def validate_fetch_url(url: str) -> tuple[bool, str]:
     return True, ""
 
 
-async def _fetch_with_provider(
-    provider: str,
+async def _handle_builtin(
     urls: list[str],
     timeout: float,
+    *,
     selector: str | None = None,
     start_index: int = 0,
     max_length: int | None = None,
     respect_robots_txt: bool = False,
+    **_kwargs: Any,
 ) -> FetchResponse:
-    """使用指定提供者抓取内容
+    from souwen.web.builtin import BuiltinFetcherClient
 
-    Args:
-        provider: 提供者名称
-        urls: URL 列表
-        timeout: 超时秒数
-        selector: CSS 选择器（仅 builtin 支持）
-        start_index: 内容起始切片位置（仅 builtin 支持）
-        max_length: 内容最大长度（仅 builtin 支持）
-        respect_robots_txt: 是否遵守 robots.txt（仅 builtin 支持）
-
-    Returns:
-        FetchResponse
-    """
-    if provider == "builtin":
-        from souwen.web.builtin import BuiltinFetcherClient
-
-        async with BuiltinFetcherClient(respect_robots_txt=respect_robots_txt) as client:
-            # 涉及 selector / 分页参数时按单 URL 调用以传递参数
-            if selector or start_index > 0 or max_length is not None:
-                results = []
-                for u in urls:
-                    r = await client.fetch(
-                        u,
-                        timeout=timeout,
-                        start_index=start_index,
-                        max_length=max_length,
-                        selector=selector,
-                    )
-                    results.append(r)
-                ok = sum(1 for r in results if r.error is None)
-                return FetchResponse(
-                    urls=urls,
-                    results=results,
-                    total=len(results),
-                    total_ok=ok,
-                    total_failed=len(results) - ok,
-                    provider="builtin",
-                )
-            return await client.fetch_batch(urls, timeout=timeout)
-
-    elif provider == "jina_reader":
-        from souwen.web.jina_reader import JinaReaderClient
-
-        config = get_config()
-        api_key = getattr(config, "jina_api_key", None) or None
-        async with JinaReaderClient(api_key=api_key) as client:
-            return await client.fetch_batch(urls, timeout=timeout)
-
-    elif provider == "arxiv_fulltext":
-        from souwen.paper.arxiv_fulltext import ArxivFulltextClient
-
-        async with ArxivFulltextClient() as client:
+    async with BuiltinFetcherClient(respect_robots_txt=respect_robots_txt) as client:
+        # 涉及 selector / 分页参数时按单 URL 调用以传递参数
+        if selector or start_index > 0 or max_length is not None:
             results: list[FetchResult] = []
-            for url in urls:
-                paper_id = _extract_arxiv_paper_id(url)
-                if paper_id is None:
-                    results.append(
-                        FetchResult(
-                            url=url,
-                            final_url=url,
-                            source="arxiv_fulltext",
-                            error="arxiv_fulltext 仅支持 arxiv.org 的 /abs/、/html/ 或 /pdf/ URL",
-                        )
-                    )
-                    continue
-                try:
-                    result = await asyncio.wait_for(
-                        client.get_fulltext(paper_id),
-                        timeout=timeout,
-                    )
-                except asyncio.TimeoutError:
-                    results.append(
-                        FetchResult(
-                            url=url,
-                            final_url=url,
-                            source="arxiv_fulltext",
-                            error=f"单 URL 超时（{timeout}s）",
-                        )
-                    )
-                    continue
-                except Exception as exc:
-                    results.append(
-                        FetchResult(
-                            url=url,
-                            final_url=url,
-                            source="arxiv_fulltext",
-                            error=str(exc),
-                        )
-                    )
-                    continue
-                results.append(result.model_copy(update={"url": url}))
-
-            ok = sum(1 for result in results if result.error is None)
+            for u in urls:
+                r = await client.fetch(
+                    u,
+                    timeout=timeout,
+                    start_index=start_index,
+                    max_length=max_length,
+                    selector=selector,
+                )
+                results.append(r)
+            ok = sum(1 for r in results if r.error is None)
             return FetchResponse(
                 urls=urls,
                 results=results,
                 total=len(results),
                 total_ok=ok,
                 total_failed=len(results) - ok,
-                provider="arxiv_fulltext",
+                provider="builtin",
             )
+        return await client.fetch_batch(urls, timeout=timeout)
 
-    elif provider == "tavily":
-        from souwen.web.tavily import TavilyClient
 
-        async with TavilyClient() as client:
-            return await client.extract(urls, timeout=timeout)
+async def _handle_jina_reader(urls: list[str], timeout: float, **_kwargs: Any) -> FetchResponse:
+    from souwen.web.jina_reader import JinaReaderClient
 
-    elif provider == "firecrawl":
-        from souwen.web.firecrawl import FirecrawlClient
+    config = get_config()
+    api_key = getattr(config, "jina_api_key", None) or None
+    async with JinaReaderClient(api_key=api_key) as client:
+        return await client.fetch_batch(urls, timeout=timeout)
 
-        async with FirecrawlClient() as client:
-            return await client.scrape_batch(urls, timeout=timeout)
 
-    elif provider == "exa":
-        from souwen.web.exa import ExaClient
+async def _handle_arxiv_fulltext(urls: list[str], timeout: float, **_kwargs: Any) -> FetchResponse:
+    from souwen.paper.arxiv_fulltext import ArxivFulltextClient
 
-        async with ExaClient() as client:
-            return await client.contents(urls, timeout=timeout)
+    async with ArxivFulltextClient() as client:
+        results: list[FetchResult] = []
+        for url in urls:
+            paper_id = _extract_arxiv_paper_id(url)
+            if paper_id is None:
+                results.append(
+                    FetchResult(
+                        url=url,
+                        final_url=url,
+                        source="arxiv_fulltext",
+                        error="arxiv_fulltext 仅支持 arxiv.org 的 /abs/、/html/ 或 /pdf/ URL",
+                    )
+                )
+                continue
+            try:
+                result = await asyncio.wait_for(
+                    client.get_fulltext(paper_id),
+                    timeout=timeout,
+                )
+            except asyncio.TimeoutError:
+                results.append(
+                    FetchResult(
+                        url=url,
+                        final_url=url,
+                        source="arxiv_fulltext",
+                        error=f"单 URL 超时（{timeout}s）",
+                    )
+                )
+                continue
+            except Exception as exc:
+                results.append(
+                    FetchResult(
+                        url=url,
+                        final_url=url,
+                        source="arxiv_fulltext",
+                        error=str(exc),
+                    )
+                )
+                continue
+            results.append(result.model_copy(update={"url": url}))
 
-    elif provider == "crawl4ai":
-        from souwen.web.crawl4ai_fetcher import Crawl4AIFetcherClient
-
-        async with Crawl4AIFetcherClient() as client:
-            return await client.fetch_batch(urls, timeout=timeout)
-
-    elif provider == "scrapfly":
-        from souwen.web.scrapfly import ScrapflyClient
-
-        async with ScrapflyClient() as client:
-            return await client.fetch_batch(urls, timeout=timeout)
-
-    elif provider == "diffbot":
-        from souwen.web.diffbot import DiffbotClient
-
-        async with DiffbotClient() as client:
-            return await client.fetch_batch(urls, timeout=timeout)
-
-    elif provider == "scrapingbee":
-        from souwen.web.scrapingbee import ScrapingBeeClient
-
-        async with ScrapingBeeClient() as client:
-            return await client.fetch_batch(urls, timeout=timeout)
-
-    elif provider == "zenrows":
-        from souwen.web.zenrows import ZenRowsClient
-
-        async with ZenRowsClient() as client:
-            return await client.fetch_batch(urls, timeout=timeout)
-
-    elif provider == "scraperapi":
-        from souwen.web.scraperapi import ScraperAPIClient
-
-        async with ScraperAPIClient() as client:
-            return await client.fetch_batch(urls, timeout=timeout)
-
-    elif provider == "apify":
-        from souwen.web.apify import ApifyClient
-
-        async with ApifyClient() as client:
-            return await client.fetch_batch(urls, timeout=timeout)
-
-    elif provider == "cloudflare":
-        from souwen.web.cloudflare_browser import CloudflareBrowserClient
-
-        async with CloudflareBrowserClient() as client:
-            return await client.fetch_batch(urls, timeout=timeout)
-
-    elif provider == "wayback":
-        from souwen.web.wayback import WaybackClient
-
-        async with WaybackClient() as client:
-            return await client.fetch_batch(urls, timeout=timeout)
-
-    elif provider == "newspaper":
-        from souwen.web.newspaper_fetcher import NewspaperFetcherClient
-
-        async with NewspaperFetcherClient() as client:
-            return await client.fetch_batch(urls, timeout=timeout)
-
-    elif provider == "readability":
-        from souwen.web.readability_fetcher import ReadabilityFetcherClient
-
-        async with ReadabilityFetcherClient() as client:
-            return await client.fetch_batch(urls, timeout=timeout)
-
-    elif provider == "mcp":
-        from souwen.web.mcp_fetch import MCPFetchClient
-
-        async with MCPFetchClient() as client:
-            return await client.fetch_batch(urls, timeout=timeout)
-
-    elif provider == "site_crawler":
-        from souwen.web.site_crawler import SiteCrawlerClient
-
-        async with SiteCrawlerClient() as client:
-            # max_depth=1 默认爬取根页面 + 一级子页面
-            return await client.fetch_batch(urls, timeout=timeout, max_depth=1)
-
-    elif provider == "deepwiki":
-        from souwen.web.deepwiki import DeepWikiClient
-
-        async with DeepWikiClient() as client:
-            return await client.fetch_batch(urls, timeout=timeout)
-
-    else:
-        # 未知提供者 → 全部标记失败
-        results = [
-            FetchResult(url=u, final_url=u, source=provider, error=f"未知提供者: {provider}")
-            for u in urls
-        ]
+        ok = sum(1 for result in results if result.error is None)
         return FetchResponse(
             urls=urls,
             results=results,
-            total=len(urls),
-            total_ok=0,
-            total_failed=len(urls),
-            provider=provider,
+            total=len(results),
+            total_ok=ok,
+            total_failed=len(results) - ok,
+            provider="arxiv_fulltext",
         )
+
+
+async def _handle_tavily(urls: list[str], timeout: float, **_kwargs: Any) -> FetchResponse:
+    from souwen.web.tavily import TavilyClient
+
+    async with TavilyClient() as client:
+        return await client.extract(urls, timeout=timeout)
+
+
+async def _handle_firecrawl(urls: list[str], timeout: float, **_kwargs: Any) -> FetchResponse:
+    from souwen.web.firecrawl import FirecrawlClient
+
+    async with FirecrawlClient() as client:
+        return await client.scrape_batch(urls, timeout=timeout)
+
+
+async def _handle_exa(urls: list[str], timeout: float, **_kwargs: Any) -> FetchResponse:
+    from souwen.web.exa import ExaClient
+
+    async with ExaClient() as client:
+        return await client.contents(urls, timeout=timeout)
+
+
+async def _handle_crawl4ai(urls: list[str], timeout: float, **_kwargs: Any) -> FetchResponse:
+    from souwen.web.crawl4ai_fetcher import Crawl4AIFetcherClient
+
+    async with Crawl4AIFetcherClient() as client:
+        return await client.fetch_batch(urls, timeout=timeout)
+
+
+async def _handle_scrapfly(urls: list[str], timeout: float, **_kwargs: Any) -> FetchResponse:
+    from souwen.web.scrapfly import ScrapflyClient
+
+    async with ScrapflyClient() as client:
+        return await client.fetch_batch(urls, timeout=timeout)
+
+
+async def _handle_diffbot(urls: list[str], timeout: float, **_kwargs: Any) -> FetchResponse:
+    from souwen.web.diffbot import DiffbotClient
+
+    async with DiffbotClient() as client:
+        return await client.fetch_batch(urls, timeout=timeout)
+
+
+async def _handle_scrapingbee(urls: list[str], timeout: float, **_kwargs: Any) -> FetchResponse:
+    from souwen.web.scrapingbee import ScrapingBeeClient
+
+    async with ScrapingBeeClient() as client:
+        return await client.fetch_batch(urls, timeout=timeout)
+
+
+async def _handle_zenrows(urls: list[str], timeout: float, **_kwargs: Any) -> FetchResponse:
+    from souwen.web.zenrows import ZenRowsClient
+
+    async with ZenRowsClient() as client:
+        return await client.fetch_batch(urls, timeout=timeout)
+
+
+async def _handle_scraperapi(urls: list[str], timeout: float, **_kwargs: Any) -> FetchResponse:
+    from souwen.web.scraperapi import ScraperAPIClient
+
+    async with ScraperAPIClient() as client:
+        return await client.fetch_batch(urls, timeout=timeout)
+
+
+async def _handle_apify(urls: list[str], timeout: float, **_kwargs: Any) -> FetchResponse:
+    from souwen.web.apify import ApifyClient
+
+    async with ApifyClient() as client:
+        return await client.fetch_batch(urls, timeout=timeout)
+
+
+async def _handle_cloudflare(urls: list[str], timeout: float, **_kwargs: Any) -> FetchResponse:
+    from souwen.web.cloudflare_browser import CloudflareBrowserClient
+
+    async with CloudflareBrowserClient() as client:
+        return await client.fetch_batch(urls, timeout=timeout)
+
+
+async def _handle_wayback(urls: list[str], timeout: float, **_kwargs: Any) -> FetchResponse:
+    from souwen.web.wayback import WaybackClient
+
+    async with WaybackClient() as client:
+        return await client.fetch_batch(urls, timeout=timeout)
+
+
+async def _handle_newspaper(urls: list[str], timeout: float, **_kwargs: Any) -> FetchResponse:
+    from souwen.web.newspaper_fetcher import NewspaperFetcherClient
+
+    async with NewspaperFetcherClient() as client:
+        return await client.fetch_batch(urls, timeout=timeout)
+
+
+async def _handle_readability(urls: list[str], timeout: float, **_kwargs: Any) -> FetchResponse:
+    from souwen.web.readability_fetcher import ReadabilityFetcherClient
+
+    async with ReadabilityFetcherClient() as client:
+        return await client.fetch_batch(urls, timeout=timeout)
+
+
+async def _handle_mcp(urls: list[str], timeout: float, **_kwargs: Any) -> FetchResponse:
+    from souwen.web.mcp_fetch import MCPFetchClient
+
+    async with MCPFetchClient() as client:
+        return await client.fetch_batch(urls, timeout=timeout)
+
+
+async def _handle_site_crawler(urls: list[str], timeout: float, **_kwargs: Any) -> FetchResponse:
+    from souwen.web.site_crawler import SiteCrawlerClient
+
+    async with SiteCrawlerClient() as client:
+        # max_depth=1 默认爬取根页面 + 一级子页面
+        return await client.fetch_batch(urls, timeout=timeout, max_depth=1)
+
+
+async def _handle_deepwiki(urls: list[str], timeout: float, **_kwargs: Any) -> FetchResponse:
+    from souwen.web.deepwiki import DeepWikiClient
+
+    async with DeepWikiClient() as client:
+        return await client.fetch_batch(urls, timeout=timeout)
+
+
+# 注册全部内置 provider 的抓取处理函数（外部插件可通过 register_fetch_handler 扩展）
+register_fetch_handler("builtin", _handle_builtin)
+register_fetch_handler("jina_reader", _handle_jina_reader)
+register_fetch_handler("arxiv_fulltext", _handle_arxiv_fulltext)
+register_fetch_handler("tavily", _handle_tavily)
+register_fetch_handler("firecrawl", _handle_firecrawl)
+register_fetch_handler("exa", _handle_exa)
+register_fetch_handler("crawl4ai", _handle_crawl4ai)
+register_fetch_handler("scrapfly", _handle_scrapfly)
+register_fetch_handler("diffbot", _handle_diffbot)
+register_fetch_handler("scrapingbee", _handle_scrapingbee)
+register_fetch_handler("zenrows", _handle_zenrows)
+register_fetch_handler("scraperapi", _handle_scraperapi)
+register_fetch_handler("apify", _handle_apify)
+register_fetch_handler("cloudflare", _handle_cloudflare)
+register_fetch_handler("wayback", _handle_wayback)
+register_fetch_handler("newspaper", _handle_newspaper)
+register_fetch_handler("readability", _handle_readability)
+register_fetch_handler("mcp", _handle_mcp)
+register_fetch_handler("site_crawler", _handle_site_crawler)
+register_fetch_handler("deepwiki", _handle_deepwiki)
+
+
+async def _fetch_with_provider(
+    provider: str,
+    urls: list[str],
+    timeout: float,
+    **kwargs: Any,
+) -> FetchResponse:
+    """通过注册表派发到指定 provider 的抓取处理函数。
+
+    Args:
+        provider: 提供者名称
+        urls: URL 列表
+        timeout: 超时秒数
+        **kwargs: provider 特定参数（例如 builtin 的 selector / start_index / max_length /
+            respect_robots_txt），未识别的参数会被对应 handler 忽略
+
+    Returns:
+        FetchResponse
+    """
+    handler = _FETCH_HANDLERS.get(provider)
+    if handler is not None:
+        return await handler(urls, timeout, **kwargs)
+
+    # 未知提供者 → 全部标记失败
+    results = [
+        FetchResult(url=u, final_url=u, source=provider, error=f"未知提供者: {provider}")
+        for u in urls
+    ]
+    return FetchResponse(
+        urls=urls,
+        results=results,
+        total=len(urls),
+        total_ok=0,
+        total_failed=len(urls),
+        provider=provider,
+    )
 
 
 async def fetch_content(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,39 @@ from __future__ import annotations
 import pytest
 
 
+@pytest.fixture
+def clean_registry():
+    """保存并恢复 registry 状态，给插件相关测试用。
+
+    适用于会向 _REGISTRY / _EXTERNAL_PLUGINS 写入条目的测试，
+    避免污染其他用例（特别是 test_consistency.py 的全量遍历）。
+    """
+    from souwen.registry.views import _EXTERNAL_PLUGINS, _REGISTRY
+
+    saved_registry = dict(_REGISTRY)
+    saved_plugins = set(_EXTERNAL_PLUGINS)
+    try:
+        yield
+    finally:
+        _REGISTRY.clear()
+        _REGISTRY.update(saved_registry)
+        _EXTERNAL_PLUGINS.clear()
+        _EXTERNAL_PLUGINS.update(saved_plugins)
+
+
+@pytest.fixture
+def clean_fetch_handlers():
+    """保存并恢复 fetch handler 注册表，给插件相关测试用。"""
+    from souwen.web.fetch import _FETCH_HANDLERS
+
+    saved = dict(_FETCH_HANDLERS)
+    try:
+        yield
+    finally:
+        _FETCH_HANDLERS.clear()
+        _FETCH_HANDLERS.update(saved)
+
+
 @pytest.fixture(autouse=True)
 def _auto_clear_config_cache():
     from souwen.config import get_config

--- a/tests/registry/test_consistency.py
+++ b/tests/registry/test_consistency.py
@@ -35,12 +35,17 @@ from souwen.registry import (
     fetch_providers,
     high_risk_sources,
 )
+from souwen.registry import external_plugins
 from souwen.registry.adapter import (
     CAPABILITIES,
     DOMAINS,
     FETCH_DOMAIN,
     INTEGRATIONS,
+    MethodSpec,
+    SourceAdapter,
 )
+from souwen.registry.loader import lazy
+from souwen.registry.views import _reg_external
 
 
 # ── 基础不变量 ──────────────────────────────────────────────
@@ -344,4 +349,62 @@ class TestCapabilityStability:
         for cap in CAPABILITIES - allowed_unused:
             assert cap in used, (
                 f"标准 capability {cap!r} 没有源实现；如果预留未用，请加入 allowed_unused 集合"
+            )
+
+
+# ── 外部插件支持 ───────────────────────────────────────────
+
+
+class TestExternalPlugins:
+    """`external_plugins()` 视图与 `_reg_external` 的集成行为。"""
+
+    def test_external_plugins_returns_list(self):
+        out = external_plugins()
+        assert isinstance(out, list)
+        # 列表内容必定是 _REGISTRY 子集
+        names = set(all_adapters().keys())
+        for n in out:
+            assert n in names, f"external_plugins() 返回的 {n!r} 不在 registry"
+
+    def test_reg_external_does_not_corrupt_registry(self, clean_registry):
+        """注册并恢复后，所有 D11 不变量仍然成立。"""
+        adapter = SourceAdapter(
+            name="ext_consistency_probe",
+            domain="fetch",
+            integration="scraper",
+            description="probe",
+            config_field=None,
+            client_loader=lazy("souwen.web.builtin:BuiltinFetcherClient"),
+            methods={"fetch": MethodSpec("fetch")},
+            needs_config=False,
+        )
+        ok = _reg_external(adapter)
+        assert ok is True
+        # 注册后，注册表里能找到；并且 capability/domain 都合法
+        adapters = all_adapters()
+        assert "ext_consistency_probe" in adapters
+        a = adapters["ext_consistency_probe"]
+        assert a.domain in DOMAINS or a.domain == FETCH_DOMAIN
+        assert a.integration in INTEGRATIONS
+        for cap in a.capabilities:
+            assert cap in CAPABILITIES or ":" in cap
+
+    def test_external_adapter_passes_d11_validation(self, clean_registry):
+        """外部 adapter 也要满足：methods 指向真实存在的 client 方法。"""
+        adapter = SourceAdapter(
+            name="ext_d11_probe",
+            domain="fetch",
+            integration="scraper",
+            description="probe",
+            config_field=None,
+            client_loader=lazy("souwen.web.builtin:BuiltinFetcherClient"),
+            methods={"fetch": MethodSpec("fetch")},
+            needs_config=False,
+        )
+        _reg_external(adapter)
+        a = all_adapters()["ext_d11_probe"]
+        client_cls = a.client_loader()
+        for cap, spec in a.methods.items():
+            assert callable(getattr(client_cls, spec.method_name, None)), (
+                f"external adapter {a.name} method {spec.method_name} 不可调用"
             )

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -23,7 +23,7 @@ class TestCheckAll:
 
         get_config.cache_clear()
         results = check_all()
-        assert len(results) == 90
+        assert len(results) >= 90  # 90 内置 + 可能有外部插件
 
     def test_result_has_required_keys(self):
         """每条结果包含必要字段"""
@@ -103,8 +103,8 @@ class TestCheckAll:
             get_config.cache_clear()
 
     def test_source_config_matches_37(self):
-        """source registry 有 90 个数据源"""
-        assert len(get_all_sources()) == 90
+        """source registry 有 90+ 个数据源（内置 + 外部插件）"""
+        assert len(get_all_sources()) >= 90
 
     def test_semantic_scholar_without_key_is_limited(self, monkeypatch):
         """Semantic Scholar 无 Key 时标记为 limited。"""

--- a/tests/test_fetch_handlers.py
+++ b/tests/test_fetch_handlers.py
@@ -1,0 +1,171 @@
+"""souwen.web.fetch handler registry 测试。
+
+覆盖：
+  - _FETCH_HANDLERS 包含全部 20 个内置 provider
+  - register_fetch_handler 新增 / 重名跳过 / override
+  - get_fetch_handlers 视图
+  - _fetch_with_provider 派发到注册的 handler
+  - 未知 provider 返回错误 FetchResponse
+  - 外部插件 handler 注册与派发
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from souwen.models import FetchResponse, FetchResult
+from souwen.web.fetch import (
+    _FETCH_HANDLERS,
+    _fetch_with_provider,
+    get_fetch_handlers,
+    register_fetch_handler,
+)
+
+EXPECTED_BUILTIN_PROVIDERS = {
+    "builtin",
+    "jina_reader",
+    "arxiv_fulltext",
+    "tavily",
+    "firecrawl",
+    "exa",
+    "crawl4ai",
+    "scrapfly",
+    "diffbot",
+    "scrapingbee",
+    "zenrows",
+    "scraperapi",
+    "apify",
+    "cloudflare",
+    "wayback",
+    "newspaper",
+    "readability",
+    "mcp",
+    "site_crawler",
+    "deepwiki",
+}
+
+
+def _make_response(provider: str, urls: list[str], ok: bool = True) -> FetchResponse:
+    results = [
+        FetchResult(
+            url=u,
+            final_url=u,
+            source=provider,
+            content="ok" if ok else None,
+            error=None if ok else "boom",
+        )
+        for u in urls
+    ]
+    n_ok = sum(1 for r in results if r.error is None)
+    return FetchResponse(
+        urls=urls,
+        results=results,
+        total=len(results),
+        total_ok=n_ok,
+        total_failed=len(results) - n_ok,
+        provider=provider,
+    )
+
+
+# ── 内置注册表完整性 ───────────────────────────────────────
+
+
+class TestBuiltinHandlers:
+    def test_all_20_providers_registered(self):
+        names = set(_FETCH_HANDLERS.keys())
+        missing = EXPECTED_BUILTIN_PROVIDERS - names
+        assert not missing, f"缺失内置 provider: {missing}"
+
+    def test_handler_count_at_least_20(self):
+        # 允许其它插件追加，但内置 20 个必须就位
+        assert len(_FETCH_HANDLERS) >= 20
+
+    def test_get_fetch_handlers_returns_copy(self):
+        snap = get_fetch_handlers()
+        assert isinstance(snap, dict)
+        assert set(snap.keys()) >= EXPECTED_BUILTIN_PROVIDERS
+        # 修改副本不影响原表
+        snap["__bogus__"] = lambda *a, **kw: None  # type: ignore[assignment]
+        assert "__bogus__" not in _FETCH_HANDLERS
+
+
+# ── register_fetch_handler ─────────────────────────────────
+
+
+class TestRegisterFetchHandler:
+    def test_register_new(self, clean_fetch_handlers):
+        async def my_handler(urls, timeout, **_):
+            return _make_response("my_new", urls)
+
+        register_fetch_handler("my_new", my_handler)
+        assert _FETCH_HANDLERS["my_new"] is my_handler
+
+    def test_duplicate_no_override_skips(self, clean_fetch_handlers):
+        async def first(urls, timeout, **_):
+            return _make_response("dup", urls)
+
+        async def second(urls, timeout, **_):
+            return _make_response("dup", urls)
+
+        register_fetch_handler("dup", first)
+        register_fetch_handler("dup", second)
+        # 重名不覆盖，保留第一个
+        assert _FETCH_HANDLERS["dup"] is first
+
+    def test_override_true_replaces(self, clean_fetch_handlers):
+        async def first(urls, timeout, **_):
+            return _make_response("ovr", urls)
+
+        async def second(urls, timeout, **_):
+            return _make_response("ovr2", urls)
+
+        register_fetch_handler("ovr", first)
+        register_fetch_handler("ovr", second, override=True)
+        assert _FETCH_HANDLERS["ovr"] is second
+
+
+# ── _fetch_with_provider ───────────────────────────────────
+
+
+class TestFetchWithProvider:
+    @pytest.mark.asyncio
+    async def test_dispatches_to_registered_handler(self, clean_fetch_handlers):
+        called = {}
+
+        async def my_handler(urls, timeout, **kwargs):
+            called["urls"] = urls
+            called["timeout"] = timeout
+            called["kwargs"] = kwargs
+            return _make_response("dispatch_test", urls)
+
+        register_fetch_handler("dispatch_test", my_handler)
+        resp = await _fetch_with_provider(
+            "dispatch_test", ["http://example.com"], 5.0, foo="bar"
+        )
+        assert resp.provider == "dispatch_test"
+        assert called["urls"] == ["http://example.com"]
+        assert called["timeout"] == 5.0
+        assert called["kwargs"] == {"foo": "bar"}
+
+    @pytest.mark.asyncio
+    async def test_unknown_provider_returns_error_response(self):
+        urls = ["http://a.example", "http://b.example"]
+        resp = await _fetch_with_provider("does_not_exist_xyz", urls, 1.0)
+        assert resp.provider == "does_not_exist_xyz"
+        assert resp.total == 2
+        assert resp.total_ok == 0
+        assert resp.total_failed == 2
+        for r in resp.results:
+            assert r.error is not None
+            assert "未知提供者" in r.error
+
+    @pytest.mark.asyncio
+    async def test_external_plugin_handler_dispatches(self, clean_fetch_handlers):
+        async def ext_handler(urls, timeout, **_):
+            return _make_response("ext_via_plugin", urls)
+
+        # 模拟外部插件在加载时调用 register_fetch_handler
+        register_fetch_handler("ext_via_plugin", ext_handler)
+        resp = await _fetch_with_provider("ext_via_plugin", ["http://x.example"], 2.0)
+        assert resp.provider == "ext_via_plugin"
+        assert resp.total_ok == 1

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -538,7 +538,7 @@ class TestCLI:
         )
         # v0 期望 31；v1 修复漂移后为 38
         assert total_web == 38
-        assert len(ALL_SOURCES["fetch"]) == 20
+        assert len(ALL_SOURCES["fetch"]) >= 20  # 20 内置 + 可能有外部插件
         # cn_tech 拆分后独立源
         assert len(ALL_SOURCES["cn_tech"]) == 9
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -52,9 +52,9 @@ class TestAllSources:
         assert len(ALL_SOURCES["cn_tech"]) == 9
 
     def test_total_count(self):
-        """总计暴露的数据源数量。"""
+        """总计暴露的数据源数量（含可能的外部插件）。"""
         total = sum(len(v) for v in ALL_SOURCES.values())
-        assert total == 90  # v0: 73
+        assert total >= 90  # v0: 73, v1 内置: 90, 外部插件可增加
 
     def test_each_entry_is_tuple_of_three(self):
         """每条目是 (name, requires_key, desc) 三元组"""

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,377 @@
+"""souwen.plugin 测试 — 外部插件发现、加载与注册。
+
+覆盖：
+  - _coerce_to_adapters：单/列表/工厂 callable/异常分支
+  - _resolve_dotted_path：合法/非法/缺失模块或属性
+  - _reg_external：新增/重名/external_plugins 视图
+  - discover_entrypoint_plugins：无入口/有效入口/加载失败
+  - load_config_plugins：合法/非法/空
+  - load_plugins：纯 entry_points / 含 config / 错误隔离
+  - _reset_registry 清理 EXTERNAL_PLUGINS
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from souwen.plugin import (
+    _coerce_to_adapters,
+    _resolve_dotted_path,
+    discover_entrypoint_plugins,
+    load_config_plugins,
+    load_plugins,
+)
+from souwen.registry.adapter import MethodSpec, SourceAdapter
+from souwen.registry.loader import lazy
+from souwen.registry.views import (
+    _EXTERNAL_PLUGINS,
+    _REGISTRY,
+    _reg_external,
+    _reset_registry,
+    all_adapters,
+    external_plugins,
+)
+
+
+# ── helpers ────────────────────────────────────────────────
+
+
+def make_test_adapter(name: str = "test_plugin", domain: str = "fetch") -> SourceAdapter:
+    """构造测试用 adapter，复用 builtin fetch 的 client_loader。"""
+    return SourceAdapter(
+        name=name,
+        domain=domain,
+        integration="scraper",
+        description=f"Test plugin: {name}",
+        config_field=None,
+        client_loader=lazy("souwen.web.builtin:BuiltinFetcherClient"),
+        methods={"fetch": MethodSpec("fetch")},
+        needs_config=False,
+    )
+
+
+class _FakeEntryPoint:
+    """模拟 importlib.metadata.EntryPoint."""
+
+    def __init__(self, name: str, loader):
+        self.name = name
+        self._loader = loader
+
+    def load(self):
+        return self._loader()
+
+
+class _FakeEntryPoints:
+    """模拟 importlib.metadata.EntryPoints（实现 .select）。"""
+
+    def __init__(self, eps: list[_FakeEntryPoint]):
+        self._eps = eps
+
+    def select(self, *, group: str):  # noqa: ARG002
+        return list(self._eps)
+
+
+# ── _coerce_to_adapters ────────────────────────────────────
+
+
+class TestCoerceToAdapters:
+    def test_single_adapter(self):
+        a = make_test_adapter("c1")
+        out = _coerce_to_adapters(a)
+        assert out == [a]
+
+    def test_callable_returning_adapter(self):
+        a = make_test_adapter("c2")
+        out = _coerce_to_adapters(lambda: a)
+        assert out == [a]
+
+    def test_list_of_adapters(self):
+        a1, a2 = make_test_adapter("c3a"), make_test_adapter("c3b")
+        out = _coerce_to_adapters([a1, a2])
+        assert out == [a1, a2]
+
+    def test_tuple_of_adapters(self):
+        a1, a2 = make_test_adapter("c3c"), make_test_adapter("c3d")
+        out = _coerce_to_adapters((a1, a2))
+        assert out == [a1, a2]
+
+    def test_callable_returning_list(self):
+        a1, a2 = make_test_adapter("c4a"), make_test_adapter("c4b")
+        out = _coerce_to_adapters(lambda: [a1, a2])
+        assert out == [a1, a2]
+
+    def test_invalid_type_raises(self):
+        with pytest.raises(TypeError, match="必须是 SourceAdapter"):
+            _coerce_to_adapters(123)
+
+    def test_invalid_type_string_raises(self):
+        with pytest.raises(TypeError):
+            _coerce_to_adapters("not an adapter")
+
+    def test_list_with_non_adapter_raises(self):
+        a = make_test_adapter("c5")
+        with pytest.raises(TypeError, match="非 SourceAdapter 元素"):
+            _coerce_to_adapters([a, "bad"])
+
+
+# ── _resolve_dotted_path ────────────────────────────────────
+
+
+class TestResolveDottedPath:
+    def test_valid_path(self):
+        obj = _resolve_dotted_path("souwen.registry.views:all_adapters")
+        assert callable(obj)
+        assert obj is all_adapters
+
+    def test_missing_colon_raises(self):
+        with pytest.raises(ValueError, match="必须是"):
+            _resolve_dotted_path("souwen.registry.views.all_adapters")
+
+    def test_empty_module_raises(self):
+        with pytest.raises(ValueError):
+            _resolve_dotted_path(":attr")
+
+    def test_empty_attr_raises(self):
+        with pytest.raises(ValueError):
+            _resolve_dotted_path("souwen.registry.views:")
+
+    def test_nonexistent_module_raises(self):
+        with pytest.raises(ImportError):
+            _resolve_dotted_path("souwen.nonexistent_xyz_module:foo")
+
+    def test_nonexistent_attr_raises(self):
+        with pytest.raises(AttributeError, match="没有属性"):
+            _resolve_dotted_path("souwen.registry.views:nonexistent_attr_xyz")
+
+
+# ── _reg_external ──────────────────────────────────────────
+
+
+class TestRegExternal:
+    def test_new_adapter_registered(self, clean_registry):
+        a = make_test_adapter("ext_new_one")
+        ok = _reg_external(a)
+        assert ok is True
+        assert "ext_new_one" in _REGISTRY
+        assert "ext_new_one" in _EXTERNAL_PLUGINS
+        assert "ext_new_one" in external_plugins()
+
+    def test_duplicate_returns_false(self, clean_registry):
+        a = make_test_adapter("ext_dup")
+        assert _reg_external(a) is True
+        # 同名再注册应失败
+        a2 = make_test_adapter("ext_dup")
+        ok = _reg_external(a2)
+        assert ok is False
+
+    def test_external_plugins_sorted(self, clean_registry):
+        _reg_external(make_test_adapter("zz_plugin"))
+        _reg_external(make_test_adapter("aa_plugin"))
+        plugins = external_plugins()
+        assert plugins.index("aa_plugin") < plugins.index("zz_plugin")
+
+    def test_appears_in_all_adapters(self, clean_registry):
+        a = make_test_adapter("ext_visible")
+        _reg_external(a)
+        assert "ext_visible" in all_adapters()
+        assert all_adapters()["ext_visible"] is a
+
+
+# ── discover_entrypoint_plugins ────────────────────────────
+
+
+class TestDiscoverEntrypointPlugins:
+    def test_no_plugins_installed(self, clean_registry, monkeypatch):
+        # 强制返回空 EntryPoints
+        monkeypatch.setattr(
+            "souwen.plugin.metadata.entry_points",
+            lambda: _FakeEntryPoints([]),
+        )
+        loaded, errors = discover_entrypoint_plugins()
+        assert loaded == []
+        assert errors == []
+
+    def test_valid_entry_point(self, clean_registry, monkeypatch):
+        adapter = make_test_adapter("ep_ok")
+        ep = _FakeEntryPoint("ep_ok", lambda: adapter)
+        monkeypatch.setattr(
+            "souwen.plugin.metadata.entry_points",
+            lambda: _FakeEntryPoints([ep]),
+        )
+        loaded, errors = discover_entrypoint_plugins()
+        assert loaded == ["ep_ok"]
+        assert errors == []
+        assert "ep_ok" in external_plugins()
+
+    def test_entry_point_load_failure(self, clean_registry, monkeypatch):
+        def boom():
+            raise RuntimeError("boom!")
+
+        ep = _FakeEntryPoint("bad_ep", boom)
+        monkeypatch.setattr(
+            "souwen.plugin.metadata.entry_points",
+            lambda: _FakeEntryPoints([ep]),
+        )
+        loaded, errors = discover_entrypoint_plugins()
+        assert loaded == []
+        assert len(errors) == 1
+        assert errors[0]["name"] == "bad_ep"
+        assert "boom" in errors[0]["error"]
+
+    def test_entry_points_call_itself_fails(self, clean_registry, monkeypatch):
+        def fail():
+            raise RuntimeError("metadata broken")
+
+        monkeypatch.setattr("souwen.plugin.metadata.entry_points", fail)
+        loaded, errors = discover_entrypoint_plugins()
+        assert loaded == []
+        assert errors == []  # 整体失败时只 warn，不计入 errors
+
+    def test_invalid_type_returned_collected_as_error(self, clean_registry, monkeypatch):
+        ep = _FakeEntryPoint("bad_type_ep", lambda: 42)
+        monkeypatch.setattr(
+            "souwen.plugin.metadata.entry_points",
+            lambda: _FakeEntryPoints([ep]),
+        )
+        loaded, errors = discover_entrypoint_plugins()
+        assert loaded == []
+        assert len(errors) == 1
+        assert errors[0]["name"] == "bad_type_ep"
+
+    def test_duplicate_with_builtin_logged_not_error(self, clean_registry, monkeypatch):
+        # 与已有内置源同名 → _reg_external 返回 False，不计入 loaded，也不计 errors
+        ep = _FakeEntryPoint("builtin", lambda: make_test_adapter("builtin"))
+        monkeypatch.setattr(
+            "souwen.plugin.metadata.entry_points",
+            lambda: _FakeEntryPoints([ep]),
+        )
+        loaded, errors = discover_entrypoint_plugins()
+        assert "builtin" not in loaded
+        assert errors == []
+
+
+# ── load_config_plugins ────────────────────────────────────
+
+
+class TestLoadConfigPlugins:
+    def test_valid_path(self, clean_registry, monkeypatch):
+        # 暴露一个 adapter 工厂以便 _resolve_dotted_path 能 import
+        adapter = make_test_adapter("cfg_ok")
+        import souwen.plugin as plugin_mod
+
+        monkeypatch.setattr(plugin_mod, "_test_factory", lambda: adapter, raising=False)
+        loaded, errors = load_config_plugins(["souwen.plugin:_test_factory"])
+        assert loaded == ["cfg_ok"]
+        assert errors == []
+
+    def test_invalid_path_format(self, clean_registry):
+        loaded, errors = load_config_plugins(["no_colon_here"])
+        assert loaded == []
+        assert len(errors) == 1
+        assert errors[0]["name"] == "no_colon_here"
+
+    def test_nonexistent_module(self, clean_registry):
+        loaded, errors = load_config_plugins(["souwen.nonexistent_qqq:foo"])
+        assert loaded == []
+        assert len(errors) == 1
+        assert "souwen.nonexistent_qqq:foo" == errors[0]["name"]
+
+    def test_empty_list(self, clean_registry):
+        loaded, errors = load_config_plugins([])
+        assert (loaded, errors) == ([], [])
+
+    def test_none_handled(self, clean_registry):
+        loaded, errors = load_config_plugins(None)  # type: ignore[arg-type]
+        assert (loaded, errors) == ([], [])
+
+    def test_skips_blank_and_non_str(self, clean_registry):
+        loaded, errors = load_config_plugins(["", "  ", None])  # type: ignore[list-item]
+        assert loaded == []
+        assert errors == []
+
+
+# ── load_plugins ───────────────────────────────────────────
+
+
+class TestLoadPlugins:
+    def test_no_config_only_entry_points(self, clean_registry, monkeypatch):
+        monkeypatch.setattr(
+            "souwen.plugin.metadata.entry_points",
+            lambda: _FakeEntryPoints([]),
+        )
+        result = load_plugins(None)
+        assert result == {"loaded": [], "errors": []}
+
+    def test_with_config_plugins(self, clean_registry, monkeypatch):
+        monkeypatch.setattr(
+            "souwen.plugin.metadata.entry_points",
+            lambda: _FakeEntryPoints([]),
+        )
+        adapter = make_test_adapter("cfg_via_load")
+        import souwen.plugin as plugin_mod
+
+        monkeypatch.setattr(plugin_mod, "_test_load_factory", lambda: adapter, raising=False)
+
+        class FakeConfig:
+            plugins = ["souwen.plugin:_test_load_factory"]
+
+        result = load_plugins(FakeConfig())
+        assert "cfg_via_load" in result["loaded"]
+        assert result["errors"] == []
+
+    def test_errors_collected_not_raised(self, clean_registry, monkeypatch):
+        monkeypatch.setattr(
+            "souwen.plugin.metadata.entry_points",
+            lambda: _FakeEntryPoints([]),
+        )
+
+        class FakeConfig:
+            plugins = ["bogus:path", "souwen.no_such_module:x"]
+
+        result = load_plugins(FakeConfig())
+        assert result["loaded"] == []
+        assert len(result["errors"]) == 2
+
+    def test_config_without_plugins_attr(self, clean_registry, monkeypatch):
+        monkeypatch.setattr(
+            "souwen.plugin.metadata.entry_points",
+            lambda: _FakeEntryPoints([]),
+        )
+
+        class FakeConfig:
+            pass
+
+        result = load_plugins(FakeConfig())
+        assert result == {"loaded": [], "errors": []}
+
+    def test_entry_point_discovery_total_failure(self, clean_registry, monkeypatch):
+        # discover_entrypoint_plugins 抛异常时被 load_plugins 兜底
+        def boom(*_a: Any, **_kw: Any):
+            raise RuntimeError("ep system down")
+
+        monkeypatch.setattr("souwen.plugin.discover_entrypoint_plugins", boom)
+        result = load_plugins(None)
+        assert result["loaded"] == []
+        assert len(result["errors"]) == 1
+        assert "ep system down" in result["errors"][0]["error"]
+
+
+# ── 集成 / 状态清理 ────────────────────────────────────────
+
+
+class TestPluginIntegration:
+    def test_register_and_appear_in_views(self, clean_registry):
+        a = make_test_adapter("integration_one")
+        assert _reg_external(a) is True
+        assert "integration_one" in all_adapters()
+        assert "integration_one" in external_plugins()
+
+    def test_reset_registry_clears_external_plugins(self, clean_registry):
+        _reg_external(make_test_adapter("will_be_cleared"))
+        assert "will_be_cleared" in _EXTERNAL_PLUGINS
+        _reset_registry()
+        assert _EXTERNAL_PLUGINS == set()
+        assert _REGISTRY == {}
+        # clean_registry fixture 会在 yield 后恢复


### PR DESCRIPTION
## 概述
为 SouWen 新增插件系统，允许外部包（如 SuperWeb2PDF）以外挂方式集成，无需复制源代码。

## 主要变更

### 插件基础设施
- `src/souwen/plugin.py` — 基于 setuptools entry_points 的插件发现与加载
- 支持双模式：运行时 `pip install <plugin>` 或捆绑 `pip install "souwen[web2pdf]"`
- 配置支持：`plugins` 字段 + `SOUWEN_PLUGINS` 环境变量

### Fetch 分发重构
- `web/fetch.py` 从 20+ if/elif 硬编码重构为 handler 注册表驱动
- 外部插件可通过 `register_fetch_handler()` 注册自定义 provider

### Registry 扩展
- `_reg_external()` 支持外部插件注册（冲突时 warn+skip）
- 插件在 registry import 时自动加载

### 文档
- `docs/plugin-integration-spec.md` — 完整的插件对接规范
- `examples/minimal-plugin/` — 无依赖的回显插件模板
- 更新 CHANGELOG、architecture、README

### CI
- 新增 `plugin-test` job（含 superweb2pdf 软安装验证）

## 测试
- 859 passed, 2 skipped
- 新增 46 个插件相关测试（test_plugin.py + test_fetch_handlers.py）

## 关联 PR
- SuperWeb2PDF 侧：BlueSkyXN/SuperWeb2PDF#3