### PR TITLE
feat(warp): 动态组件管理与非阻塞启动

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - 新增前端 WarpPage 专属管理页面（souwen-nebula 皮肤）
 - 新增 CLI `souwen warp` 命令组：status / enable / disable / modes / register / test
 - 新增 API 端点：`/warp/modes`、`/warp/register`、`/warp/test`、`/warp/config`
+- 新增 WARP 组件管理卡片：展示 usque / wireproxy / wgcf 安装来源与版本，并支持一键安装
 - Dockerfile 预装 usque v3.0.0 二进制
 
 ### Behavior

--- a/cloud/hfs/Dockerfile
+++ b/cloud/hfs/Dockerfile
@@ -15,6 +15,7 @@ ARG SOUWEN_REPO=https://github.com/BlueSkyXN/SouWen.git
 ARG SOUWEN_REF=main
 ARG WGCF_VERSION=2.2.30
 ARG WIREPROXY_VERSION=1.1.2
+ARG USQUE_VERSION=3.0.0
 
 ENV PORT=49265 \
     PYTHONUNBUFFERED=1 \
@@ -27,14 +28,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && echo "${TZ}" > /etc/timezone \
     && rm -rf /var/lib/apt/lists/*
 
-# 预装 WARP 组件 (wireproxy 用户态 WireGuard + wgcf 注册工具)
+# 预装 WARP 组件 (wireproxy + wgcf + usque)
 RUN ARCH=$(dpkg --print-architecture) && \
     curl -fsSL -o /usr/local/bin/wgcf \
         "https://github.com/ViRb3/wgcf/releases/download/v${WGCF_VERSION}/wgcf_${WGCF_VERSION}_linux_${ARCH}" && \
     chmod +x /usr/local/bin/wgcf && \
     curl -fsSL "https://github.com/pufferffish/wireproxy/releases/download/v${WIREPROXY_VERSION}/wireproxy_linux_${ARCH}.tar.gz" \
         | tar xz -C /usr/local/bin/ wireproxy && \
-    chmod +x /usr/local/bin/wireproxy
+    chmod +x /usr/local/bin/wireproxy && \
+    curl -fsSL "https://github.com/Diniboy1123/usque/releases/download/v${USQUE_VERSION}/usque_${USQUE_VERSION}_linux_${ARCH}.zip" \
+        | python -c "import io, sys, zipfile; zipfile.ZipFile(io.BytesIO(sys.stdin.buffer.read())).extract('usque', '/usr/local/bin')" && \
+    chmod +x /usr/local/bin/usque
 
 WORKDIR /app
 

--- a/cloud/hfs/entrypoint.sh
+++ b/cloud/hfs/entrypoint.sh
@@ -13,9 +13,22 @@ echo "  PYTHON:   $(python --version 2>&1)"
 echo "  SOUWEN:   $(python -c 'import souwen; print(souwen.__version__)' 2>/dev/null || echo 'unknown')"
 echo "=========================================="
 
-# ----- WARP 代理初始化 (在所有 Python 代码之前) -----
-if [ "${WARP_ENABLED:-0}" = "1" ] && [ -f /usr/local/bin/warp-init.sh ]; then
-    . /usr/local/bin/warp-init.sh
+# ----- Runtime bin 目录 (WARP 组件动态安装目录) -----
+RUNTIME_BIN="${WARP_RUNTIME_BIN_DIR:-/app/data/bin}"
+if [ -d "$RUNTIME_BIN" ]; then
+    export PATH="${RUNTIME_BIN}:${PATH}"
+fi
+
+# ----- WARP 代理初始化 -----
+# WARP_ENTRYPOINT_INIT=1 时在 entrypoint 同步初始化 (旧行为, 阻塞启动)
+# WARP_ENTRYPOINT_INIT=0 (默认) 跳过, 由 Python WarpManager 后台异步启动
+if [ "${WARP_ENABLED:-0}" = "1" ]; then
+    if [ "${WARP_ENTRYPOINT_INIT:-0}" = "1" ] && [ -f /usr/local/bin/warp-init.sh ]; then
+        echo "==> [WARP] entrypoint 同步初始化 (WARP_ENTRYPOINT_INIT=1)"
+        . /usr/local/bin/warp-init.sh
+    else
+        echo "==> [WARP] 已启用, 将由 Python WarpManager 后台启动"
+    fi
 fi
 
 # ----- 配置注入 -----

--- a/cloud/modelscope/Dockerfile
+++ b/cloud/modelscope/Dockerfile
@@ -15,6 +15,7 @@ ARG SOUWEN_REPO=https://github.com/BlueSkyXN/SouWen.git
 ARG SOUWEN_REF=main
 ARG WGCF_VERSION=2.2.30
 ARG WIREPROXY_VERSION=1.1.2
+ARG USQUE_VERSION=3.0.0
 ARG GH_PROXY=""
 
 ENV PORT=7860 \
@@ -24,15 +25,19 @@ ENV PORT=7860 \
 
 WORKDIR /home/user/app
 
-# 预装 WARP 组件 (wireproxy 用户态 WireGuard + wgcf 注册工具)
+# 预装 WARP 组件 (wireproxy + wgcf + usque)
 RUN ARCH=$(dpkg --print-architecture 2>/dev/null || (uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')) && \
     WGCF_URL="https://github.com/ViRb3/wgcf/releases/download/v${WGCF_VERSION}/wgcf_${WGCF_VERSION}_linux_${ARCH}" && \
     WP_URL="https://github.com/pufferffish/wireproxy/releases/download/v${WIREPROXY_VERSION}/wireproxy_linux_${ARCH}.tar.gz" && \
-    if [ -n "${GH_PROXY}" ]; then WGCF_URL="${GH_PROXY}/${WGCF_URL}"; WP_URL="${GH_PROXY}/${WP_URL}"; fi && \
+    USQUE_URL="https://github.com/Diniboy1123/usque/releases/download/v${USQUE_VERSION}/usque_${USQUE_VERSION}_linux_${ARCH}.zip" && \
+    if [ -n "${GH_PROXY}" ]; then WGCF_URL="${GH_PROXY}/${WGCF_URL}"; WP_URL="${GH_PROXY}/${WP_URL}"; USQUE_URL="${GH_PROXY}/${USQUE_URL}"; fi && \
     curl -fsSL -o /usr/local/bin/wgcf "${WGCF_URL}" && \
     chmod +x /usr/local/bin/wgcf && \
     curl -fsSL "${WP_URL}" | tar xz -C /usr/local/bin/ wireproxy && \
-    chmod +x /usr/local/bin/wireproxy
+    chmod +x /usr/local/bin/wireproxy && \
+    curl -fsSL "${USQUE_URL}" \
+        | python -c "import io, sys, zipfile; zipfile.ZipFile(io.BytesIO(sys.stdin.buffer.read())).extract('usque', '/usr/local/bin')" && \
+    chmod +x /usr/local/bin/usque
 
 RUN git clone --depth 1 --branch "${SOUWEN_REF}" "${SOUWEN_REPO}" .
 

--- a/cloud/modelscope/entrypoint.sh
+++ b/cloud/modelscope/entrypoint.sh
@@ -11,9 +11,22 @@ echo "  PYTHON:   $(python --version 2>&1)"
 echo "  SOUWEN:   $(python -c 'import souwen; print(souwen.__version__)' 2>/dev/null || echo 'unknown')"
 echo "=========================================="
 
-# ----- WARP 代理初始化 (在所有 Python 代码之前) -----
-if [ "${WARP_ENABLED:-0}" = "1" ] && [ -f /usr/local/bin/warp-init.sh ]; then
-    . /usr/local/bin/warp-init.sh
+# ----- Runtime bin 目录 (WARP 组件动态安装目录) -----
+RUNTIME_BIN="${WARP_RUNTIME_BIN_DIR:-/app/data/bin}"
+if [ -d "$RUNTIME_BIN" ]; then
+    export PATH="${RUNTIME_BIN}:${PATH}"
+fi
+
+# ----- WARP 代理初始化 -----
+# WARP_ENTRYPOINT_INIT=1 时在 entrypoint 同步初始化 (旧行为, 阻塞启动)
+# WARP_ENTRYPOINT_INIT=0 (默认) 跳过, 由 Python WarpManager 后台异步启动
+if [ "${WARP_ENABLED:-0}" = "1" ]; then
+    if [ "${WARP_ENTRYPOINT_INIT:-0}" = "1" ] && [ -f /usr/local/bin/warp-init.sh ]; then
+        echo "==> [WARP] entrypoint 同步初始化 (WARP_ENTRYPOINT_INIT=1)"
+        . /usr/local/bin/warp-init.sh
+    else
+        echo "==> [WARP] 已启用, 将由 Python WarpManager 后台启动"
+    fi
 fi
 
 # ----- 配置注入 -----

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,10 +16,22 @@ echo "  PYTHON:   $(python --version 2>&1)"
 echo "  SOUWEN:   $(python -c 'import souwen; print(souwen.__version__)' 2>/dev/null || echo 'unknown')"
 echo "=========================================="
 
+# ----- Runtime bin 目录 (WARP 组件动态安装目录) -----
+RUNTIME_BIN="${WARP_RUNTIME_BIN_DIR:-/app/data/bin}"
+if [ -d "$RUNTIME_BIN" ]; then
+    export PATH="${RUNTIME_BIN}:${PATH}"
+fi
+
 # ===== WARP 代理初始化 =====
-# 在所有 Python 代码之前执行，建立网络代理（如启用）
-if [ "${WARP_ENABLED:-0}" = "1" ] && [ -f /usr/local/bin/warp-init.sh ]; then
-    . /usr/local/bin/warp-init.sh
+# WARP_ENTRYPOINT_INIT=1 时在 entrypoint 同步初始化 (旧行为, 阻塞启动)
+# WARP_ENTRYPOINT_INIT=0 (默认) 跳过, 由 Python WarpManager 后台异步启动
+if [ "${WARP_ENABLED:-0}" = "1" ]; then
+    if [ "${WARP_ENTRYPOINT_INIT:-0}" = "1" ] && [ -f /usr/local/bin/warp-init.sh ]; then
+        echo "==> [WARP] entrypoint 同步初始化 (WARP_ENTRYPOINT_INIT=1)"
+        . /usr/local/bin/warp-init.sh
+    else
+        echo "==> [WARP] 已启用, 将由 Python WarpManager 后台启动"
+    fi
 fi
 
 # ===== 配置注入 =====

--- a/panel/src/core/services/index.ts
+++ b/panel/src/core/services/index.ts
@@ -45,6 +45,8 @@ import type {
   WarpModesResponse,
   WarpTestResult,
   WarpConfigResponse,
+  WarpComponentsResponse,
+  WarpInstallResult,
   HttpBackendResponse,
   SourceChannelConfig,
   YouTubeTrendingResponse,
@@ -107,6 +109,10 @@ export interface ApiService {
   registerWarp(backend?: string): Promise<WarpActionResult>
   testWarp(): Promise<WarpTestResult>
   getWarpConfig(): Promise<WarpConfigResponse>
+  getWarpComponents(): Promise<WarpComponentsResponse>
+  installWarpComponent(component: string, version?: string): Promise<WarpInstallResult>
+  uninstallWarpComponent(component: string): Promise<WarpActionResult>
+  switchWarpMode(mode: string, socksPort?: number, endpoint?: string, httpPort?: number): Promise<WarpActionResult>
 
   // === http-backend ===
   getHttpBackend(): Promise<HttpBackendResponse>

--- a/panel/src/core/services/warp.ts
+++ b/panel/src/core/services/warp.ts
@@ -3,7 +3,7 @@
  */
 
 import type { ApiServiceBase } from './_base'
-import type { WarpStatus, WarpActionResult, WarpModesResponse, WarpTestResult, WarpConfigResponse } from '../types'
+import type { WarpStatus, WarpActionResult, WarpModesResponse, WarpTestResult, WarpConfigResponse, WarpComponentsResponse, WarpInstallResult } from '../types'
 
 export interface WarpApi {
   getWarpStatus(): Promise<WarpStatus>
@@ -13,6 +13,10 @@ export interface WarpApi {
   registerWarp(backend?: string): Promise<WarpActionResult>
   testWarp(): Promise<WarpTestResult>
   getWarpConfig(): Promise<WarpConfigResponse>
+  getWarpComponents(): Promise<WarpComponentsResponse>
+  installWarpComponent(component: string, version?: string): Promise<WarpInstallResult>
+  uninstallWarpComponent(component: string): Promise<WarpActionResult>
+  switchWarpMode(mode: string, socksPort?: number, endpoint?: string, httpPort?: number): Promise<WarpActionResult>
 }
 
 export const warpMethods = {
@@ -65,5 +69,40 @@ export const warpMethods = {
   /** 获取 WARP 配置 */
   async getWarpConfig(this: ApiServiceBase): Promise<WarpConfigResponse> {
     return this.request<WarpConfigResponse>('/api/v1/admin/warp/config', { headers: this.headers() })
+  },
+
+  /** 获取 WARP 组件安装状态 */
+  async getWarpComponents(this: ApiServiceBase): Promise<WarpComponentsResponse> {
+    return this.request<WarpComponentsResponse>('/api/v1/admin/warp/components', { headers: this.headers() })
+  },
+
+  /** 安装 WARP 组件 */
+  async installWarpComponent(this: ApiServiceBase, component: string, version?: string): Promise<WarpInstallResult> {
+    const params = new URLSearchParams({ component })
+    if (version) params.set('version', version)
+    return this.request<WarpInstallResult>(`/api/v1/admin/warp/components/install?${params}`, {
+      method: 'POST',
+      headers: this.headers(),
+    })
+  },
+
+  /** 卸载 WARP 组件 */
+  async uninstallWarpComponent(this: ApiServiceBase, component: string): Promise<WarpActionResult> {
+    const params = new URLSearchParams({ component })
+    return this.request<WarpActionResult>(`/api/v1/admin/warp/components/uninstall?${params}`, {
+      method: 'POST',
+      headers: this.headers(),
+    })
+  },
+
+  /** 切换 WARP 模式 */
+  async switchWarpMode(this: ApiServiceBase, mode: string, socksPort = 1080, endpoint?: string, httpPort?: number): Promise<WarpActionResult> {
+    const params = new URLSearchParams({ mode, socks_port: String(socksPort) })
+    if (endpoint) params.set('endpoint', endpoint)
+    if (httpPort !== undefined) params.set('http_port', String(httpPort))
+    return this.request<WarpActionResult>(`/api/v1/admin/warp/switch?${params}`, {
+      method: 'POST',
+      headers: this.headers(),
+    })
   },
 }

--- a/panel/src/core/types/api.ts
+++ b/panel/src/core/types/api.ts
@@ -208,6 +208,29 @@ export interface WarpActionResult {
 }
 
 /**
+ * WARP 组件安装状态
+ */
+export interface WarpComponentInfo {
+  name: string
+  installed: boolean
+  version: string | null
+  path: string | null
+  system_path: string | null
+  source: 'runtime' | 'system' | 'not_installed'
+}
+
+export interface WarpComponentsResponse {
+  components: WarpComponentInfo[]
+}
+
+export interface WarpInstallResult {
+  ok: boolean
+  component: string
+  version: string
+  path: string
+}
+
+/**
  * HTTP 代理后端配置
  */
 export interface HttpBackendResponse {

--- a/panel/src/skins/apple/pages/WarpPage.tsx
+++ b/panel/src/skins/apple/pages/WarpPage.tsx
@@ -14,7 +14,9 @@ import {
   Container,
   Globe,
   Loader2,
+  Download,
   Network,
+  Package,
   Play,
   Power,
   RefreshCw,
@@ -32,7 +34,7 @@ import { api } from '@core/services/api'
 import { formatError } from '@core/lib/errors'
 import { staggerContainer, staggerItem } from '@core/lib/animations'
 import { useNotificationStore } from '@core/stores/notificationStore'
-import type { WarpConfigResponse, WarpModeInfo, WarpStatus, WarpTestResult } from '@core/types'
+import type { WarpComponentInfo, WarpConfigResponse, WarpModeInfo, WarpStatus, WarpTestResult } from '@core/types'
 
 const MODE_OPTIONS = [
   { id: 'auto', label: '自动选择' },
@@ -197,6 +199,17 @@ export function WarpPage() {
   const [socksPort, setSocksPort] = useState('1080')
   const [httpPort, setHttpPort] = useState('0')
   const [endpoint, setEndpoint] = useState('')
+  const [components, setComponents] = useState<WarpComponentInfo[]>([])
+  const [installingComponent, setInstallingComponent] = useState<string | null>(null)
+
+  const fetchComponents = useCallback(async () => {
+    try {
+      const res = await api.getWarpComponents()
+      setComponents(res.components)
+    } catch {
+      // ignore component status failures
+    }
+  }, [])
 
   const loadData = useCallback(async (silent = false) => {
     if (silent) setRefreshing(true)
@@ -237,12 +250,25 @@ export function WarpPage() {
     }
   }, [addToast])
 
-  useEffect(() => { void loadData() }, [loadData])
+  useEffect(() => { void loadData(); void fetchComponents() }, [fetchComponents, loadData])
 
   const visibleModes = useMemo(() => {
     const modeMap = new Map(modes.map((item) => [item.id, item]))
     return MODE_OPTIONS.filter((item) => item.id !== 'auto').map((item) => modeMap.get(item.id) || fallbackMode(item.id, warp))
   }, [modes, warp])
+
+  const handleInstallComponent = useCallback(async (name: string) => {
+    setInstallingComponent(name)
+    try {
+      await api.installWarpComponent(name)
+      addToast('success', `${name} 安装成功`)
+      await Promise.all([fetchComponents(), loadData(true)])
+    } catch (err) {
+      addToast('error', `${name} 安装失败：${formatError(err)}`)
+    } finally {
+      setInstallingComponent(null)
+    }
+  }, [addToast, fetchComponents, loadData])
 
   const handleEnable = useCallback(async () => {
     setActing(true)
@@ -441,6 +467,42 @@ export function WarpPage() {
             <StatusField label="当前代理类型" value={warp?.proxy_type || '—'} />
           </div>
         </div>
+      </m.section>
+
+      <m.section style={styles.card} variants={staggerItem}>
+        <CardHeader icon={<Package size={19} />} title="WARP 组件" badge={`${components.filter((comp) => comp.installed).length}/${components.length || 3} 已安装`} badgeColor={theme.success} />
+        {components.length === 0 ? (
+          <Notice icon={<AlertTriangle size={15} />} tone="warning">组件状态暂不可用。</Notice>
+        ) : (
+          <div style={styles.componentList}>
+            {components.map((comp) => (
+              <div key={comp.name} style={styles.componentRow}>
+                <div style={styles.componentInfo}>
+                  <span style={styles.componentName}>{comp.name}</span>
+                  <span style={styles.componentStatus}>
+                    {comp.source === 'system' && '系统预装'}
+                    {comp.source === 'runtime' && (comp.version ? `v${comp.version}` : '已安装')}
+                    {comp.source === 'not_installed' && '未安装'}
+                  </span>
+                </div>
+                <div style={styles.componentActions}>
+                  {comp.source === 'not_installed' && (
+                    <button
+                      style={styles.installButton}
+                      onClick={() => void handleInstallComponent(comp.name)}
+                      disabled={installingComponent !== null}
+                    >
+                      {installingComponent === comp.name ? <Loader2 size={15} /> : <Download size={15} />}
+                      安装
+                    </button>
+                  )}
+                  {comp.source === 'runtime' && <span style={styles.installedMark}>✓ 已安装</span>}
+                  {comp.source === 'system' && <span style={styles.preinstalledMark}>✓ 预装</span>}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
       </m.section>
     </m.div>
   )
@@ -749,6 +811,72 @@ function makeStyles(): Record<string, CSSProperties> {
       display: 'grid',
       gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))',
       gap: 10,
+    },
+
+    componentList: {
+      display: 'grid',
+      gap: 12,
+    },
+    componentRow: {
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      gap: 14,
+      padding: '13px 14px',
+      background: theme.fieldBg,
+      border: `1px solid ${theme.fieldBorder}`,
+      borderRadius: theme.fieldRadius,
+      flexWrap: 'wrap',
+    },
+    componentInfo: {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 6,
+      minWidth: 0,
+    },
+    componentName: {
+      color: theme.text,
+      fontSize: 15,
+      fontWeight: 800,
+      fontFamily: 'monospace',
+    },
+    componentStatus: {
+      color: theme.muted,
+      fontSize: 12,
+      fontWeight: 700,
+    },
+    componentActions: {
+      display: 'flex',
+      alignItems: 'center',
+      gap: 10,
+      marginLeft: 'auto',
+    },
+    installButton: {
+      ...buttonBase(),
+      minHeight: 34,
+      padding: '0 12px',
+      fontSize: 13,
+      color: theme.primaryButtonText,
+      background: theme.primaryButtonBg,
+      border: `1px solid ${theme.primaryButtonBorder}`,
+    },
+    installedMark: {
+      color: theme.success,
+      background: theme.successSoft,
+      border: `1px solid ${theme.successBorder}`,
+      borderRadius: theme.badgeRadius,
+      padding: '5px 9px',
+      fontSize: 12,
+      fontWeight: 800,
+    },
+    preinstalledMark: {
+      color: theme.info,
+      background: theme.surfaceMuted,
+      border: `1px solid ${theme.border}`,
+      borderRadius: theme.badgeRadius,
+      padding: '5px 9px',
+      fontSize: 12,
+      fontWeight: 800,
     },
   }
 }

--- a/panel/src/skins/carbon/pages/WarpPage.tsx
+++ b/panel/src/skins/carbon/pages/WarpPage.tsx
@@ -14,7 +14,9 @@ import {
   Container,
   Globe,
   Loader2,
+  Download,
   Network,
+  Package,
   Play,
   Power,
   RefreshCw,
@@ -32,7 +34,7 @@ import { api } from '@core/services/api'
 import { formatError } from '@core/lib/errors'
 import { staggerContainer, staggerItem } from '@core/lib/animations'
 import { useNotificationStore } from '@core/stores/notificationStore'
-import type { WarpConfigResponse, WarpModeInfo, WarpStatus, WarpTestResult } from '@core/types'
+import type { WarpComponentInfo, WarpConfigResponse, WarpModeInfo, WarpStatus, WarpTestResult } from '@core/types'
 
 const MODE_OPTIONS = [
   { id: 'auto', label: '自动选择' },
@@ -197,6 +199,17 @@ export function WarpPage() {
   const [socksPort, setSocksPort] = useState('1080')
   const [httpPort, setHttpPort] = useState('0')
   const [endpoint, setEndpoint] = useState('')
+  const [components, setComponents] = useState<WarpComponentInfo[]>([])
+  const [installingComponent, setInstallingComponent] = useState<string | null>(null)
+
+  const fetchComponents = useCallback(async () => {
+    try {
+      const res = await api.getWarpComponents()
+      setComponents(res.components)
+    } catch {
+      // ignore component status failures
+    }
+  }, [])
 
   const loadData = useCallback(async (silent = false) => {
     if (silent) setRefreshing(true)
@@ -237,12 +250,25 @@ export function WarpPage() {
     }
   }, [addToast])
 
-  useEffect(() => { void loadData() }, [loadData])
+  useEffect(() => { void loadData(); void fetchComponents() }, [fetchComponents, loadData])
 
   const visibleModes = useMemo(() => {
     const modeMap = new Map(modes.map((item) => [item.id, item]))
     return MODE_OPTIONS.filter((item) => item.id !== 'auto').map((item) => modeMap.get(item.id) || fallbackMode(item.id, warp))
   }, [modes, warp])
+
+  const handleInstallComponent = useCallback(async (name: string) => {
+    setInstallingComponent(name)
+    try {
+      await api.installWarpComponent(name)
+      addToast('success', `${name} 安装成功`)
+      await Promise.all([fetchComponents(), loadData(true)])
+    } catch (err) {
+      addToast('error', `${name} 安装失败：${formatError(err)}`)
+    } finally {
+      setInstallingComponent(null)
+    }
+  }, [addToast, fetchComponents, loadData])
 
   const handleEnable = useCallback(async () => {
     setActing(true)
@@ -441,6 +467,42 @@ export function WarpPage() {
             <StatusField label="当前代理类型" value={warp?.proxy_type || '—'} />
           </div>
         </div>
+      </m.section>
+
+      <m.section style={styles.card} variants={staggerItem}>
+        <CardHeader icon={<Package size={19} />} title="WARP 组件" badge={`${components.filter((comp) => comp.installed).length}/${components.length || 3} 已安装`} badgeColor={theme.success} />
+        {components.length === 0 ? (
+          <Notice icon={<AlertTriangle size={15} />} tone="warning">组件状态暂不可用。</Notice>
+        ) : (
+          <div style={styles.componentList}>
+            {components.map((comp) => (
+              <div key={comp.name} style={styles.componentRow}>
+                <div style={styles.componentInfo}>
+                  <span style={styles.componentName}>{comp.name}</span>
+                  <span style={styles.componentStatus}>
+                    {comp.source === 'system' && '系统预装'}
+                    {comp.source === 'runtime' && (comp.version ? `v${comp.version}` : '已安装')}
+                    {comp.source === 'not_installed' && '未安装'}
+                  </span>
+                </div>
+                <div style={styles.componentActions}>
+                  {comp.source === 'not_installed' && (
+                    <button
+                      style={styles.installButton}
+                      onClick={() => void handleInstallComponent(comp.name)}
+                      disabled={installingComponent !== null}
+                    >
+                      {installingComponent === comp.name ? <Loader2 size={15} /> : <Download size={15} />}
+                      安装
+                    </button>
+                  )}
+                  {comp.source === 'runtime' && <span style={styles.installedMark}>✓ 已安装</span>}
+                  {comp.source === 'system' && <span style={styles.preinstalledMark}>✓ 预装</span>}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
       </m.section>
     </m.div>
   )
@@ -749,6 +811,72 @@ function makeStyles(): Record<string, CSSProperties> {
       display: 'grid',
       gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))',
       gap: 10,
+    },
+
+    componentList: {
+      display: 'grid',
+      gap: 12,
+    },
+    componentRow: {
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      gap: 14,
+      padding: '13px 14px',
+      background: theme.fieldBg,
+      border: `1px solid ${theme.fieldBorder}`,
+      borderRadius: theme.fieldRadius,
+      flexWrap: 'wrap',
+    },
+    componentInfo: {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 6,
+      minWidth: 0,
+    },
+    componentName: {
+      color: theme.text,
+      fontSize: 15,
+      fontWeight: 800,
+      fontFamily: 'monospace',
+    },
+    componentStatus: {
+      color: theme.muted,
+      fontSize: 12,
+      fontWeight: 700,
+    },
+    componentActions: {
+      display: 'flex',
+      alignItems: 'center',
+      gap: 10,
+      marginLeft: 'auto',
+    },
+    installButton: {
+      ...buttonBase(),
+      minHeight: 34,
+      padding: '0 12px',
+      fontSize: 13,
+      color: theme.primaryButtonText,
+      background: theme.primaryButtonBg,
+      border: `1px solid ${theme.primaryButtonBorder}`,
+    },
+    installedMark: {
+      color: theme.success,
+      background: theme.successSoft,
+      border: `1px solid ${theme.successBorder}`,
+      borderRadius: theme.badgeRadius,
+      padding: '5px 9px',
+      fontSize: 12,
+      fontWeight: 800,
+    },
+    preinstalledMark: {
+      color: theme.info,
+      background: theme.surfaceMuted,
+      border: `1px solid ${theme.border}`,
+      borderRadius: theme.badgeRadius,
+      padding: '5px 9px',
+      fontSize: 12,
+      fontWeight: 800,
     },
   }
 }

--- a/panel/src/skins/ios/pages/WarpPage.tsx
+++ b/panel/src/skins/ios/pages/WarpPage.tsx
@@ -14,7 +14,9 @@ import {
   Container,
   Globe,
   Loader2,
+  Download,
   Network,
+  Package,
   Play,
   Power,
   RefreshCw,
@@ -32,7 +34,7 @@ import { api } from '@core/services/api'
 import { formatError } from '@core/lib/errors'
 import { staggerContainer, staggerItem } from '@core/lib/animations'
 import { useNotificationStore } from '@core/stores/notificationStore'
-import type { WarpConfigResponse, WarpModeInfo, WarpStatus, WarpTestResult } from '@core/types'
+import type { WarpComponentInfo, WarpConfigResponse, WarpModeInfo, WarpStatus, WarpTestResult } from '@core/types'
 
 const MODE_OPTIONS = [
   { id: 'auto', label: '自动选择' },
@@ -197,6 +199,17 @@ export function WarpPage() {
   const [socksPort, setSocksPort] = useState('1080')
   const [httpPort, setHttpPort] = useState('0')
   const [endpoint, setEndpoint] = useState('')
+  const [components, setComponents] = useState<WarpComponentInfo[]>([])
+  const [installingComponent, setInstallingComponent] = useState<string | null>(null)
+
+  const fetchComponents = useCallback(async () => {
+    try {
+      const res = await api.getWarpComponents()
+      setComponents(res.components)
+    } catch {
+      // ignore component status failures
+    }
+  }, [])
 
   const loadData = useCallback(async (silent = false) => {
     if (silent) setRefreshing(true)
@@ -237,12 +250,25 @@ export function WarpPage() {
     }
   }, [addToast])
 
-  useEffect(() => { void loadData() }, [loadData])
+  useEffect(() => { void loadData(); void fetchComponents() }, [fetchComponents, loadData])
 
   const visibleModes = useMemo(() => {
     const modeMap = new Map(modes.map((item) => [item.id, item]))
     return MODE_OPTIONS.filter((item) => item.id !== 'auto').map((item) => modeMap.get(item.id) || fallbackMode(item.id, warp))
   }, [modes, warp])
+
+  const handleInstallComponent = useCallback(async (name: string) => {
+    setInstallingComponent(name)
+    try {
+      await api.installWarpComponent(name)
+      addToast('success', `${name} 安装成功`)
+      await Promise.all([fetchComponents(), loadData(true)])
+    } catch (err) {
+      addToast('error', `${name} 安装失败：${formatError(err)}`)
+    } finally {
+      setInstallingComponent(null)
+    }
+  }, [addToast, fetchComponents, loadData])
 
   const handleEnable = useCallback(async () => {
     setActing(true)
@@ -441,6 +467,42 @@ export function WarpPage() {
             <StatusField label="当前代理类型" value={warp?.proxy_type || '—'} />
           </div>
         </div>
+      </m.section>
+
+      <m.section style={styles.card} variants={staggerItem}>
+        <CardHeader icon={<Package size={19} />} title="WARP 组件" badge={`${components.filter((comp) => comp.installed).length}/${components.length || 3} 已安装`} badgeColor={theme.success} />
+        {components.length === 0 ? (
+          <Notice icon={<AlertTriangle size={15} />} tone="warning">组件状态暂不可用。</Notice>
+        ) : (
+          <div style={styles.componentList}>
+            {components.map((comp) => (
+              <div key={comp.name} style={styles.componentRow}>
+                <div style={styles.componentInfo}>
+                  <span style={styles.componentName}>{comp.name}</span>
+                  <span style={styles.componentStatus}>
+                    {comp.source === 'system' && '系统预装'}
+                    {comp.source === 'runtime' && (comp.version ? `v${comp.version}` : '已安装')}
+                    {comp.source === 'not_installed' && '未安装'}
+                  </span>
+                </div>
+                <div style={styles.componentActions}>
+                  {comp.source === 'not_installed' && (
+                    <button
+                      style={styles.installButton}
+                      onClick={() => void handleInstallComponent(comp.name)}
+                      disabled={installingComponent !== null}
+                    >
+                      {installingComponent === comp.name ? <Loader2 size={15} /> : <Download size={15} />}
+                      安装
+                    </button>
+                  )}
+                  {comp.source === 'runtime' && <span style={styles.installedMark}>✓ 已安装</span>}
+                  {comp.source === 'system' && <span style={styles.preinstalledMark}>✓ 预装</span>}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
       </m.section>
     </m.div>
   )
@@ -749,6 +811,72 @@ function makeStyles(): Record<string, CSSProperties> {
       display: 'grid',
       gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))',
       gap: 10,
+    },
+
+    componentList: {
+      display: 'grid',
+      gap: 12,
+    },
+    componentRow: {
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      gap: 14,
+      padding: '13px 14px',
+      background: theme.fieldBg,
+      border: `1px solid ${theme.fieldBorder}`,
+      borderRadius: theme.fieldRadius,
+      flexWrap: 'wrap',
+    },
+    componentInfo: {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 6,
+      minWidth: 0,
+    },
+    componentName: {
+      color: theme.text,
+      fontSize: 15,
+      fontWeight: 800,
+      fontFamily: 'monospace',
+    },
+    componentStatus: {
+      color: theme.muted,
+      fontSize: 12,
+      fontWeight: 700,
+    },
+    componentActions: {
+      display: 'flex',
+      alignItems: 'center',
+      gap: 10,
+      marginLeft: 'auto',
+    },
+    installButton: {
+      ...buttonBase(),
+      minHeight: 34,
+      padding: '0 12px',
+      fontSize: 13,
+      color: theme.primaryButtonText,
+      background: theme.primaryButtonBg,
+      border: `1px solid ${theme.primaryButtonBorder}`,
+    },
+    installedMark: {
+      color: theme.success,
+      background: theme.successSoft,
+      border: `1px solid ${theme.successBorder}`,
+      borderRadius: theme.badgeRadius,
+      padding: '5px 9px',
+      fontSize: 12,
+      fontWeight: 800,
+    },
+    preinstalledMark: {
+      color: theme.info,
+      background: theme.surfaceMuted,
+      border: `1px solid ${theme.border}`,
+      borderRadius: theme.badgeRadius,
+      padding: '5px 9px',
+      fontSize: 12,
+      fontWeight: 800,
     },
   }
 }

--- a/panel/src/skins/souwen-google/pages/WarpPage.tsx
+++ b/panel/src/skins/souwen-google/pages/WarpPage.tsx
@@ -14,7 +14,9 @@ import {
   Container,
   Globe,
   Loader2,
+  Download,
   Network,
+  Package,
   Play,
   Power,
   RefreshCw,
@@ -32,7 +34,7 @@ import { api } from '@core/services/api'
 import { formatError } from '@core/lib/errors'
 import { staggerContainer, staggerItem } from '@core/lib/animations'
 import { useNotificationStore } from '@core/stores/notificationStore'
-import type { WarpConfigResponse, WarpModeInfo, WarpStatus, WarpTestResult } from '@core/types'
+import type { WarpComponentInfo, WarpConfigResponse, WarpModeInfo, WarpStatus, WarpTestResult } from '@core/types'
 
 const MODE_OPTIONS = [
   { id: 'auto', label: '自动选择' },
@@ -197,6 +199,17 @@ export function WarpPage() {
   const [socksPort, setSocksPort] = useState('1080')
   const [httpPort, setHttpPort] = useState('0')
   const [endpoint, setEndpoint] = useState('')
+  const [components, setComponents] = useState<WarpComponentInfo[]>([])
+  const [installingComponent, setInstallingComponent] = useState<string | null>(null)
+
+  const fetchComponents = useCallback(async () => {
+    try {
+      const res = await api.getWarpComponents()
+      setComponents(res.components)
+    } catch {
+      // ignore component status failures
+    }
+  }, [])
 
   const loadData = useCallback(async (silent = false) => {
     if (silent) setRefreshing(true)
@@ -237,12 +250,25 @@ export function WarpPage() {
     }
   }, [addToast])
 
-  useEffect(() => { void loadData() }, [loadData])
+  useEffect(() => { void loadData(); void fetchComponents() }, [fetchComponents, loadData])
 
   const visibleModes = useMemo(() => {
     const modeMap = new Map(modes.map((item) => [item.id, item]))
     return MODE_OPTIONS.filter((item) => item.id !== 'auto').map((item) => modeMap.get(item.id) || fallbackMode(item.id, warp))
   }, [modes, warp])
+
+  const handleInstallComponent = useCallback(async (name: string) => {
+    setInstallingComponent(name)
+    try {
+      await api.installWarpComponent(name)
+      addToast('success', `${name} 安装成功`)
+      await Promise.all([fetchComponents(), loadData(true)])
+    } catch (err) {
+      addToast('error', `${name} 安装失败：${formatError(err)}`)
+    } finally {
+      setInstallingComponent(null)
+    }
+  }, [addToast, fetchComponents, loadData])
 
   const handleEnable = useCallback(async () => {
     setActing(true)
@@ -441,6 +467,42 @@ export function WarpPage() {
             <StatusField label="当前代理类型" value={warp?.proxy_type || '—'} />
           </div>
         </div>
+      </m.section>
+
+      <m.section style={styles.card} variants={staggerItem}>
+        <CardHeader icon={<Package size={19} />} title="WARP 组件" badge={`${components.filter((comp) => comp.installed).length}/${components.length || 3} 已安装`} badgeColor={theme.success} />
+        {components.length === 0 ? (
+          <Notice icon={<AlertTriangle size={15} />} tone="warning">组件状态暂不可用。</Notice>
+        ) : (
+          <div style={styles.componentList}>
+            {components.map((comp) => (
+              <div key={comp.name} style={styles.componentRow}>
+                <div style={styles.componentInfo}>
+                  <span style={styles.componentName}>{comp.name}</span>
+                  <span style={styles.componentStatus}>
+                    {comp.source === 'system' && '系统预装'}
+                    {comp.source === 'runtime' && (comp.version ? `v${comp.version}` : '已安装')}
+                    {comp.source === 'not_installed' && '未安装'}
+                  </span>
+                </div>
+                <div style={styles.componentActions}>
+                  {comp.source === 'not_installed' && (
+                    <button
+                      style={styles.installButton}
+                      onClick={() => void handleInstallComponent(comp.name)}
+                      disabled={installingComponent !== null}
+                    >
+                      {installingComponent === comp.name ? <Loader2 size={15} /> : <Download size={15} />}
+                      安装
+                    </button>
+                  )}
+                  {comp.source === 'runtime' && <span style={styles.installedMark}>✓ 已安装</span>}
+                  {comp.source === 'system' && <span style={styles.preinstalledMark}>✓ 预装</span>}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
       </m.section>
     </m.div>
   )
@@ -749,6 +811,72 @@ function makeStyles(): Record<string, CSSProperties> {
       display: 'grid',
       gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))',
       gap: 10,
+    },
+
+    componentList: {
+      display: 'grid',
+      gap: 12,
+    },
+    componentRow: {
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      gap: 14,
+      padding: '13px 14px',
+      background: theme.fieldBg,
+      border: `1px solid ${theme.fieldBorder}`,
+      borderRadius: theme.fieldRadius,
+      flexWrap: 'wrap',
+    },
+    componentInfo: {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 6,
+      minWidth: 0,
+    },
+    componentName: {
+      color: theme.text,
+      fontSize: 15,
+      fontWeight: 800,
+      fontFamily: 'monospace',
+    },
+    componentStatus: {
+      color: theme.muted,
+      fontSize: 12,
+      fontWeight: 700,
+    },
+    componentActions: {
+      display: 'flex',
+      alignItems: 'center',
+      gap: 10,
+      marginLeft: 'auto',
+    },
+    installButton: {
+      ...buttonBase(),
+      minHeight: 34,
+      padding: '0 12px',
+      fontSize: 13,
+      color: theme.primaryButtonText,
+      background: theme.primaryButtonBg,
+      border: `1px solid ${theme.primaryButtonBorder}`,
+    },
+    installedMark: {
+      color: theme.success,
+      background: theme.successSoft,
+      border: `1px solid ${theme.successBorder}`,
+      borderRadius: theme.badgeRadius,
+      padding: '5px 9px',
+      fontSize: 12,
+      fontWeight: 800,
+    },
+    preinstalledMark: {
+      color: theme.info,
+      background: theme.surfaceMuted,
+      border: `1px solid ${theme.border}`,
+      borderRadius: theme.badgeRadius,
+      padding: '5px 9px',
+      fontSize: 12,
+      fontWeight: 800,
     },
   }
 }

--- a/panel/src/skins/souwen-nebula/pages/WarpPage.module.scss
+++ b/panel/src/skins/souwen-nebula/pages/WarpPage.module.scss
@@ -372,6 +372,50 @@
   }
 }
 
+
+.componentsGrid {
+  display: grid;
+  gap: $space-3;
+}
+
+.componentItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $space-3;
+  padding: $space-3 $space-4;
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: $radius-sm;
+  flex-wrap: wrap;
+}
+
+.componentInfo {
+  display: flex;
+  flex-direction: column;
+  gap: $space-1;
+  min-width: 0;
+}
+
+.componentName {
+  font-family: var(--font-mono);
+  font-size: $text-base;
+  font-weight: $font-bold;
+  color: var(--text);
+}
+
+.componentStatus {
+  font-size: $text-xs;
+  color: var(--text-muted);
+}
+
+.componentActions {
+  display: flex;
+  align-items: center;
+  gap: $space-2;
+  margin-left: auto;
+}
+
 .docLink {
   display: inline-flex;
   align-items: center;

--- a/panel/src/skins/souwen-nebula/pages/WarpPage.tsx
+++ b/panel/src/skins/souwen-nebula/pages/WarpPage.tsx
@@ -14,12 +14,14 @@ import {
   CircleDot,
   Cloud,
   Container,
+  Download,
   ExternalLink,
   Globe,
   HelpCircle,
   KeyRound,
   Loader2,
   Network,
+  Package,
   RefreshCw,
   Route,
   Server,
@@ -35,7 +37,7 @@ import { api } from '@core/services/api'
 import { formatError } from '@core/lib/errors'
 import { staggerContainer, staggerItem } from '@core/lib/animations'
 import { useNotificationStore } from '@core/stores/notificationStore'
-import type { WarpConfigResponse, WarpModeInfo, WarpStatus, WarpTestResult } from '@core/types'
+import type { WarpComponentInfo, WarpConfigResponse, WarpModeInfo, WarpStatus, WarpTestResult } from '@core/types'
 import { Badge } from '../components/common/Badge'
 import { Button } from '../components/common/Button'
 import { Card } from '../components/common/Card'
@@ -345,6 +347,56 @@ function WarpAdvancedCard({ config, registering, onRegister }: {
   )
 }
 
+
+function WarpComponentsCard({ components, installingComponent, onInstall }: {
+  components: WarpComponentInfo[]
+  installingComponent: string | null
+  onInstall: (name: string) => Promise<void>
+}) {
+  return (
+    <Card className={styles.sectionCard}>
+      <div className={styles.sectionHeader}>
+        <div className={styles.sectionTitle}><Package size={18} />WARP 组件</div>
+        <Badge color="teal">{components.filter((comp) => comp.installed).length}/{components.length || 3} 已安装</Badge>
+      </div>
+      {components.length === 0 ? (
+        <div className={styles.infoNote}><AlertCircle size={14} />组件状态暂不可用。</div>
+      ) : (
+        <div className={styles.componentsGrid}>
+          {components.map((comp) => (
+            <div key={comp.name} className={styles.componentItem}>
+              <div className={styles.componentInfo}>
+                <span className={styles.componentName}>{comp.name}</span>
+                <span className={styles.componentStatus}>
+                  {comp.source === 'system' && '系统预装'}
+                  {comp.source === 'runtime' && (comp.version ? `v${comp.version}` : '已安装')}
+                  {comp.source === 'not_installed' && '未安装'}
+                </span>
+              </div>
+              <div className={styles.componentActions}>
+                {comp.source === 'not_installed' && (
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    icon={<Download size={14} />}
+                    loading={installingComponent === comp.name}
+                    disabled={installingComponent !== null}
+                    onClick={() => void onInstall(comp.name)}
+                  >
+                    安装
+                  </Button>
+                )}
+                {comp.source === 'runtime' && <Badge color="green">✓ 已安装</Badge>}
+                {comp.source === 'system' && <Badge color="blue">✓ 预装</Badge>}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </Card>
+  )
+}
+
 function WarpEnvironmentCard({ warp, modes }: { warp: WarpStatus | null; modes: WarpModeInfo[] }) {
   const { t } = useTranslation()
   const dockerReady = modes.some((mode) => mode.docker_only && mode.installed)
@@ -378,6 +430,17 @@ export function WarpPage() {
   const [refreshing, setRefreshing] = useState(false)
   const [acting, setActing] = useState(false)
   const [registering, setRegistering] = useState(false)
+  const [components, setComponents] = useState<WarpComponentInfo[]>([])
+  const [installingComponent, setInstallingComponent] = useState<string | null>(null)
+
+  const fetchComponents = useCallback(async () => {
+    try {
+      const res = await api.getWarpComponents()
+      setComponents(res.components)
+    } catch {
+      // ignore component status failures
+    }
+  }, [])
 
   const loadAll = useCallback(async (silent = false) => {
     if (silent) setRefreshing(true)
@@ -399,7 +462,7 @@ export function WarpPage() {
     }
   }, [addToast, t])
 
-  useEffect(() => { void loadAll() }, [loadAll])
+  useEffect(() => { void loadAll(); void fetchComponents() }, [fetchComponents, loadAll])
 
   const handleEnable = useCallback(async (params: { mode: string; socksPort: number; httpPort: number; endpoint?: string }) => {
     setActing(true)
@@ -426,6 +489,19 @@ export function WarpPage() {
       setActing(false)
     }
   }, [addToast, loadAll, t])
+
+  const handleInstallComponent = useCallback(async (name: string) => {
+    setInstallingComponent(name)
+    try {
+      await api.installWarpComponent(name)
+      addToast('success', `${name} 安装成功`)
+      await Promise.all([fetchComponents(), loadAll(true)])
+    } catch (err) {
+      addToast('error', `${name} 安装失败：${formatError(err)}`)
+    } finally {
+      setInstallingComponent(null)
+    }
+  }, [addToast, fetchComponents, loadAll])
 
   const handleRegister = useCallback(async (backend: string) => {
     setRegistering(true)
@@ -468,6 +544,9 @@ export function WarpPage() {
       </m.div>
       <m.div variants={staggerItem}>
         <WarpEnvironmentCard warp={warp} modes={modes} />
+      </m.div>
+      <m.div variants={staggerItem}>
+        <WarpComponentsCard components={components} installingComponent={installingComponent} onInstall={handleInstallComponent} />
       </m.div>
     </m.div>
   )

--- a/src/souwen/server/routes/admin/warp.py
+++ b/src/souwen/server/routes/admin/warp.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit
 
 from fastapi import APIRouter, HTTPException, Query
+from starlette.responses import StreamingResponse
 
 from souwen.server.routes._common import logger
 from souwen.server.schemas import WaybackSaveRequest, WaybackSaveResponse
@@ -246,6 +247,120 @@ async def warp_disable():
     if not result["ok"]:
         raise HTTPException(status_code=400, detail=result["error"])
     return result
+
+
+@router.get("/warp/components")
+async def warp_components():
+    """获取 WARP 组件安装状态列表。"""
+    from souwen.server.warp_installer import WarpInstaller
+
+    installer = WarpInstaller()
+    return {"components": installer.get_components_status()}
+
+
+@router.post("/warp/components/install")
+async def warp_component_install(
+    component: str = Query(..., description="组件名: usque | wireproxy | wgcf"),
+    version: str | None = Query(None, description="版本号 (如 3.0.0)，留空使用默认版本"),
+):
+    """从 GitHub Releases 下载安装 WARP 组件。"""
+    from souwen.server.warp_installer import WarpInstaller
+
+    installer = WarpInstaller()
+    try:
+        result = await installer.install(component, version)
+        return result
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except RuntimeError as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.post("/warp/components/uninstall")
+async def warp_component_uninstall(
+    component: str = Query(..., description="组件名"),
+):
+    """卸载运行时安装的 WARP 组件（不影响系统预装）。"""
+    from souwen.server.warp_installer import WarpInstaller
+
+    installer = WarpInstaller()
+    try:
+        result = await installer.uninstall(component)
+        return result
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except RuntimeError as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.post("/warp/switch")
+async def warp_switch(
+    mode: str = Query(..., description="目标模式"),
+    socks_port: int = Query(1080, ge=1, le=65535),
+    http_port: int = Query(0, ge=0, le=65535),
+    endpoint: str | None = Query(None),
+):
+    """一步切换 WARP 模式 — 先禁用当前模式，再以目标模式启用。"""
+    from souwen.server.warp import WarpManager
+
+    mgr = WarpManager.get_instance()
+
+    status = mgr.get_status()
+    if status["status"] in ("enabled", "starting", "error"):
+        disable_result = await mgr.disable()
+        if not disable_result["ok"]:
+            raise HTTPException(status_code=500, detail=f"禁用失败: {disable_result.get('error')}")
+
+    result = await mgr.enable(
+        mode=mode,
+        socks_port=socks_port,
+        http_port=http_port,
+        endpoint=endpoint,
+    )
+    if not result["ok"]:
+        raise HTTPException(status_code=400, detail=result["error"])
+    return result
+
+
+@router.get("/warp/events")
+async def warp_events():
+    """SSE 实时推送 WARP 状态变化。
+
+    每 2 秒推送一次当前状态。客户端使用 EventSource 连接。
+    """
+    from souwen.server.warp import WarpManager
+
+    async def event_stream():
+        mgr = WarpManager.get_instance()
+        last_status = None
+        heartbeat = 0
+        while True:
+            try:
+                current = mgr.get_status()
+                status_key = (current["status"], current["mode"], current["ip"])
+                heartbeat += 1
+                if status_key != last_status or heartbeat >= 10:
+                    import json
+
+                    data = json.dumps(current, ensure_ascii=False)
+                    yield f"data: {data}\n\n"
+                    last_status = status_key
+                    heartbeat = 0
+                await asyncio.sleep(2)
+            except asyncio.CancelledError:
+                break
+            except Exception:
+                break
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/souwen/server/warp.py
+++ b/src/souwen/server/warp.py
@@ -27,6 +27,7 @@ logger = logging.getLogger("souwen.warp")
 
 STATE_FILE = Path("/run/souwen-warp.json")
 WARP_DATA_DIR = Path("/app/data")
+RUNTIME_BIN_DIR = Path("/app/data/bin")
 
 # ---------- input sanitisation helpers ----------
 
@@ -178,9 +179,29 @@ class WarpManager:
     # ------ capability detection ------
 
     @staticmethod
+    def _find_binary(name: str, extra_path: str | None = None) -> str | None:
+        """在 PATH 和 runtime bin 目录中查找二进制。
+
+        查找顺序: extra_path (配置指定) > runtime bin dir > system PATH
+
+        Args:
+            name: 二进制名称
+            extra_path: 配置中指定的自定义路径
+
+        Returns:
+            二进制完整路径, 或 None
+        """
+        if extra_path and Path(extra_path).is_file():
+            return extra_path
+        runtime = RUNTIME_BIN_DIR / name
+        if runtime.is_file() and os.access(runtime, os.X_OK):
+            return str(runtime)
+        return shutil.which(name)
+
+    @staticmethod
     def _has_wireproxy() -> bool:
         """检测当前系统是否已安装 wireproxy 二进制（用户态模式可用性）"""
-        return shutil.which("wireproxy") is not None
+        return WarpManager._find_binary("wireproxy") is not None
 
     @staticmethod
     def _has_kernel_wg() -> bool:
@@ -200,7 +221,7 @@ class WarpManager:
     @staticmethod
     def _has_usque() -> bool:
         """检测 usque 二进制是否可用"""
-        return shutil.which("usque") is not None
+        return WarpManager._find_binary("usque") is not None
 
     @staticmethod
     def _has_warp_cli() -> bool:
@@ -798,11 +819,12 @@ class WarpManager:
         if not conf_path:
             raise RuntimeError("无法获取 wireproxy 配置 (需要 WARP_CONFIG_B64 或已注册配置)")
 
-        if not shutil.which("wireproxy"):
+        wireproxy_bin = self._find_binary("wireproxy")
+        if not wireproxy_bin:
             raise RuntimeError("wireproxy 未安装")
 
         self._process = subprocess.Popen(
-            ["wireproxy", "-c", str(conf_path)],
+            [wireproxy_bin, "-c", str(conf_path)],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
@@ -1090,7 +1112,7 @@ class WarpManager:
         if transport not in ("auto", "quic", "http2"):
             raise ValueError(f"非法 usque transport: {transport!r}")
 
-        usque_bin = cfg.warp_usque_path or shutil.which("usque")
+        usque_bin = self._find_binary("usque", cfg.warp_usque_path)
         if not usque_bin or not Path(usque_bin).is_file():
             raise RuntimeError("usque 未安装")
 

--- a/src/souwen/server/warp_installer.py
+++ b/src/souwen/server/warp_installer.py
@@ -156,7 +156,9 @@ class WarpInstaller:
             self._cleanup_paths(download_path, new_binary_path)
             await self._download(url, download_path)
             self._validate_download(download_path)
-            self._materialize_binary(download_path, new_binary_path, binary_name, str(spec["extract_type"]))
+            self._materialize_binary(
+                download_path, new_binary_path, binary_name, str(spec["extract_type"])
+            )
             self._validate_binary(new_binary_path)
             sha256 = self._sha256_file(new_binary_path)
             os.replace(new_binary_path, target_path)
@@ -266,7 +268,9 @@ class WarpInstaller:
 
     async def _download(self, url: str, path: Path) -> None:
         try:
-            async with httpx.AsyncClient(timeout=_DOWNLOAD_TIMEOUT, follow_redirects=True) as client:
+            async with httpx.AsyncClient(
+                timeout=_DOWNLOAD_TIMEOUT, follow_redirects=True
+            ) as client:
                 async with client.stream("GET", url) as response:
                     if response.status_code >= 400:
                         raise RuntimeError(f"下载失败 HTTP {response.status_code}: {url}")
@@ -345,7 +349,9 @@ class WarpInstaller:
             raise RuntimeError("二进制文件校验失败，内容疑似 HTML 错误页")
 
     def _ensure_space(self) -> None:
-        probe = self.bin_dir if self.bin_dir.exists() else self._nearest_existing_parent(self.bin_dir)
+        probe = (
+            self.bin_dir if self.bin_dir.exists() else self._nearest_existing_parent(self.bin_dir)
+        )
         usage = shutil.disk_usage(probe)
         if usage.free < _MIN_FREE_BYTES:
             raise RuntimeError("磁盘剩余空间不足，无法安装 WARP 组件")

--- a/src/souwen/server/warp_installer.py
+++ b/src/souwen/server/warp_installer.py
@@ -1,0 +1,393 @@
+"""SouWen WARP 组件动态安装器
+
+在运行时从 GitHub Releases 下载 WARP 相关二进制工具。
+安装目录: /app/data/bin/ (可配置)
+状态文件: /app/data/warp-components.json
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import platform
+import re
+import shutil
+import tarfile
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger("souwen.warp.installer")
+
+COMPONENTS = {
+    "usque": {
+        "repo": "Diniboy1123/usque",
+        "asset_pattern": "usque_{version}_linux_{arch}.zip",
+        "extract_type": "zip",
+        "binary_name": "usque",
+        "default_version": "3.0.0",
+    },
+    "wireproxy": {
+        "repo": "pufferffish/wireproxy",
+        "asset_pattern": "wireproxy_linux_{arch}.tar.gz",
+        "extract_type": "tar.gz",
+        "binary_name": "wireproxy",
+        "default_version": "1.1.2",
+    },
+    "wgcf": {
+        "repo": "ViRb3/wgcf",
+        "asset_pattern": "wgcf_{version}_linux_{arch}",
+        "extract_type": "binary",
+        "binary_name": "wgcf",
+        "default_version": "2.2.30",
+    },
+}
+
+ARCH_MAP = {
+    "x86_64": "amd64",
+    "aarch64": "arm64",
+    "arm64": "arm64",
+    "amd64": "amd64",
+}
+
+_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+_MIN_FREE_BYTES = 50 * 1024 * 1024
+_DOWNLOAD_TIMEOUT = httpx.Timeout(60.0, connect=20.0)
+
+
+class WarpInstaller:
+    """WARP 组件安装管理器"""
+
+    def __init__(
+        self,
+        bin_dir: str = "/app/data/bin",
+        state_file: str = "/app/data/warp-components.json",
+    ) -> None:
+        self.bin_dir = Path(bin_dir).expanduser().resolve()
+        self.state_file = Path(state_file).expanduser().resolve()
+
+    def get_components_status(self) -> list[dict[str, Any]]:
+        """获取所有组件状态列表
+
+        Returns: [{
+            "name": "usque",
+            "installed": True,
+            "version": "3.0.0",
+            "path": "/app/data/bin/usque",
+            "system_path": "/usr/local/bin/usque",
+            "source": "runtime" | "system" | "not_installed",
+        }, ...]
+        """
+        state = self._load_state()
+        result: list[dict[str, Any]] = []
+
+        for name, spec in COMPONENTS.items():
+            binary_name = str(spec["binary_name"])
+            runtime_path = self._component_path(name)
+            runtime_installed = self._is_executable_file(runtime_path)
+            system_path = shutil.which(binary_name)
+            state_entry = state.get(name, {})
+
+            if runtime_installed:
+                source = "runtime"
+                installed = True
+                path = str(runtime_path)
+                version = state_entry.get("version")
+            elif system_path:
+                source = "system"
+                installed = True
+                path = system_path
+                version = None
+            else:
+                source = "not_installed"
+                installed = False
+                path = None
+                version = None
+
+            result.append(
+                {
+                    "name": name,
+                    "installed": installed,
+                    "version": version,
+                    "path": path,
+                    "system_path": system_path,
+                    "source": source,
+                }
+            )
+
+        return result
+
+    async def install(self, component: str, version: str | None = None) -> dict[str, Any]:
+        """安装或升级组件
+
+        Args:
+            component: 组件名 (usque, wireproxy, wgcf)
+            version: 版本号（None 使用默认版本）
+
+        Returns: {"ok": True, "component": str, "version": str, "path": str}
+        Raises: ValueError (未知组件), RuntimeError (下载/校验失败)
+        """
+        spec = self._get_component_spec(component)
+        target_version = version or str(spec["default_version"])
+        self._validate_version(target_version)
+
+        try:
+            self.bin_dir.mkdir(parents=True, exist_ok=True)
+            self.state_file.parent.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            raise RuntimeError(f"WARP 组件目录不可写: {exc}") from exc
+
+        self._ensure_space()
+        arch = self._detect_arch()
+        asset = str(spec["asset_pattern"]).format(version=target_version, arch=arch)
+        url = self._release_url(str(spec["repo"]), target_version, asset)
+        binary_name = str(spec["binary_name"])
+        target_path = self._component_path(component)
+        download_path = self._safe_bin_child(f".{binary_name}.download")
+        new_binary_path = self._safe_bin_child(f".{binary_name}.new")
+
+        logger.info("开始安装 WARP 组件: component=%s version=%s", component, target_version)
+        try:
+            self._cleanup_paths(download_path, new_binary_path)
+            await self._download(url, download_path)
+            self._validate_download(download_path)
+            self._materialize_binary(download_path, new_binary_path, binary_name, str(spec["extract_type"]))
+            self._validate_binary(new_binary_path)
+            sha256 = self._sha256_file(new_binary_path)
+            os.replace(new_binary_path, target_path)
+            target_path.chmod(0o755)
+            self._write_component_state(component, target_version, target_path, sha256)
+        except (httpx.HTTPError, OSError, zipfile.BadZipFile, tarfile.TarError) as exc:
+            self._cleanup_paths(download_path, new_binary_path)
+            raise RuntimeError(f"WARP 组件 {component} 安装失败: {exc}") from exc
+        except RuntimeError:
+            self._cleanup_paths(download_path, new_binary_path)
+            raise
+        finally:
+            self._cleanup_paths(download_path, new_binary_path)
+
+        logger.info("WARP 组件安装完成: component=%s path=%s", component, target_path)
+        return {
+            "ok": True,
+            "component": component,
+            "version": target_version,
+            "path": str(target_path),
+        }
+
+    async def uninstall(self, component: str) -> dict[str, Any]:
+        """卸载运行时安装的组件（不影响系统预装）
+
+        Returns: {"ok": True, "component": str}
+        """
+        self._get_component_spec(component)
+        target_path = self._component_path(component)
+
+        try:
+            if target_path.exists():
+                target_path.unlink()
+            state = self._load_state()
+            state.pop(component, None)
+            self._save_state(state)
+        except OSError as exc:
+            raise RuntimeError(f"WARP 组件 {component} 卸载失败: {exc}") from exc
+
+        logger.info("WARP 组件已卸载: component=%s", component)
+        return {"ok": True, "component": component}
+
+    def get_binary_path(self, component: str) -> str | None:
+        """获取组件二进制路径 — 优先返回运行时安装，fallback 到系统 PATH
+
+        WarpManager 在能力检测中应调用此方法。
+        """
+        spec = self._get_component_spec(component)
+        runtime_path = self._component_path(component)
+        if self._is_executable_file(runtime_path):
+            return str(runtime_path)
+        return shutil.which(str(spec["binary_name"]))
+
+    def _get_component_spec(self, component: str) -> dict[str, Any]:
+        if component not in COMPONENTS:
+            raise ValueError(f"未知 WARP 组件: {component}")
+        return COMPONENTS[component]
+
+    def _component_path(self, component: str) -> Path:
+        spec = self._get_component_spec(component)
+        return self._safe_bin_child(str(spec["binary_name"]))
+
+    def _safe_bin_child(self, filename: str) -> Path:
+        path = (self.bin_dir / filename).resolve()
+        if path.parent != self.bin_dir:
+            raise RuntimeError(f"安装路径非法: {path}")
+        return path
+
+    def _load_state(self) -> dict[str, Any]:
+        if not self.state_file.is_file():
+            return {}
+        try:
+            data = json.loads(self.state_file.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("读取 WARP 组件状态失败，将忽略状态文件: %s", exc)
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _save_state(self, state: dict[str, Any]) -> None:
+        if self.state_file.parent and not self.state_file.parent.exists():
+            self.state_file.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = self.state_file.with_name(f".{self.state_file.name}.tmp")
+        tmp_path.write_text(
+            json.dumps(state, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        os.replace(tmp_path, self.state_file)
+
+    def _write_component_state(
+        self,
+        component: str,
+        version: str,
+        target_path: Path,
+        sha256: str,
+    ) -> None:
+        state = self._load_state()
+        state[component] = {
+            "version": version,
+            "path": str(target_path),
+            "installed_at": datetime.now(timezone.utc)
+            .replace(microsecond=0)
+            .isoformat()
+            .replace("+00:00", "Z"),
+            "sha256": sha256,
+        }
+        self._save_state(state)
+
+    async def _download(self, url: str, path: Path) -> None:
+        try:
+            async with httpx.AsyncClient(timeout=_DOWNLOAD_TIMEOUT, follow_redirects=True) as client:
+                async with client.stream("GET", url) as response:
+                    if response.status_code >= 400:
+                        raise RuntimeError(f"下载失败 HTTP {response.status_code}: {url}")
+                    with path.open("wb") as file:
+                        async for chunk in response.aiter_bytes():
+                            if chunk:
+                                file.write(chunk)
+        except httpx.RequestError as exc:
+            raise RuntimeError(f"网络错误，无法下载 WARP 组件: {exc}") from exc
+
+    def _materialize_binary(
+        self,
+        download_path: Path,
+        binary_path: Path,
+        binary_name: str,
+        extract_type: str,
+    ) -> None:
+        if extract_type == "binary":
+            shutil.copyfile(download_path, binary_path)
+        elif extract_type == "zip":
+            self._extract_zip_binary(download_path, binary_path, binary_name)
+        elif extract_type == "tar.gz":
+            self._extract_tar_binary(download_path, binary_path, binary_name)
+        else:
+            raise RuntimeError(f"不支持的解压类型: {extract_type}")
+        binary_path.chmod(0o755)
+
+    def _extract_zip_binary(self, archive_path: Path, binary_path: Path, binary_name: str) -> None:
+        with zipfile.ZipFile(archive_path) as archive:
+            member = next(
+                (
+                    info
+                    for info in archive.infolist()
+                    if not info.is_dir() and Path(info.filename).name == binary_name
+                ),
+                None,
+            )
+            if member is None:
+                raise RuntimeError(f"压缩包内未找到二进制文件: {binary_name}")
+            with archive.open(member) as source, binary_path.open("wb") as target:
+                shutil.copyfileobj(source, target)
+
+    def _extract_tar_binary(self, archive_path: Path, binary_path: Path, binary_name: str) -> None:
+        with tarfile.open(archive_path, "r:gz") as archive:
+            member = next(
+                (
+                    info
+                    for info in archive.getmembers()
+                    if info.isfile() and Path(info.name).name == binary_name
+                ),
+                None,
+            )
+            if member is None:
+                raise RuntimeError(f"压缩包内未找到二进制文件: {binary_name}")
+            source = archive.extractfile(member)
+            if source is None:
+                raise RuntimeError(f"无法读取压缩包内二进制文件: {binary_name}")
+            with source, binary_path.open("wb") as target:
+                shutil.copyfileobj(source, target)
+
+    def _validate_download(self, path: Path) -> None:
+        if not path.is_file() or path.stat().st_size == 0:
+            raise RuntimeError("下载文件为空")
+        head = path.read_bytes()[:512].lstrip().lower()
+        if head.startswith((b"<!doctype html", b"<html")):
+            raise RuntimeError("下载结果看起来是 HTML 错误页，而不是组件文件")
+
+    def _validate_binary(self, path: Path) -> None:
+        if not path.is_file() or path.stat().st_size == 0:
+            raise RuntimeError("二进制文件为空")
+        path.chmod(0o755)
+        if not os.access(path, os.X_OK):
+            raise RuntimeError("二进制文件不可执行")
+        head = path.read_bytes()[:512].lstrip().lower()
+        if head.startswith((b"<!doctype html", b"<html")):
+            raise RuntimeError("二进制文件校验失败，内容疑似 HTML 错误页")
+
+    def _ensure_space(self) -> None:
+        probe = self.bin_dir if self.bin_dir.exists() else self._nearest_existing_parent(self.bin_dir)
+        usage = shutil.disk_usage(probe)
+        if usage.free < _MIN_FREE_BYTES:
+            raise RuntimeError("磁盘剩余空间不足，无法安装 WARP 组件")
+
+    def _nearest_existing_parent(self, path: Path) -> Path:
+        current = path
+        while not current.exists() and current.parent != current:
+            current = current.parent
+        return current
+
+    def _detect_arch(self) -> str:
+        machine = platform.machine().lower()
+        arch = ARCH_MAP.get(machine)
+        if arch is None:
+            raise RuntimeError(f"不支持的 CPU 架构: {machine}")
+        return arch
+
+    def _release_url(self, repo: str, version: str, asset: str) -> str:
+        url = f"https://github.com/{repo}/releases/download/v{version}/{asset}"
+        proxy = os.getenv("GH_PROXY", "").strip()
+        if proxy:
+            return f"{proxy.rstrip('/')}/{url}"
+        return url
+
+    def _validate_version(self, version: str) -> None:
+        if not _VERSION_RE.match(version):
+            raise ValueError(f"非法版本号: {version}")
+
+    def _sha256_file(self, path: Path) -> str:
+        digest = hashlib.sha256()
+        with path.open("rb") as file:
+            for chunk in iter(lambda: file.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    def _cleanup_paths(self, *paths: Path) -> None:
+        for path in paths:
+            try:
+                if path.exists():
+                    path.unlink()
+            except OSError:
+                logger.warning("清理 WARP 组件临时文件失败: %s", path)
+
+    def _is_executable_file(self, path: Path) -> bool:
+        return path.is_file() and os.access(path, os.X_OK)


### PR DESCRIPTION
## 概述

WARP 代理架构升级，实现动态组件管理和非阻塞启动。

## 改动内容

### Docker 镜像
- HFS/ModelScope Dockerfile 补装 **usque v3.0.0**（固定版本）
- 与主 Dockerfile 保持一致

### 非阻塞启动
- 3 个 entrypoint.sh 默认跳过同步 `warp-init.sh`
- 由 Python `WarpManager` 后台异步启动 WARP
- `WARP_ENTRYPOINT_INIT=1` 可恢复旧行为（向后兼容）
- Runtime bin 目录 `/app/data/bin` 自动加入 PATH

### WarpInstaller 动态安装器
- 新模块 `src/souwen/server/warp_installer.py`
- 运行时从 GitHub Releases 下载 usque/wireproxy/wgcf
- 支持 `GH_PROXY` 代理、SHA256 校验、版本管理
- 安装到 `/app/data/bin/`，不影响系统预装

### WarpManager 增强
- `_find_binary()` 支持 runtime bin 目录搜索
- 优先级：配置路径 > runtime bin > system PATH

### 新增 API 端点
| 端点 | 说明 |
|------|------|
| `GET /admin/warp/components` | 列出组件安装状态 |
| `POST /admin/warp/components/install` | 安装组件 |
| `POST /admin/warp/components/uninstall` | 卸载组件 |
| `POST /admin/warp/switch` | 一步模式切换 |
| `GET /admin/warp/events` | SSE 实时状态推送 |

### 前端面板
- 5 个 WarpPage 新增 **组件安装器卡片**
- 显示 usque/wireproxy/wgcf 安装状态
- 支持一键安装/升级

## 验证
- ✅ ruff lint 通过
- ✅ 859 tests passed, 2 skipped
- ✅ panel build 成功

## 影响范围
18 files changed, +1311/-30 lines