### PR TITLE
feat(paper): 新增 bioRxiv/medRxiv 预印本搜索源（零配置）

### DIFF
--- a/src/souwen/models.py
+++ b/src/souwen/models.py
@@ -138,6 +138,7 @@ class SourceType(str, Enum):
     HAL = "hal"
     OPENAIRE = "openaire"
     IACR = "iacr"
+    BIORXIV = "biorxiv"
     # 专利数据源
     PATENTSVIEW = "patentsview"
     USPTO_ODP = "uspto_odp"

--- a/src/souwen/paper/__init__.py
+++ b/src/souwen/paper/__init__.py
@@ -18,6 +18,7 @@
 - HalClient: HAL (无需Key)
 - OpenAireClient: OpenAIRE (可选Key)
 - IacrClient: IACR ePrint (无需Key，实验性 HTML 爬虫)
+- BioRxivClient: bioRxiv/medRxiv 预印本 (无需Key)
 - fetch_pdf: PDF 回退链获取器
 """
 
@@ -40,6 +41,7 @@ from souwen.paper.zenodo import ZenodoClient
 from souwen.paper.hal import HalClient
 from souwen.paper.openaire import OpenAireClient
 from souwen.paper.iacr import IacrClient
+from souwen.paper.biorxiv import BioRxivClient
 
 __all__ = [
     "OpenAlexClient",
@@ -61,4 +63,5 @@ __all__ = [
     "HalClient",
     "OpenAireClient",
     "IacrClient",
+    "BioRxivClient",
 ]

--- a/src/souwen/paper/biorxiv.py
+++ b/src/souwen/paper/biorxiv.py
@@ -24,23 +24,26 @@ logger = logging.getLogger(__name__)
 
 _BASE_URL = "https://api.biorxiv.org"
 _DEFAULT_RPS = 1.0
-_DEFAULT_LOOKBACK_DAYS = 30
+_DEFAULT_LOOKBACK_DAYS = 7
 _MAX_FETCHED = 1000
-_MAX_API_REQUESTS = 10
+# bioRxiv has no server-side search; we fetch recent preprints and filter locally.
+# To limit API calls, only the last 7 days are scanned by default.
+_MAX_API_REQUESTS = 34
 _VALID_SERVERS = {"biorxiv", "medrxiv"}
+_BIORXIV_LIMITER = TokenBucketLimiter(rate=_DEFAULT_RPS, burst=_DEFAULT_RPS)
 
 
 class BioRxivClient:
     """bioRxiv / medRxiv 生物医学预印本搜索客户端。
 
-    bioRxiv 官方 API 没有全文搜索端点，本客户端拉取最近 30 天内容详情，
+    bioRxiv 官方 API 没有全文搜索端点，本客户端拉取最近 7 天内容详情，
     再按 query 在 title / abstract 中做大小写不敏感过滤。
     """
 
     def __init__(self) -> None:
         """初始化 bioRxiv API 客户端。"""
         self._client = SouWenHttpClient(base_url=_BASE_URL, source_name="biorxiv")
-        self._limiter = TokenBucketLimiter(rate=_DEFAULT_RPS, burst=_DEFAULT_RPS)
+        self._limiter = _BIORXIV_LIMITER
 
     # ------------------------------------------------------------------
     # async context manager
@@ -149,7 +152,8 @@ class BioRxivClient:
                 str(item.get("abstract") or ""),
             ]
         ).lower()
-        return normalized_query in haystack
+        terms = normalized_query.split()
+        return all(term in haystack for term in terms)
 
     @staticmethod
     def _int_or_none(value: Any) -> int | None:

--- a/src/souwen/paper/biorxiv.py
+++ b/src/souwen/paper/biorxiv.py
@@ -1,0 +1,217 @@
+"""bioRxiv / medRxiv content API 客户端
+
+官方文档: https://api.biorxiv.org
+鉴权: 无需 Key
+限流: 保守 1 req/s
+返回: JSON（collection[]）
+
+文件用途：使用 bioRxiv content details API 获取近期 bioRxiv/medRxiv 预印本，
+并在本地按标题与摘要进行关键词过滤。
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import logging
+from typing import Any
+
+from souwen.exceptions import ParseError
+from souwen.http_client import SouWenHttpClient
+from souwen.models import Author, PaperResult, SearchResponse, SourceType
+from souwen.rate_limiter import TokenBucketLimiter
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://api.biorxiv.org"
+_DEFAULT_RPS = 1.0
+_DEFAULT_LOOKBACK_DAYS = 30
+_PAGE_SIZE = 100
+_MAX_FETCHED = 1000
+_VALID_SERVERS = {"biorxiv", "medrxiv"}
+
+
+class BioRxivClient:
+    """bioRxiv / medRxiv 生物医学预印本搜索客户端。
+
+    bioRxiv 官方 API 没有全文搜索端点，本客户端拉取最近 30 天内容详情，
+    再按 query 在 title / abstract 中做大小写不敏感过滤。
+    """
+
+    def __init__(self) -> None:
+        """初始化 bioRxiv API 客户端。"""
+        self._client = SouWenHttpClient(base_url=_BASE_URL, source_name="biorxiv")
+        self._limiter = TokenBucketLimiter(rate=_DEFAULT_RPS, burst=_DEFAULT_RPS)
+
+    # ------------------------------------------------------------------
+    # async context manager
+    # ------------------------------------------------------------------
+
+    async def __aenter__(self) -> BioRxivClient:
+        await self._client.__aenter__()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> None:
+        await self._client.__aexit__(exc_type, exc_val, exc_tb)
+
+    # ------------------------------------------------------------------
+    # 内部工具
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _parse_result(item: dict[str, Any]) -> PaperResult:
+        """将 bioRxiv content API 单条 collection 记录转换为 PaperResult。
+
+        Args:
+            item: ``collection[]`` 中的单条预印本元数据。
+
+        Returns:
+            统一的 PaperResult 模型。
+
+        Raises:
+            ParseError: 解析关键字段失败时抛出。
+        """
+        try:
+            doi = str(item.get("doi") or "").strip() or None
+            title = str(item.get("title") or "")
+            abstract = str(item.get("abstract") or "")
+
+            raw_authors = item.get("authors") or ""
+            authors: list[Author] = []
+            if isinstance(raw_authors, str):
+                authors = [
+                    Author(name=name.strip()) for name in raw_authors.split(";") if name.strip()
+                ]
+            elif isinstance(raw_authors, list):
+                authors = [
+                    Author(name=str(name).strip()) for name in raw_authors if str(name).strip()
+                ]
+
+            pub_date = str(item.get("date") or "").strip() or None
+            year: int | None = None
+            if pub_date:
+                try:
+                    year = int(pub_date[:4])
+                except (TypeError, ValueError):
+                    year = None
+
+            server = str(item.get("server") or "biorxiv").lower()
+            if server not in _VALID_SERVERS:
+                server = "biorxiv"
+            server_label = "medRxiv" if server == "medrxiv" else "bioRxiv"
+
+            source_url = f"https://doi.org/{doi}" if doi else "https://www.biorxiv.org/"
+            category = str(item.get("category") or "").strip() or None
+            journal = server_label
+
+            return PaperResult(
+                title=title,
+                authors=authors,
+                abstract=abstract,
+                doi=doi,
+                year=year,
+                publication_date=pub_date,
+                source=SourceType.BIORXIV,
+                source_url=source_url,
+                journal=journal,
+                venue=category,
+                citation_count=None,
+                raw={
+                    "server": server,
+                    "category": category,
+                    "version": item.get("version") or None,
+                    "type": item.get("type") or None,
+                    "license": item.get("license") or None,
+                    "jatsxml": item.get("jatsxml") or None,
+                    "published": item.get("published") or None,
+                    "author_corresponding": item.get("author_corresponding") or None,
+                    "author_corresponding_institution": item.get("author_corresponding_institution")
+                    or None,
+                },
+            )
+        except Exception as exc:
+            raise ParseError(f"解析 bioRxiv/medRxiv result 失败: {exc}") from exc
+
+    @staticmethod
+    def _matches_query(item: dict[str, Any], query: str) -> bool:
+        """按 title / abstract 做简单大小写不敏感关键词匹配。"""
+        normalized_query = query.strip().lower()
+        if not normalized_query:
+            return True
+
+        haystack = " ".join(
+            [
+                str(item.get("title") or ""),
+                str(item.get("abstract") or ""),
+            ]
+        ).lower()
+        return normalized_query in haystack
+
+    # ------------------------------------------------------------------
+    # 公开方法
+    # ------------------------------------------------------------------
+
+    async def search(
+        self,
+        query: str,
+        per_page: int = 10,
+        server: str = "biorxiv",
+    ) -> SearchResponse:
+        """搜索近期 bioRxiv / medRxiv 预印本。
+
+        Args:
+            query: 本地过滤关键词，匹配 title / abstract。
+            per_page: 返回结果数量。
+            server: ``"biorxiv"`` 或 ``"medrxiv"``。
+
+        Returns:
+            SearchResponse 包含本地过滤后的预印本结果。
+        """
+        normalized_server = server.lower().strip()
+        if normalized_server not in _VALID_SERVERS:
+            raise ValueError("server must be 'biorxiv' or 'medrxiv'")
+
+        page_size = min(max(per_page, 1), _MAX_FETCHED)
+        end_date = datetime.now(timezone.utc).date()
+        start_date = end_date - timedelta(days=_DEFAULT_LOOKBACK_DAYS)
+        interval = f"{start_date.isoformat()}/{end_date.isoformat()}"
+
+        results: list[PaperResult] = []
+        fetched = 0
+        cursor = 0
+
+        while len(results) < page_size and fetched < _MAX_FETCHED:
+            await self._limiter.acquire()
+            resp = await self._client.get(f"/details/{normalized_server}/{interval}/{cursor}/json")
+            data: dict[str, Any] = resp.json()
+            items = data.get("collection") or []
+            if not isinstance(items, list) or not items:
+                break
+
+            fetched += len(items)
+            for item in items:
+                if not isinstance(item, dict) or not self._matches_query(item, query):
+                    continue
+                try:
+                    results.append(self._parse_result(item))
+                except ParseError as exc:
+                    logger.debug("跳过解析失败的 bioRxiv/medRxiv 论文: %s", exc)
+                if len(results) >= page_size:
+                    break
+
+            if len(items) < _PAGE_SIZE:
+                break
+            cursor += len(items)
+
+        return SearchResponse(
+            query=query,
+            total_results=len(results),
+            page=1,
+            per_page=per_page,
+            results=results,
+            source=SourceType.BIORXIV,
+        )

--- a/src/souwen/paper/biorxiv.py
+++ b/src/souwen/paper/biorxiv.py
@@ -25,8 +25,8 @@ logger = logging.getLogger(__name__)
 _BASE_URL = "https://api.biorxiv.org"
 _DEFAULT_RPS = 1.0
 _DEFAULT_LOOKBACK_DAYS = 30
-_PAGE_SIZE = 100
 _MAX_FETCHED = 1000
+_MAX_API_REQUESTS = 10
 _VALID_SERVERS = {"biorxiv", "medrxiv"}
 
 
@@ -151,6 +151,14 @@ class BioRxivClient:
         ).lower()
         return normalized_query in haystack
 
+    @staticmethod
+    def _int_or_none(value: Any) -> int | None:
+        """将 bioRxiv API 元数据中的数字字段安全转换为 int。"""
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
     # ------------------------------------------------------------------
     # 公开方法
     # ------------------------------------------------------------------
@@ -183,14 +191,32 @@ class BioRxivClient:
         results: list[PaperResult] = []
         fetched = 0
         cursor = 0
+        requests_made = 0
 
-        while len(results) < page_size and fetched < _MAX_FETCHED:
+        while (
+            len(results) < page_size
+            and fetched < _MAX_FETCHED
+            and requests_made < _MAX_API_REQUESTS
+        ):
             await self._limiter.acquire()
             resp = await self._client.get(f"/details/{normalized_server}/{interval}/{cursor}/json")
+            requests_made += 1
             data: dict[str, Any] = resp.json()
             items = data.get("collection") or []
             if not isinstance(items, list) or not items:
                 break
+
+            messages = data.get("messages") or []
+            metadata = messages[0] if isinstance(messages, list) and messages else {}
+            if not isinstance(metadata, dict):
+                metadata = {}
+            total = self._int_or_none(metadata.get("total"))
+            count = self._int_or_none(metadata.get("count"))
+            current_cursor = self._int_or_none(metadata.get("cursor"))
+            if count is None:
+                count = len(items)
+            if current_cursor is None:
+                current_cursor = cursor
 
             fetched += len(items)
             for item in items:
@@ -203,9 +229,10 @@ class BioRxivClient:
                 if len(results) >= page_size:
                     break
 
-            if len(items) < _PAGE_SIZE:
+            next_cursor = current_cursor + count
+            if total is None or next_cursor >= total or next_cursor <= cursor:
                 break
-            cursor += len(items)
+            cursor = next_cursor
 
         return SearchResponse(
             query=query,

--- a/src/souwen/registry/sources.py
+++ b/src/souwen/registry/sources.py
@@ -3,7 +3,7 @@
 **这是单一事实源**。新增一个数据源 = 在这个文件里加一个 `_reg(SourceAdapter(...))`。
 
 组织顺序：
-  1. paper（17 源）
+  1. paper（18 源）
   2. patent（8 源）
   3. web.engines（爬虫类 SERP，13 个）
   4. web.api（授权 API，14 个）
@@ -60,7 +60,7 @@ _P_RANGE_END: dict[str, str] = {"limit": "range_end", "query": "cql_query"}
 
 
 # ═════════════════════════════════════════════════════════════
-#  1. paper（17 源）
+#  1. paper（18 源）
 # ═════════════════════════════════════════════════════════════
 
 _reg(
@@ -150,6 +150,19 @@ _reg(
         config_field=None,
         client_loader=lazy("souwen.paper.pubmed:PubMedClient"),
         methods={"search": MethodSpec("search", _P_RETMAX)},
+        default_for=frozenset({"paper:search"}),
+    )
+)
+
+_reg(
+    SourceAdapter(
+        name="biorxiv",
+        domain="paper",
+        integration="open_api",
+        description="bioRxiv/medRxiv 生物医学预印本",
+        config_field=None,
+        client_loader=lazy("souwen.paper.biorxiv:BioRxivClient"),
+        methods={"search": MethodSpec("search", _P_PER_PAGE)},
         default_for=frozenset({"paper:search"}),
     )
 )

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -437,7 +437,7 @@ class TestUnifiedSearch:
         from souwen.search import _default_paper_sources
 
         paper_adapters = by_domain_and_capability("paper", "search")
-        assert len(paper_adapters) == 16  # 16 source 支持 search（排除 unpaywall，它只有 find_oa）
+        assert len(paper_adapters) == 17  # 17 source 支持 search（排除 unpaywall，它只有 find_oa）
         defaults = _default_paper_sources()
         assert defaults  # 必须非空
         names = {a.name for a in paper_adapters}
@@ -530,7 +530,7 @@ class TestCLI:
         """
         from souwen.models import ALL_SOURCES
 
-        assert len(ALL_SOURCES["paper"]) == 16
+        assert len(ALL_SOURCES["paper"]) == 17
         assert len(ALL_SOURCES["patent"]) == 6
         total_web = sum(
             len(ALL_SOURCES[c])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -28,8 +28,8 @@ class TestAllSources:
     """ALL_SOURCES 元信息测试"""
 
     def test_paper_count(self):
-        """paper 暴露 8 个搜索数据源"""
-        assert len(ALL_SOURCES["paper"]) == 16
+        """paper 暴露 17 个搜索数据源"""
+        assert len(ALL_SOURCES["paper"]) == 17
 
     def test_patent_count(self):
         """patent 暴露 6 个搜索数据源"""
@@ -88,14 +88,15 @@ class TestSourceTypeEnum:
     """SourceType 枚举测试"""
 
     def test_has_59_values(self):
-        """枚举有 75 个值"""
-        assert len(SourceType) == 75
+        """枚举有 76 个值"""
+        assert len(SourceType) == 76
 
     def test_paper_sources_exist(self):
         """论文数据源枚举存在"""
         assert SourceType.OPENALEX.value == "openalex"
         assert SourceType.ARXIV.value == "arxiv"
         assert SourceType.CROSSREF.value == "crossref"
+        assert SourceType.BIORXIV.value == "biorxiv"
 
     def test_patent_sources_exist(self):
         """专利数据源枚举存在"""

--- a/tests/test_paper/test_biorxiv.py
+++ b/tests/test_paper/test_biorxiv.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 from datetime import date
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from souwen.models import SourceType
 from souwen.paper.biorxiv import BioRxivClient
@@ -86,3 +89,41 @@ class TestBioRxiv:
         assert BioRxivClient._matches_query(self.SAMPLE, "coordinated neural") is True
         assert BioRxivClient._matches_query(self.SAMPLE, "not-present") is False
         assert BioRxivClient._matches_query(self.SAMPLE, "") is True
+
+    @pytest.mark.asyncio
+    async def test_search_uses_api_metadata_for_pagination(self):
+        """API 每页 30 条时，按 total/cursor/count 继续请求下一页。"""
+
+        def item(index: int) -> dict[str, str]:
+            return {
+                **self.SAMPLE,
+                "doi": f"10.1101/2024.01.01.{index:06d}",
+                "title": f"Memory pagination result {index}",
+            }
+
+        page1 = {
+            "messages": [{"total": "40", "count": "30", "cursor": "0"}],
+            "collection": [item(i) for i in range(30)],
+        }
+        page2 = {
+            "messages": [{"total": "40", "count": "10", "cursor": "30"}],
+            "collection": [item(i) for i in range(30, 40)],
+        }
+        page1_resp = MagicMock()
+        page1_resp.json.return_value = page1
+        page2_resp = MagicMock()
+        page2_resp.json.return_value = page2
+
+        client = BioRxivClient()
+        mock_get = AsyncMock(side_effect=[page1_resp, page2_resp])
+        with (
+            patch.object(client._limiter, "acquire", new=AsyncMock()),
+            patch.object(client._client, "get", new=mock_get),
+        ):
+            resp = await client.search("memory", per_page=35)
+
+        assert len(resp.results) == 35
+        assert mock_get.await_count == 2
+        requested_paths = [call.args[0] for call in mock_get.await_args_list]
+        assert requested_paths[0].endswith("/0/json")
+        assert requested_paths[1].endswith("/30/json")

--- a/tests/test_paper/test_biorxiv.py
+++ b/tests/test_paper/test_biorxiv.py
@@ -90,6 +90,16 @@ class TestBioRxiv:
         assert BioRxivClient._matches_query(self.SAMPLE, "not-present") is False
         assert BioRxivClient._matches_query(self.SAMPLE, "") is True
 
+    def test_matches_query_multi_word_terms_anywhere(self):
+        assert BioRxivClient._matches_query(self.SAMPLE, "neural coordinated") is True
+        assert BioRxivClient._matches_query(self.SAMPLE, "neural absent") is False
+
+    def test_clients_share_rate_limiter(self):
+        first = BioRxivClient()
+        second = BioRxivClient()
+
+        assert first._limiter is second._limiter
+
     @pytest.mark.asyncio
     async def test_search_uses_api_metadata_for_pagination(self):
         """API 每页 30 条时，按 total/cursor/count 继续请求下一页。"""

--- a/tests/test_paper/test_biorxiv.py
+++ b/tests/test_paper/test_biorxiv.py
@@ -1,0 +1,88 @@
+"""bioRxiv / medRxiv 预印本源解析测试。"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from souwen.models import SourceType
+from souwen.paper.biorxiv import BioRxivClient
+
+
+class TestBioRxiv:
+    SAMPLE = {
+        "doi": "10.1101/2024.01.01.123456",
+        "title": "Neural mechanisms of memory consolidation",
+        "authors": "Author One; Author Two; Author Three",
+        "author_corresponding": "Author One",
+        "author_corresponding_institution": "MIT",
+        "date": "2024-01-15",
+        "version": "1",
+        "type": "new results",
+        "license": "cc_by",
+        "category": "neuroscience",
+        "jatsxml": "https://www.biorxiv.org/content/10.1101/2024.01.01.123456v1.source.xml",
+        "abstract": "Memory consolidation depends on coordinated neural activity.",
+        "published": "NA",
+        "server": "biorxiv",
+    }
+
+    def test_parse_result_basic(self):
+        paper = BioRxivClient._parse_result(self.SAMPLE)
+
+        assert paper.title == "Neural mechanisms of memory consolidation"
+        assert [a.name for a in paper.authors] == [
+            "Author One",
+            "Author Two",
+            "Author Three",
+        ]
+        assert paper.abstract == "Memory consolidation depends on coordinated neural activity."
+        assert paper.doi == "10.1101/2024.01.01.123456"
+        assert paper.year == 2024
+        assert paper.publication_date == date(2024, 1, 15)
+        assert paper.source == SourceType.BIORXIV
+        assert paper.source_url == "https://doi.org/10.1101/2024.01.01.123456"
+        assert paper.journal == "bioRxiv"
+        assert paper.venue == "neuroscience"
+        assert paper.citation_count is None
+        assert paper.raw["server"] == "biorxiv"
+        assert paper.raw["category"] == "neuroscience"
+        assert paper.raw["version"] == "1"
+        assert paper.raw["license"] == "cc_by"
+        assert paper.raw["author_corresponding"] == "Author One"
+
+    def test_parse_result_medrxiv(self):
+        sample = {
+            **self.SAMPLE,
+            "server": "medrxiv",
+            "category": "epidemiology",
+            "doi": "10.1101/2024.02.03.987654",
+        }
+        paper = BioRxivClient._parse_result(sample)
+
+        assert paper.source == SourceType.BIORXIV
+        assert paper.journal == "medRxiv"
+        assert paper.venue == "epidemiology"
+        assert paper.source_url == "https://doi.org/10.1101/2024.02.03.987654"
+        assert paper.raw["server"] == "medrxiv"
+
+    def test_parse_result_missing_fields(self):
+        minimal = {"title": "Minimal preprint"}
+        paper = BioRxivClient._parse_result(minimal)
+
+        assert paper.title == "Minimal preprint"
+        assert paper.authors == []
+        assert paper.abstract == ""
+        assert paper.doi is None
+        assert paper.year is None
+        assert paper.publication_date is None
+        assert paper.source == SourceType.BIORXIV
+        assert paper.source_url == "https://www.biorxiv.org/"
+        assert paper.journal == "bioRxiv"
+        assert paper.venue is None
+        assert paper.raw["server"] == "biorxiv"
+
+    def test_matches_query_title_or_abstract(self):
+        assert BioRxivClient._matches_query(self.SAMPLE, "memory") is True
+        assert BioRxivClient._matches_query(self.SAMPLE, "coordinated neural") is True
+        assert BioRxivClient._matches_query(self.SAMPLE, "not-present") is False
+        assert BioRxivClient._matches_query(self.SAMPLE, "") is True


### PR DESCRIPTION
## 概述

新增 `BioRxivClient`，集成 bioRxiv 官方 content API，支持搜索 bioRxiv 和 medRxiv 两个生物医学预印本服务器。零配置即可使用，无需 API Key。

## 实现方案

bioRxiv 官方 API 不提供全文搜索端点，因此采用"拉取近期数据 + 本地关键词过滤"策略：
- 拉取最近 7 天的预印本详情（cursor 分页）
- 按 title / abstract 做大小写不敏感多词匹配
- 限流 1 req/s，最多 34 次请求 / 1000 条数据上限

## 变更文件

| 文件 | 说明 |
|------|------|
| `src/souwen/paper/biorxiv.py` (+248) | BioRxivClient 实现 |
| `src/souwen/registry/sources.py` (+15/-2) | 注册 biorxiv 源（paper 源计数 17→18） |
| `src/souwen/models.py` (+1) | 新增 `SourceType.BIORXIV` 枚举 |
| `src/souwen/paper/__init__.py` (+3) | 模块导出与文档说明 |
| `tests/test_paper/test_biorxiv.py` (+139) | 单元测试 |
| `tests/test_infra.py` (+2/-2) | infra 测试适配新源 |
| `tests/test_models.py` (+5/-4) | model 测试适配新源 |

## 注册信息

- 源名称: `biorxiv`
- 源类型: `SourceType.BIORXIV`
- 领域: paper
- 集成方式: open_api
- 配置: 无（零配置）
- 默认参与: `paper:search`
- 方法: `search(query, per_page, server)`
