### PR TITLE
feat(auth): Admin 默认锁定 + 配置优先级修复 + Panel 权限控制 + Sources 过滤

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -287,22 +287,21 @@ SouWen 支持三级角色认证（Guest/User/Admin），并向后兼容旧版密
 | 角色 | Token 来源 | 可访问端点 |
 |------|------------|-----------|
 | Guest 游客 | 无 Token（需 `guest_enabled=true`） | 搜索（受限源、限速） |
-| User 用户 | `user_password` / `visitor_password` / `api_password` | 搜索 + `/sources` + 只读管理 |
+| User 用户 | `user_password` / `visitor_password` / `api_password` | 搜索 + `/sources` |
 | Admin 管理员 | `admin_password` / `api_password` | 全部端点 |
 
 **密码优先级：**
 
 - 用户端点：`user_password` > `visitor_password` > `api_password` > 无（开放）
-- 管理端点：`admin_password` > `api_password` > 无（开放）
+- 管理端点：`admin_password` > `api_password` > 无（默认锁定，需 `SOUWEN_ADMIN_OPEN=1` 显式开放）
 - Admin Token 自动满足所有低级别端点（Admin ⊃ User ⊃ Guest）
-- 显式将 `user_password` 或 `admin_password` 设为空字符串 `""` 表示**强制开放**该作用域
+- 显式将 `user_password` 设为空字符串 `""` 表示开放用户端点；显式将 `admin_password` 设为空字符串 `""` 表示不回退 `api_password`，但管理端仍需 `SOUWEN_ADMIN_OPEN=1` 才开放。
 
 **请求格式：** `Authorization: Bearer <password>`
 
 **角色自检：** `GET /api/v1/whoami` — 返回当前角色和可用功能列表，用于前端 UI 动态渲染。
 
-> ⚠️ 当未设置任何密码时，所有端点（含管理端点）开放访问。生产部署务必至少设置 `admin_password`。
-> 此外，可通过环境变量 `SOUWEN_ADMIN_OPEN=1` 显式声明"管理端开放"以避免启动告警。
+> ⚠️ 当未设置管理密码时，管理端点默认拒绝访问。仅在本地开发或 CI 冒烟测试中使用 `SOUWEN_ADMIN_OPEN=1` 显式开放；生产部署务必设置 `admin_password`。
 
 ### 错误响应格式
 
@@ -467,7 +466,7 @@ Cache-Control: public, max-age=3600
 ### 管理端点 (`/api/v1/admin/...`)
 
 > 管理端点由 `require_auth` 强制保护，验证 `effective_admin_password`（`admin_password` > `api_password`）。
-> 未设置任一密码时管理端点开放访问，建议生产环境至少设置 `admin_password`。
+> 未设置任一管理密码时，管理端点默认返回 `401 Unauthorized`；只有设置 `SOUWEN_ADMIN_OPEN=1` 才会显式开放。
 
 #### `GET /api/v1/admin/config`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -213,7 +213,7 @@ sources: {}
 | 字段 | 环境变量 | 默认值 | 说明 |
 |------|---------|--------|------|
 | `api_password` | `SOUWEN_API_PASSWORD` | None | 旧版统一密码（向后兼容，同时作用于用户 + 管理） |
-| `user_password` | `SOUWEN_USER_PASSWORD` | None | 用户密码，保护搜索 + 只读管理端点 |
+| `user_password` | `SOUWEN_USER_PASSWORD` | None | 用户密码，保护搜索和 `/sources` |
 | `admin_password` | `SOUWEN_ADMIN_PASSWORD` | None | 管理密码，保护全部 `/api/v1/admin/*` |
 | `guest_enabled` | `SOUWEN_GUEST_ENABLED` | `false` | 是否启用游客访问（无 Token 也可搜索，受限源） |
 | `cors_origins` | `SOUWEN_CORS_ORIGINS` | `[]` | CORS 允许来源列表（逗号分隔），为空时不启用 CORS |
@@ -227,16 +227,16 @@ sources: {}
 | 角色 | 获取方式 | 可用端点 |
 |------|----------|----------|
 | Guest 游客 | 无 Token（需 `guest_enabled=true`） | 搜索（受限源、限速） |
-| User 用户 | `user_password` / `visitor_password` / `api_password` | 搜索 + 只读管理 |
+| User 用户 | `user_password` / `visitor_password` / `api_password` | 搜索 + `/sources` |
 | Admin 管理员 | `admin_password` / `api_password` | 全部权限 |
 
 **密码优先级**：
 
 - 用户端点：`user_password` > `visitor_password` > `api_password` > 无（开放）
-- 管理端点：`admin_password` > `api_password` > 无（开放，且需 `SOUWEN_ADMIN_OPEN=1` 显式放行）
+- 管理端点：`admin_password` > `api_password` > 无（默认锁定，需 `SOUWEN_ADMIN_OPEN=1` 显式放行）
 - Admin Token 自动满足 User/Guest 端点（角色层级：Admin ⊃ User ⊃ Guest）
 
-显式将 `user_password` 或 `admin_password` 设为空字符串可"强制开放"对应分组，忽略 `api_password` 回退。
+显式将 `user_password` 设为空字符串可开放用户端点；显式将 `admin_password` 设为空字符串只表示忽略 `api_password` 回退，管理端仍需 `SOUWEN_ADMIN_OPEN=1` 才开放。
 
 ## 代理池配置
 

--- a/panel/src/App.tsx
+++ b/panel/src/App.tsx
@@ -31,6 +31,7 @@ import { HashRouter, Routes, Route, Navigate, useLocation } from 'react-router-d
 import { LazyMotion, domAnimation, AnimatePresence } from 'framer-motion'
 import { useAuthStore } from '@core/stores/authStore'
 import { getActiveSkin } from '@core/skin-registry'
+import { canAccessPath } from '@core/lib/access'
 
 /**
  * AuthGuard 组件：认证保护装饰器
@@ -38,7 +39,11 @@ import { getActiveSkin } from '@core/skin-registry'
  */
 function AuthGuard({ children }: { children: React.ReactNode }) {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
+  const features = useAuthStore((s) => s.features)
+  const role = useAuthStore((s) => s.role)
+  const location = useLocation()
   if (!isAuthenticated) return <Navigate to="/login" replace />
+  if (!canAccessPath(location.pathname, features, role)) return <Navigate to="/search/paper" replace />
   return <>{children}</>
 }
 

--- a/panel/src/core/hooks/useToolsPage.ts
+++ b/panel/src/core/hooks/useToolsPage.ts
@@ -8,7 +8,9 @@
 import { useEffect, useRef, useState, type FormEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api } from '../services/api'
+import { hasFeatureAccess } from '../lib/access'
 import { useNotificationStore } from '../stores/notificationStore'
+import { useAuthStore } from '../stores/authStore'
 import type {
   WaybackSnapshot,
   WaybackAvailabilityResponse,
@@ -47,6 +49,9 @@ function toWaybackDate(s: string): string | undefined {
 export function useToolsPage() {
   const { t } = useTranslation()
   const addToast = useNotificationStore((s) => s.addToast)
+  const features = useAuthStore((s) => s.features)
+  const role = useAuthStore((s) => s.role)
+  const canSave = hasFeatureAccess(features, role, 'wayback_save')
   const [tab, setTab] = useState<Tab>('cdx')
   const abortRef = useRef<AbortController | null>(null)
 
@@ -71,6 +76,10 @@ export function useToolsPage() {
   useEffect(() => {
     return () => abortRef.current?.abort()
   }, [])
+
+  useEffect(() => {
+    if (!canSave && tab === 'save') setTab('cdx')
+  }, [canSave, tab])
 
   const cancelInflight = () => {
     abortRef.current?.abort()
@@ -124,6 +133,7 @@ export function useToolsPage() {
 
   const handleSave = async (e?: FormEvent) => {
     e?.preventDefault()
+    if (!canSave) return
     if (!saveUrl.trim()) return
     const signal = cancelInflight()
     setSaveLoading(true)
@@ -163,6 +173,7 @@ export function useToolsPage() {
     checkResult,
     handleCheck,
     // save
+    canSave,
     saveUrl, setSaveUrl,
     saveLoading,
     saveResult,

--- a/panel/src/core/lib/access.ts
+++ b/panel/src/core/lib/access.ts
@@ -1,0 +1,55 @@
+/**
+ * 文件用途：前端路由与导航的角色功能访问判断。
+ */
+
+import type { UserRole } from '../types'
+
+type Features = Record<string, boolean | string>
+
+const ADMIN_FEATURES = new Set([
+  'fetch',
+  'wayback_save',
+  'config_write',
+  'sources_config_write',
+  'proxy_admin',
+  'warp_admin',
+  'doctor_full',
+])
+
+const NAV_FEATURES: Record<string, string | undefined> = {
+  '/': 'doctor_full',
+  '/fetch': 'fetch',
+  '/sources': 'doctor_full',
+  '/network': 'proxy_admin',
+  '/warp': 'warp_admin',
+  '/config': 'config_write',
+}
+
+const ROUTE_FEATURES: Array<{ prefix: string; feature: string }> = [
+  { prefix: '/', feature: 'doctor_full' },
+  { prefix: '/fetch', feature: 'fetch' },
+  { prefix: '/sources', feature: 'doctor_full' },
+  { prefix: '/network', feature: 'proxy_admin' },
+  { prefix: '/warp', feature: 'warp_admin' },
+  { prefix: '/config', feature: 'config_write' },
+]
+
+export function hasFeatureAccess(features: Features, role: UserRole, feature: string): boolean {
+  const value = features[feature]
+  if (typeof value === 'boolean') return value
+  if (typeof value === 'string') return value.length > 0 && value !== 'false'
+  return role === 'admin' && ADMIN_FEATURES.has(feature)
+}
+
+export function canAccessNavItem(path: string, features: Features, role: UserRole): boolean {
+  const feature = NAV_FEATURES[path]
+  if (!feature) return true
+  return hasFeatureAccess(features, role, feature)
+}
+
+export function canAccessPath(path: string, features: Features, role: UserRole): boolean {
+  if (path === '/') return hasFeatureAccess(features, role, 'doctor_full')
+  const rule = ROUTE_FEATURES.find((entry) => path === entry.prefix || path.startsWith(`${entry.prefix}/`))
+  if (!rule) return true
+  return hasFeatureAccess(features, role, rule.feature)
+}

--- a/panel/src/core/lib/errors.ts
+++ b/panel/src/core/lib/errors.ts
@@ -14,8 +14,8 @@
  *     AppError.fromResponse（静态方法）
  *         - 功能：从 HTTP 响应创建错误实例
  *         - 输入：status 响应码，body 响应体文本
- *         - 输出：AppError 实例（自动检测 401/403 为认证错误）
- *         - 逻辑：状态码 401 或 403 时，isAuth 标记为 true；空 body 时用 HTTP 状态信息作消息
+ *         - 输出：AppError 实例（自动检测 401 为认证错误）
+ *         - 逻辑：状态码 401 时，isAuth 标记为 true；空 body 时用 HTTP 状态信息作消息
  *
  *     AppError.network（静态方法）
  *         - 功能：创建网络错误实例
@@ -52,10 +52,10 @@ export class AppError extends Error {
 
   /**
    * 从 HTTP 响应创建 AppError 实例
-   * 自动判断 401/403 为认证错误，使用响应状态信息作为备用消息
+   * 自动判断 401 为认证错误，使用响应状态信息作为备用消息
    */
   static fromResponse(status: number, body: string): AppError {
-    const isAuth = status === 401 || status === 403
+    const isAuth = status === 401
     return new AppError(body || `HTTP ${status}`, status, isAuth)
   }
 

--- a/panel/src/core/services/wayback.ts
+++ b/panel/src/core/services/wayback.ts
@@ -63,7 +63,7 @@ export const waybackMethods = {
     timeout = 60,
     signal?: AbortSignal,
   ): Promise<WaybackSaveResponse> {
-    return this.request<WaybackSaveResponse>('/api/v1/wayback/save', {
+    return this.request<WaybackSaveResponse>('/api/v1/admin/wayback/save', {
       method: 'POST',
       headers: this.headers(),
       body: JSON.stringify({ url, timeout }),

--- a/panel/src/core/test/access.test.ts
+++ b/panel/src/core/test/access.test.ts
@@ -1,0 +1,36 @@
+/**
+ * 文件用途：前端角色功能访问判断单元测试。
+ */
+
+import { describe, expect, it } from 'vitest'
+import { canAccessNavItem, canAccessPath, hasFeatureAccess } from '../lib/access'
+
+describe('access helpers', () => {
+  it('allows public navigation items without feature flags', () => {
+    expect(canAccessNavItem('/search', {}, 'user')).toBe(true)
+    expect(canAccessPath('/tools', {}, 'guest')).toBe(true)
+  })
+
+  it('hides admin navigation when whoami features deny access', () => {
+    const features = {
+      fetch: false,
+      config_write: false,
+      proxy_admin: false,
+      warp_admin: false,
+      doctor_full: false,
+    }
+    expect(canAccessNavItem('/fetch', features, 'user')).toBe(false)
+    expect(canAccessNavItem('/config', features, 'user')).toBe(false)
+    expect(canAccessNavItem('/', features, 'user')).toBe(false)
+    expect(canAccessPath('/', features, 'user')).toBe(false)
+    expect(canAccessPath('/network', features, 'user')).toBe(false)
+    expect(canAccessPath('/sources', features, 'user')).toBe(false)
+  })
+
+  it('allows admin navigation from explicit features or restored admin role fallback', () => {
+    expect(canAccessNavItem('/fetch', { fetch: true }, 'user')).toBe(true)
+    expect(canAccessPath('/config', {}, 'admin')).toBe(true)
+    expect(canAccessPath('/', {}, 'admin')).toBe(true)
+    expect(hasFeatureAccess({ wayback_save: true }, 'user', 'wayback_save')).toBe(true)
+  })
+})

--- a/panel/src/core/test/errors.test.ts
+++ b/panel/src/core/test/errors.test.ts
@@ -11,8 +11,8 @@
  *             it('creates auth error for 401')
  *                 - 验证：401 状态码自动标记为认证错误（isAuth=true）
  *
- *             it('creates auth error for 403')
- *                 - 验证：403 状态码也标记为认证错误
+ *             it('creates permission error for 403')
+ *                 - 验证：403 状态码不标记为认证错误
  *                 - 验证：空响应体时用 HTTP 状态文本作为消息
  *
  *             it('creates non-auth error for 500')
@@ -64,11 +64,11 @@ describe('AppError', () => {
     })
 
     /**
-     * 测试：403 响应创建认证错误
+     * 测试：403 响应创建权限错误，不触发认证登出
      */
-    it('creates auth error for 403', () => {
+    it('creates permission error for 403', () => {
       const err = AppError.fromResponse(403, '')
-      expect(err.isAuth).toBe(true)
+      expect(err.isAuth).toBe(false)
       expect(err.message).toBe('HTTP 403')
     })
 

--- a/panel/src/core/test/wayback.test.ts
+++ b/panel/src/core/test/wayback.test.ts
@@ -1,0 +1,23 @@
+/**
+ * 文件用途：Wayback API 路径单元测试。
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { waybackMethods } from '../services/wayback'
+
+describe('wayback service', () => {
+  it('uses the admin route for Save Page Now writes', async () => {
+    const request = vi.fn().mockResolvedValue({ success: true })
+    const ctx = {
+      request,
+      headers: vi.fn().mockReturnValue({ 'Content-Type': 'application/json' }),
+    }
+
+    await waybackMethods.waybackSave.call(ctx as never, 'https://example.com', 60)
+
+    expect(request).toHaveBeenCalledWith('/api/v1/admin/wayback/save', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ url: 'https://example.com', timeout: 60 }),
+    }))
+  })
+})

--- a/panel/src/skins/apple/components/layout/MainLayout.tsx
+++ b/panel/src/skins/apple/components/layout/MainLayout.tsx
@@ -41,6 +41,7 @@ import {
   FileText,
 } from 'lucide-react'
 import { useAuthStore } from '@core/stores/authStore'
+import { canAccessNavItem } from '@core/lib/access'
 import { useSkinStore } from '../../stores/skinStore'
 import { isSingleSkin, listSkinIds, getSkinOrDefault } from '@core/skin-registry'
 import styles from './MainLayout.module.scss'
@@ -90,6 +91,8 @@ export function MainLayout() {
   const location = useLocation()
   const logout = useAuthStore((s) => s.logout)
   const version = useAuthStore((s) => s.version)
+  const features = useAuthStore((s) => s.features)
+  const role = useAuthStore((s) => s.role)
   const { mode, toggleMode } = useSkinStore()
   const [mobileOpen, setMobileOpen] = useState(false)
   const [skinPaletteOpen, setSkinPaletteOpen] = useState(false)
@@ -97,6 +100,7 @@ export function MainLayout() {
 
   // 从 HTML 根元素的 data-skin 属性获取当前皮肤 ID，默认为 'apple'
   const currentSkinId = document.documentElement.getAttribute('data-skin') || 'apple'
+  const visibleNavItems = NAV_ITEMS.filter((item) => canAccessNavItem(item.to, features, role))
 
   // 路由路径变化时关闭移动端菜单
   useEffect(() => {
@@ -162,7 +166,7 @@ export function MainLayout() {
             </NavLink>
             {/* 桌面端导航链接列表 */}
             <div className={styles.navLinks}>
-              {NAV_ITEMS.map((item) => (
+              {visibleNavItems.map((item) => (
                 <NavLink
                   key={item.to}
                   to={item.to}
@@ -270,7 +274,7 @@ export function MainLayout() {
                 <X size={20} />
               </button>
             </div>
-            {NAV_ITEMS.map((item) => (
+            {visibleNavItems.map((item) => (
               <NavLink
                 key={item.to}
                 to={item.to}

--- a/panel/src/skins/apple/pages/ToolsPage.tsx
+++ b/panel/src/skins/apple/pages/ToolsPage.tsx
@@ -33,6 +33,7 @@ export function ToolsPage() {
     checkLoading,
     checkResult,
     handleCheck,
+    canSave,
     saveUrl, setSaveUrl,
     saveLoading,
     saveResult,
@@ -66,14 +67,16 @@ export function ToolsPage() {
         >
           <CheckCircle2 size={16} /> {t('tools.check')}
         </button>
-        <button
-          role="tab"
-          aria-selected={tab === 'save'}
-          className={`${styles.tab} ${tab === 'save' ? styles.tabActive : ''}`}
-          onClick={() => setTab('save')}
-        >
-          <Save size={16} /> {t('tools.save')}
-        </button>
+        {canSave && (
+          <button
+            role="tab"
+            aria-selected={tab === 'save'}
+            className={`${styles.tab} ${tab === 'save' ? styles.tabActive : ''}`}
+            onClick={() => setTab('save')}
+          >
+            <Save size={16} /> {t('tools.save')}
+          </button>
+        )}
       </div>
 
       {tab === 'cdx' && (
@@ -266,7 +269,7 @@ export function ToolsPage() {
         </section>
       )}
 
-      {tab === 'save' && (
+      {canSave && tab === 'save' && (
         <section className={styles.panel}>
           <form className={styles.form} onSubmit={handleSave}>
             <div className={styles.field}>

--- a/panel/src/skins/carbon/components/layout/MainLayout.tsx
+++ b/panel/src/skins/carbon/components/layout/MainLayout.tsx
@@ -25,6 +25,7 @@ import {
   FileText,
 } from 'lucide-react'
 import { useAuthStore } from '@core/stores/authStore'
+import { canAccessNavItem } from '@core/lib/access'
 import { useSkinStore } from '../../stores/skinStore'
 import { skinConfig } from '../../skin.config'
 import { isSingleSkin, listSkinIds, getSkinOrDefault } from '@core/skin-registry'
@@ -58,6 +59,8 @@ export function MainLayout() {
   const location = useLocation()
   const logout = useAuthStore((s) => s.logout)
   const version = useAuthStore((s) => s.version)
+  const features = useAuthStore((s) => s.features)
+  const role = useAuthStore((s) => s.role)
   const { mode, toggleMode, scheme, setScheme } = useSkinStore()
   const [mobileOpen, setMobileOpen] = useState(false)
   const [skinPaletteOpen, setSkinPaletteOpen] = useState(false)
@@ -99,6 +102,7 @@ export function MainLayout() {
   }, [skinPaletteOpen, schemePaletteOpen])
 
   const currentSkinId = document.documentElement.getAttribute('data-skin') || 'carbon'
+  const visibleNavItems = NAV_ITEMS.filter((item) => canAccessNavItem(item.to, features, role))
 
   const handleSkinSwitch = (nextId: string) => {
     if (nextId === currentSkinId) {
@@ -133,7 +137,7 @@ export function MainLayout() {
           </div>
 
           <nav className={styles.nav}>
-            {NAV_ITEMS.map((item) => (
+            {visibleNavItems.map((item) => (
               <NavLink
                 key={item.to}
                 to={item.to}
@@ -294,7 +298,7 @@ export function MainLayout() {
               SouWen.
             </div>
             <nav className={styles.drawerNav}>
-              {NAV_ITEMS.map((item) => (
+              {visibleNavItems.map((item) => (
                 <NavLink
                   key={item.to}
                   to={item.to}

--- a/panel/src/skins/carbon/pages/ToolsPage.tsx
+++ b/panel/src/skins/carbon/pages/ToolsPage.tsx
@@ -33,6 +33,7 @@ export function ToolsPage() {
     checkLoading,
     checkResult,
     handleCheck,
+    canSave,
     saveUrl, setSaveUrl,
     saveLoading,
     saveResult,
@@ -68,14 +69,16 @@ export function ToolsPage() {
         >
           <CheckCircle2 size={14} /> {t('tools.check')}
         </button>
-        <button
-          role="tab"
-          aria-selected={tab === 'save'}
-          className={`${styles.tab} ${tab === 'save' ? styles.tabActive : ''}`}
-          onClick={() => setTab('save')}
-        >
-          <Save size={14} /> {t('tools.save')}
-        </button>
+        {canSave && (
+          <button
+            role="tab"
+            aria-selected={tab === 'save'}
+            className={`${styles.tab} ${tab === 'save' ? styles.tabActive : ''}`}
+            onClick={() => setTab('save')}
+          >
+            <Save size={14} /> {t('tools.save')}
+          </button>
+        )}
       </div>
 
       {tab === 'cdx' && (
@@ -270,7 +273,7 @@ export function ToolsPage() {
         </section>
       )}
 
-      {tab === 'save' && (
+      {canSave && tab === 'save' && (
         <section className={styles.panel}>
           <div className={styles.panelHeader}>
             <Save size={12} /> {t('tools.save')}

--- a/panel/src/skins/ios/components/layout/MainLayout.tsx
+++ b/panel/src/skins/ios/components/layout/MainLayout.tsx
@@ -41,6 +41,7 @@ import {
   FileText,
 } from 'lucide-react'
 import { useAuthStore } from '@core/stores/authStore'
+import { canAccessNavItem } from '@core/lib/access'
 import { useSkinStore } from '../../stores/skinStore'
 import { isSingleSkin, listSkinIds, getSkinOrDefault } from '@core/skin-registry'
 import styles from './MainLayout.module.scss'
@@ -77,6 +78,8 @@ export function MainLayout() {
   const location = useLocation()
   const logout = useAuthStore((s) => s.logout)
   const version = useAuthStore((s) => s.version)
+  const features = useAuthStore((s) => s.features)
+  const role = useAuthStore((s) => s.role)
   const { mode, toggleMode } = useSkinStore()
   const [mobileOpen, setMobileOpen] = useState(false)
   const [skinPaletteOpen, setSkinPaletteOpen] = useState(false)
@@ -84,6 +87,7 @@ export function MainLayout() {
 
   // 获取当前应用皮肤（默认为 'ios'）
   const currentSkinId = document.documentElement.getAttribute('data-skin') || 'ios'
+  const visibleNavItems = NAV_ITEMS.filter((item) => canAccessNavItem(item.to, features, role))
 
   // 路由变化时关闭移动菜单
   useEffect(() => {
@@ -130,7 +134,7 @@ export function MainLayout() {
 
       {/* Navigation items */}
       <nav className={styles.sidebarNav}>
-        {NAV_ITEMS.map((item) => (
+        {visibleNavItems.map((item) => (
           <NavLink
             key={item.to}
             to={item.to}

--- a/panel/src/skins/ios/pages/ToolsPage.tsx
+++ b/panel/src/skins/ios/pages/ToolsPage.tsx
@@ -33,6 +33,7 @@ export function ToolsPage() {
     checkLoading,
     checkResult,
     handleCheck,
+    canSave,
     saveUrl, setSaveUrl,
     saveLoading,
     saveResult,
@@ -68,15 +69,17 @@ export function ToolsPage() {
           <CheckCircle2 size={14} />
           <span>{t('tools.check')}</span>
         </button>
-        <button
-          role="tab"
-          aria-selected={tab === 'save'}
-          className={`${styles.segment} ${tab === 'save' ? styles.segmentActive : ''}`}
-          onClick={() => setTab('save')}
-        >
-          <Save size={14} />
-          <span>{t('tools.save')}</span>
-        </button>
+        {canSave && (
+          <button
+            role="tab"
+            aria-selected={tab === 'save'}
+            className={`${styles.segment} ${tab === 'save' ? styles.segmentActive : ''}`}
+            onClick={() => setTab('save')}
+          >
+            <Save size={14} />
+            <span>{t('tools.save')}</span>
+          </button>
+        )}
       </div>
 
       {tab === 'cdx' && (
@@ -253,7 +256,7 @@ export function ToolsPage() {
         </section>
       )}
 
-      {tab === 'save' && (
+      {canSave && tab === 'save' && (
         <section className={styles.panel}>
           <form className={styles.form} onSubmit={handleSave}>
             <div className={styles.field}>

--- a/panel/src/skins/souwen-google/components/layout/MainLayout.tsx
+++ b/panel/src/skins/souwen-google/components/layout/MainLayout.tsx
@@ -50,6 +50,7 @@ import {
   Layers,
 } from 'lucide-react'
 import { useAuthStore } from '@core/stores/authStore'
+import { canAccessNavItem } from '@core/lib/access'
 import { useSkinStore } from '../../stores/skinStore'
 import { skinConfig } from '../../skin.config'
 import { getSkinOrDefault, isSingleSkin, listSkinIds } from '@core/skin-registry'
@@ -133,6 +134,8 @@ export function MainLayout() {
   const location = useLocation()
   const logout = useAuthStore((s) => s.logout)
   const version = useAuthStore((s) => s.version)
+  const features = useAuthStore((s) => s.features)
+  const role = useAuthStore((s) => s.role)
   const { mode, toggleMode, scheme, setScheme } = useSkinStore()
   // 主题调色板和 skin 选择器的显示状态
   const [themePaletteOpen, setThemePaletteOpen] = useState(false)
@@ -150,6 +153,7 @@ export function MainLayout() {
 
   // 获取当前激活的 skin ID
   const currentSkinId = document.documentElement.getAttribute('data-skin') || 'souwen-google'
+  const visibleNavItems = NAV_ITEMS.filter((item) => canAccessNavItem(item.to, features, role))
 
   // 外部点击或 ESC 关闭调色板菜单
   useEffect(() => {
@@ -212,7 +216,7 @@ export function MainLayout() {
 
       {/* 导航菜单 */}
       <nav className={styles.nav}>
-        {NAV_ITEMS.map((item) => (
+        {visibleNavItems.map((item) => (
           <NavLink
             key={item.to}
             to={item.to}

--- a/panel/src/skins/souwen-google/pages/ToolsPage.tsx
+++ b/panel/src/skins/souwen-google/pages/ToolsPage.tsx
@@ -33,6 +33,7 @@ export function ToolsPage() {
     checkLoading,
     checkResult,
     handleCheck,
+    canSave,
     saveUrl, setSaveUrl,
     saveLoading,
     saveResult,
@@ -66,14 +67,16 @@ export function ToolsPage() {
         >
           <CheckCircle2 size={14} /> {t('tools.check')}
         </button>
-        <button
-          role="tab"
-          aria-selected={tab === 'save'}
-          className={`${styles.tab} ${tab === 'save' ? styles.tabActive : ''}`}
-          onClick={() => setTab('save')}
-        >
-          <Save size={14} /> {t('tools.save')}
-        </button>
+        {canSave && (
+          <button
+            role="tab"
+            aria-selected={tab === 'save'}
+            className={`${styles.tab} ${tab === 'save' ? styles.tabActive : ''}`}
+            onClick={() => setTab('save')}
+          >
+            <Save size={14} /> {t('tools.save')}
+          </button>
+        )}
       </div>
 
       {tab === 'cdx' && (
@@ -262,7 +265,7 @@ export function ToolsPage() {
         </section>
       )}
 
-      {tab === 'save' && (
+      {canSave && tab === 'save' && (
         <section className={styles.panel}>
           <form className={styles.form} onSubmit={handleSave}>
             <div className={`${styles.field} ${styles.fieldFull}`}>

--- a/panel/src/skins/souwen-nebula/components/layout/MainLayout.tsx
+++ b/panel/src/skins/souwen-nebula/components/layout/MainLayout.tsx
@@ -50,6 +50,7 @@ import {
   Layers,
 } from 'lucide-react'
 import { useAuthStore } from '@core/stores/authStore'
+import { canAccessNavItem } from '@core/lib/access'
 import { useSkinStore } from '../../stores/skinStore'
 import { skinConfig } from '../../skin.config'
 import { getSkinOrDefault, isSingleSkin, listSkinIds } from '@core/skin-registry'
@@ -121,6 +122,8 @@ export function MainLayout() {
   const location = useLocation()
   const logout = useAuthStore((s) => s.logout)
   const version = useAuthStore((s) => s.version)
+  const features = useAuthStore((s) => s.features)
+  const role = useAuthStore((s) => s.role)
   const { mode, toggleMode, scheme, setScheme } = useSkinStore()
   // 主题调色板和 skin 选择器的显示状态
   const [themePaletteOpen, setThemePaletteOpen] = useState(false)
@@ -138,6 +141,7 @@ export function MainLayout() {
 
   // 获取当前激活的 skin ID
   const currentSkinId = document.documentElement.getAttribute('data-skin') || 'souwen-nebula'
+  const visibleNavItems = NAV_ITEMS.filter((item) => canAccessNavItem(item.to, features, role))
 
   // 外部点击或 ESC 关闭调色板菜单
   useEffect(() => {
@@ -200,7 +204,7 @@ export function MainLayout() {
 
       {/* 导航菜单 */}
       <nav className={styles.nav}>
-        {NAV_ITEMS.map((item) => (
+        {visibleNavItems.map((item) => (
           <NavLink
             key={item.to}
             to={item.to}

--- a/panel/src/skins/souwen-nebula/pages/ToolsPage.tsx
+++ b/panel/src/skins/souwen-nebula/pages/ToolsPage.tsx
@@ -33,6 +33,7 @@ export function ToolsPage() {
     checkLoading,
     checkResult,
     handleCheck,
+    canSave,
     saveUrl, setSaveUrl,
     saveLoading,
     saveResult,
@@ -66,14 +67,16 @@ export function ToolsPage() {
         >
           <CheckCircle2 size={14} /> {t('tools.check')}
         </button>
-        <button
-          role="tab"
-          aria-selected={tab === 'save'}
-          className={`${styles.tab} ${tab === 'save' ? styles.tabActive : ''}`}
-          onClick={() => setTab('save')}
-        >
-          <Save size={14} /> {t('tools.save')}
-        </button>
+        {canSave && (
+          <button
+            role="tab"
+            aria-selected={tab === 'save'}
+            className={`${styles.tab} ${tab === 'save' ? styles.tabActive : ''}`}
+            onClick={() => setTab('save')}
+          >
+            <Save size={14} /> {t('tools.save')}
+          </button>
+        )}
       </div>
 
       {tab === 'cdx' && (
@@ -262,7 +265,7 @@ export function ToolsPage() {
         </section>
       )}
 
-      {tab === 'save' && (
+      {canSave && tab === 'save' && (
         <section className={styles.panel}>
           <form className={styles.form} onSubmit={handleSave}>
             <div className={`${styles.field} ${styles.fieldFull}`}>

--- a/src/souwen/cli/config_cmds.py
+++ b/src/souwen/cli/config_cmds.py
@@ -22,14 +22,14 @@ def _mask_value(value: str | None) -> str:
 @config_app.command("show")
 def config_show() -> None:
     """显示当前配置（隐藏 Key 值）"""
-    from souwen.config import get_config
+    from souwen.config import SouWenConfig, get_config
 
     cfg = get_config()
     table = Table(title="⚙️  SouWen 配置", show_lines=True)
     table.add_column("字段", style="cyan")
     table.add_column("值", style="green")
 
-    for field_name, field_info in cfg.model_fields.items():
+    for field_name, field_info in SouWenConfig.model_fields.items():
         raw_val = getattr(cfg, field_name)
         is_secret = (
             "key" in field_name

--- a/src/souwen/cli/serve.py
+++ b/src/souwen/cli/serve.py
@@ -26,6 +26,7 @@ def serve(
     setup_logging()
 
     from souwen.config import get_config
+    from souwen.server.auth import is_admin_open_enabled
 
     cfg = get_config()
     console.print("[bold]━━━ SouWen 启动配置 ━━━[/bold]")
@@ -36,8 +37,9 @@ def serve(
     console.print(f"  访客密码:        [{v_color}]{v_text}[/]")
     # 管理密码状态
     a_pw = cfg.effective_admin_password
-    a_color = "green" if a_pw else "yellow"
-    a_text = "已启用" if a_pw else "未启用（管理端开放）"
+    admin_open = is_admin_open_enabled()
+    a_color = "green" if a_pw else "yellow" if admin_open else "red"
+    a_text = "已启用" if a_pw else "未启用（显式开放）" if admin_open else "未启用（默认锁定）"
     console.print(f"  管理密码:        [{a_color}]{a_text}[/]")
     console.print(f"  Docs:            {'已开放' if cfg.expose_docs else '已隐藏'}")
     console.print(

--- a/src/souwen/config/loader.py
+++ b/src/souwen/config/loader.py
@@ -11,7 +11,7 @@ import os
 from functools import lru_cache
 from pathlib import Path
 
-from dotenv import load_dotenv
+from dotenv import dotenv_values
 
 from .models import SouWenConfig
 from .template import _DEFAULT_CONFIG_TEMPLATE
@@ -22,10 +22,6 @@ try:
     import yaml
 except ImportError:  # pragma: no cover
     yaml = None  # type: ignore[assignment]
-
-
-# 加载 .env 文件
-load_dotenv()
 
 
 def _load_yaml_config() -> dict:
@@ -80,6 +76,106 @@ def _load_yaml_config() -> dict:
     return flat
 
 
+_WARP_ENV_ALIASES = {
+    "warp_enabled": "WARP_ENABLED",
+    "warp_mode": "WARP_MODE",
+    "warp_socks_port": "WARP_SOCKS_PORT",
+    "warp_endpoint": "WARP_ENDPOINT",
+    "warp_bind_address": "WARP_BIND_ADDRESS",
+    "warp_startup_timeout": "WARP_STARTUP_TIMEOUT",
+    "warp_device_name": "WARP_DEVICE_NAME",
+    "warp_proxy_username": "WARP_PROXY_USERNAME",
+    "warp_proxy_password": "WARP_PROXY_PASSWORD",
+    "warp_usque_path": "WARP_USQUE_PATH",
+    "warp_usque_config": "WARP_USQUE_CONFIG",
+    "warp_usque_transport": "WARP_USQUE_TRANSPORT",
+    "warp_usque_system_dns": "WARP_USQUE_SYSTEM_DNS",
+    "warp_usque_on_connect": "WARP_USQUE_ON_CONNECT",
+    "warp_usque_on_disconnect": "WARP_USQUE_ON_DISCONNECT",
+    "warp_http_port": "WARP_HTTP_PORT",
+    "warp_license_key": "WARP_LICENSE_KEY",
+    "warp_team_token": "WARP_TEAM_TOKEN",
+    "warp_gost_args": "WARP_GOST_ARGS",
+    "warp_external_proxy": "WARP_EXTERNAL_PROXY",
+}
+
+
+def _coerce_env_value(field_name: str, raw_val: str, env_key: str):
+    """按 SouWenConfig 字段类型解析环境变量 / .env 字符串值。"""
+    val = raw_val
+    field_info = SouWenConfig.model_fields[field_name]
+    if field_info.annotation is bool:
+        return val.lower() in ("1", "true", "yes", "on")
+    if field_info.annotation in (int, int | None):
+        try:
+            return int(val)
+        except (ValueError, TypeError):
+            logger.warning("环境变量 %s=%r 无法转为整数,已忽略", env_key, val)
+            return None
+    if field_name in ("proxy_pool", "cors_origins", "trusted_proxies", "plugins"):
+        stripped = val.strip()
+        if stripped.startswith("["):
+            try:
+                parsed = json.loads(stripped)
+            except json.JSONDecodeError:
+                logger.warning("环境变量 %s JSON 解析失败,已忽略", env_key)
+                return None
+            if not isinstance(parsed, list):
+                logger.warning("环境变量 %s 应为 JSON 数组,已忽略", env_key)
+                return None
+            return [str(p).strip() for p in parsed if str(p).strip()]
+        return [p.strip() for p in val.split(",") if p.strip()]
+    if field_name == "http_backend":
+        try:
+            parsed = json.loads(val)
+        except json.JSONDecodeError:
+            logger.warning("环境变量 %s JSON 解析失败,已忽略", env_key)
+            return None
+        if isinstance(parsed, dict):
+            return parsed
+        logger.warning("环境变量 %s 应为 JSON 对象,已忽略", env_key)
+        return None
+    if field_name == "sources":
+        try:
+            parsed = json.loads(val)
+        except json.JSONDecodeError:
+            logger.warning("环境变量 %s JSON 解析失败,已忽略", env_key)
+            return None
+        if isinstance(parsed, dict):
+            return parsed
+        logger.warning("环境变量 %s 应为 JSON 对象,已忽略", env_key)
+        return None
+    return val
+
+
+def _load_env_mapping(values: dict[str, str | None]) -> dict:
+    """将 .env 或 os.environ 的键值映射为 SouWenConfig kwargs。"""
+    kwargs: dict = {}
+    env_prefix = "SOUWEN_"
+    for field_name in SouWenConfig.model_fields:
+        env_key = f"{env_prefix}{field_name.upper()}"
+        val = values.get(env_key)
+        alias_key = None
+        if val is None and field_name in _WARP_ENV_ALIASES:
+            alias_key = _WARP_ENV_ALIASES[field_name]
+            val = values.get(alias_key)
+        if val is None:
+            continue
+        source_key = alias_key or env_key
+        parsed = _coerce_env_value(field_name, val, source_key)
+        if parsed is not None:
+            kwargs[field_name] = parsed
+    return kwargs
+
+
+def _load_dotenv_config() -> dict:
+    """加载当前目录 .env，优先级低于 YAML，且不污染 os.environ。"""
+    path = Path(".env")
+    if not path.is_file():
+        return {}
+    return _load_env_mapping(dotenv_values(path))
+
+
 @lru_cache(maxsize=1)
 def get_config() -> SouWenConfig:
     """获取全局配置(LRU 缓存单例)
@@ -102,92 +198,9 @@ def get_config() -> SouWenConfig:
     Note:
         若需要重新加载配置,调用 reload_config().
     """
-    # 先加载 YAML 配置(优先级低于环境变量)
-    kwargs: dict = _load_yaml_config()
-
-    # 环境变量覆盖 YAML 值
-    env_prefix = "SOUWEN_"
-    # WARP 相关字段也支持不带前缀的环境变量 (兼容 Docker entrypoint)
-    _warp_env_aliases = {
-        "warp_enabled": "WARP_ENABLED",
-        "warp_mode": "WARP_MODE",
-        "warp_socks_port": "WARP_SOCKS_PORT",
-        "warp_endpoint": "WARP_ENDPOINT",
-        "warp_bind_address": "WARP_BIND_ADDRESS",
-        "warp_startup_timeout": "WARP_STARTUP_TIMEOUT",
-        "warp_device_name": "WARP_DEVICE_NAME",
-        "warp_proxy_username": "WARP_PROXY_USERNAME",
-        "warp_proxy_password": "WARP_PROXY_PASSWORD",
-        "warp_usque_path": "WARP_USQUE_PATH",
-        "warp_usque_config": "WARP_USQUE_CONFIG",
-        "warp_usque_transport": "WARP_USQUE_TRANSPORT",
-        "warp_usque_system_dns": "WARP_USQUE_SYSTEM_DNS",
-        "warp_usque_on_connect": "WARP_USQUE_ON_CONNECT",
-        "warp_usque_on_disconnect": "WARP_USQUE_ON_DISCONNECT",
-        "warp_http_port": "WARP_HTTP_PORT",
-        "warp_license_key": "WARP_LICENSE_KEY",
-        "warp_team_token": "WARP_TEAM_TOKEN",
-        "warp_gost_args": "WARP_GOST_ARGS",
-        "warp_external_proxy": "WARP_EXTERNAL_PROXY",
-    }
-    for field_name in SouWenConfig.model_fields:
-        env_key = f"{env_prefix}{field_name.upper()}"
-        val = os.getenv(env_key)
-        # 回退到不带前缀的别名
-        if val is None and field_name in _warp_env_aliases:
-            val = os.getenv(_warp_env_aliases[field_name])
-        if val is not None:
-            field_info = SouWenConfig.model_fields[field_name]
-            # 布尔字段
-            if field_info.annotation is bool:
-                val = val.lower() in ("1", "true", "yes", "on")
-            # 整数字段
-            elif field_info.annotation in (int, int | None):
-                try:
-                    val = int(val)
-                except (ValueError, TypeError):
-                    logger.warning("环境变量 %s=%r 无法转为整数,已忽略", env_key, val)
-                    continue
-            # proxy_pool / cors_origins / trusted_proxies / plugins: 逗号分隔字符串 或 JSON 数组 → list[str]
-            elif field_name in ("proxy_pool", "cors_origins", "trusted_proxies", "plugins"):
-                stripped = val.strip()
-                if stripped.startswith("["):
-                    try:
-                        parsed = json.loads(stripped)
-                    except json.JSONDecodeError:
-                        logger.warning("环境变量 %s JSON 解析失败,已忽略", env_key)
-                        continue
-                    if not isinstance(parsed, list):
-                        logger.warning("环境变量 %s 应为 JSON 数组,已忽略", env_key)
-                        continue
-                    val = [str(p).strip() for p in parsed if str(p).strip()]
-                else:
-                    val = [p.strip() for p in val.split(",") if p.strip()]
-            # http_backend: JSON 字符串 → dict[str, str]
-            elif field_name == "http_backend":
-                try:
-                    parsed = json.loads(val)
-                    if isinstance(parsed, dict):
-                        val = parsed
-                    else:
-                        logger.warning("环境变量 %s 应为 JSON 对象,已忽略", env_key)
-                        continue
-                except json.JSONDecodeError:
-                    logger.warning("环境变量 %s JSON 解析失败,已忽略", env_key)
-                    continue
-            # sources: JSON 字符串 → dict[str, SourceChannelConfig]
-            elif field_name == "sources":
-                try:
-                    parsed = json.loads(val)
-                    if isinstance(parsed, dict):
-                        val = parsed
-                    else:
-                        logger.warning("环境变量 %s 应为 JSON 对象,已忽略", env_key)
-                        continue
-                except json.JSONDecodeError:
-                    logger.warning("环境变量 %s JSON 解析失败,已忽略", env_key)
-                    continue
-            kwargs[field_name] = val
+    kwargs: dict = _load_dotenv_config()
+    kwargs.update(_load_yaml_config())
+    kwargs.update(_load_env_mapping(dict(os.environ)))
 
     cfg = SouWenConfig(**kwargs)
 
@@ -206,14 +219,11 @@ def get_config() -> SouWenConfig:
 def reload_config() -> SouWenConfig:
     """清除缓存并返回重新加载的配置
 
-    重新读取 .env 文件但不覆盖已有的环境变量(override=False),
-    这样 `docker run -e SOUWEN_API_PASSWORD=xxx` 不会被 .env 文件冲掉.
-    用于 Docker 容器初始化或配置热更新场景.
+    清理缓存后重新按 环境变量 > YAML > .env > 默认值 的顺序加载配置。
 
     Returns:
         新加载的 SouWenConfig 实例
     """
-    load_dotenv(override=False)
     get_config.cache_clear()
     return get_config()
 

--- a/src/souwen/config/models.py
+++ b/src/souwen/config/models.py
@@ -192,7 +192,7 @@ class SouWenConfig(BaseModel):
     # ===== 服务（认证） =====
     api_password: str | None = None  # 旧版统一密码(向后兼容,同时作用于访客和管理)
     visitor_password: str | None = None  # 旧版访客密码(映射为 user_password)
-    user_password: str | None = None  # 用户密码(保护搜索/只读管理端点)
+    user_password: str | None = None  # 用户密码(保护搜索和 /sources)
     admin_password: str | None = None  # 管理密码(保护管理端点)
     guest_enabled: bool = False  # 是否启用游客访问(无Token可访问搜索)
 
@@ -213,8 +213,9 @@ class SouWenConfig(BaseModel):
 
     @property
     def effective_admin_password(self) -> str | None:
-        """解析生效的管理密码: admin_password > api_password > None(开放)。
-        显式设为空字符串表示"强制开放,忽略 api_password 回退"。"""
+        """解析生效的管理密码: admin_password > api_password > None。
+        显式设为空字符串表示"不使用密码,忽略 api_password 回退";
+        无密码 admin 访问仍需 SOUWEN_ADMIN_OPEN=1 显式放行。"""
         if self.admin_password is not None:
             return self.admin_password or None
         return self.api_password

--- a/src/souwen/config/template.py
+++ b/src/souwen/config/template.py
@@ -78,7 +78,7 @@ general:
 server:
   # 旧版统一密码（同时作用于用户和管理端点，向后兼容）
   api_password: ~
-  # 用户密码（保护搜索+只读管理端点，优先于 api_password）
+  # 用户密码（保护搜索和 /sources，优先于 api_password）
   user_password: ~
   # 管理密码（保护全部管理端点，优先于 api_password）
   admin_password: ~

--- a/src/souwen/server/app.py
+++ b/src/souwen/server/app.py
@@ -82,6 +82,7 @@ from starlette.middleware.gzip import GZipMiddleware
 from souwen import __version__
 from souwen.config import ensure_config_file, get_config
 from souwen.logging_config import setup_logging
+from souwen.server.auth import is_admin_open_enabled
 from souwen.server.middleware import RequestIDMiddleware, get_request_id
 from souwen.server.routes import router, admin_router
 from souwen.server.schemas import ErrorResponse, HealthResponse, ReadinessResponse
@@ -129,11 +130,15 @@ async def lifespan(app: FastAPI):
     auth_parts = []
     if admin_pw:
         auth_parts.append("管理员")
+    elif is_admin_open_enabled():
+        auth_parts.append("管理员(开放)")
+    else:
+        auth_parts.append("管理员(锁定)")
     if user_pw:
         auth_parts.append("用户")
     if cfg.guest_enabled:
         auth_parts.append("游客(开放)")
-    auth_desc = " + ".join(auth_parts) if auth_parts else "全开放"
+    auth_desc = " + ".join(auth_parts)
     logger.info(
         "SouWen %s 启动 | 角色: %s",
         __version__,
@@ -141,14 +146,7 @@ async def lifespan(app: FastAPI):
     )
     if (
         not admin_pw
-        and not user_pw
-        and os.getenv("SOUWEN_ADMIN_OPEN", "").strip().lower()
-        in (
-            "1",
-            "true",
-            "yes",
-            "on",
-        )
+        and is_admin_open_enabled()
     ):
         logger.warning(
             "SOUWEN_ADMIN_OPEN=1 已显式解除 Admin API 锁定；"

--- a/src/souwen/server/app.py
+++ b/src/souwen/server/app.py
@@ -144,10 +144,7 @@ async def lifespan(app: FastAPI):
         __version__,
         auth_desc,
     )
-    if (
-        not admin_pw
-        and is_admin_open_enabled()
-    ):
+    if not admin_pw and is_admin_open_enabled():
         logger.warning(
             "SOUWEN_ADMIN_OPEN=1 已显式解除 Admin API 锁定；"
             "任何能访问 /api/v1/admin/* 的客户端都将获得管理员权限，生产环境禁用。"

--- a/src/souwen/server/auth.py
+++ b/src/souwen/server/auth.py
@@ -7,12 +7,12 @@
 
 角色层级（Admin ⊃ User ⊃ Guest）：
     - Guest 游客：无 Token 即可访问搜索端点（受限源、限速）
-    - User 用户：提供 user_password，可访问搜索 + 只读管理端点
+    - User 用户：提供 user_password，可访问搜索 + /sources
     - Admin 管理员：提供 admin_password，拥有全部权限
 
 密码解析优先级：
     - 用户端点：user_password > visitor_password > api_password > 无密码（开放）
-    - 管理端点：admin_password > api_password > 无密码（开放）
+    - 管理端点：admin_password > api_password > 无密码（需 SOUWEN_ADMIN_OPEN=1 显式开放）
     - Admin Token 自动满足 User/Guest 端点
 
 主要接口：
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import enum
 import logging
+import os
 import secrets
 
 from fastapi import Depends, HTTPException, status
@@ -44,6 +45,12 @@ from souwen.config import get_config
 logger = logging.getLogger("souwen.server")
 
 _bearer_scheme = HTTPBearer(auto_error=False)
+_ADMIN_OPEN_VALUES = {"1", "true", "yes", "on"}
+
+
+def is_admin_open_enabled() -> bool:
+    """是否显式开放无密码 admin 端点。"""
+    return os.getenv("SOUWEN_ADMIN_OPEN", "").strip().lower() in _ADMIN_OPEN_VALUES
 
 
 class Role(enum.IntEnum):
@@ -83,15 +90,12 @@ def resolve_role(
     if is_user:
         return Role.USER
 
-    # Guest 逻辑：
-    # 1. 未配置任何密码 → 全开放，给 ADMIN
-    # 2. guest_enabled=True → 允许无 Token 访问（GUEST）
-    # 3. guest_enabled=False → 无有效 Token 则拒绝
-    if not admin_pw and not user_pw:
-        return Role.ADMIN  # 全开放模式
-
+    if not admin_pw and is_admin_open_enabled():
+        return Role.ADMIN
     if cfg.guest_enabled:
         return Role.GUEST
+    if not user_pw:
+        return Role.USER
 
     raise HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
@@ -142,20 +146,43 @@ def require_auth(
 ) -> None:
     """向后兼容：管理端点认证
 
-    行为与旧版一致：
-    - 若管理密码未配置（effective_admin_password 为 None）→ 放行
-    - 否则要求 ADMIN 角色（non-ADMIN 一律 401，与旧版相同）
+    行为：
+    - 若管理密码未配置，必须设置 SOUWEN_ADMIN_OPEN=1 才显式放行
+    - 否则要求 ADMIN 角色；有效但权限不足的 USER 返回 403
     """
     cfg = get_config()
     if not cfg.effective_admin_password:
-        return  # 管理密码未配置 → 管理端点开放
-    role = resolve_role(credentials)
-    if role < Role.ADMIN:
+        if is_admin_open_enabled():
+            return
+        if credentials and cfg.effective_user_password:
+            role = resolve_role(credentials)
+            if role >= Role.USER:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="权限不足：此端点需要管理员权限",
+                )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="认证失败：无效的管理端 Bearer Token",
+            detail="认证失败：管理端未配置密码，需设置 SOUWEN_ADMIN_OPEN=1 才允许无密码访问",
             headers={"WWW-Authenticate": "Bearer"},
         )
+    token = credentials.credentials if credentials else ""
+    admin_pw = cfg.effective_admin_password or ""
+    user_pw = cfg.effective_user_password or ""
+    is_admin = bool(admin_pw) and secrets.compare_digest(token, admin_pw)
+    is_user = bool(user_pw) and secrets.compare_digest(token, user_pw)
+    if is_admin:
+        return
+    if is_user:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="权限不足：此端点需要管理员权限",
+        )
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="认证失败：无效的管理端 Bearer Token",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
 
 
 def check_search_auth(

--- a/src/souwen/server/routes/sources.py
+++ b/src/souwen/server/routes/sources.py
@@ -23,6 +23,8 @@ async def list_sources():
     cfg = get_config()
 
     def _is_usable(name: str, needs_key: bool) -> bool:
+        if not cfg.is_source_enabled(name):
+            return False
         if not needs_key:
             return True
         meta = get_source(name)

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -157,6 +157,22 @@ class TestPrecedence:
         assert cfg.timeout == 13
         assert cfg.timeout != SouWenConfig().timeout
 
+    def test_yaml_beats_dotenv(self, monkeypatch, tmp_path):
+        """.env 低于 YAML，不能悄悄覆盖 souwen.yaml。"""
+        monkeypatch.delenv("SOUWEN_TIMEOUT", raising=False)
+        (tmp_path / ".env").write_text("SOUWEN_TIMEOUT=99\n", encoding="utf-8")
+        (tmp_path / "souwen.yaml").write_text("timeout: 13\n", encoding="utf-8")
+        cfg = reload_config()
+        assert cfg.timeout == 13
+
+    def test_env_beats_dotenv_and_yaml(self, monkeypatch, tmp_path):
+        """真实环境变量仍高于 YAML 和 .env。"""
+        (tmp_path / ".env").write_text("SOUWEN_TIMEOUT=22\n", encoding="utf-8")
+        (tmp_path / "souwen.yaml").write_text("timeout: 33\n", encoding="utf-8")
+        monkeypatch.setenv("SOUWEN_TIMEOUT", "44")
+        cfg = reload_config()
+        assert cfg.timeout == 44
+
     def test_default_when_neither_set(self):
         """既无 YAML 也无环境变量时，使用 SouWenConfig 默认值。"""
         cfg = reload_config()

--- a/tests/test_server/test_app.py
+++ b/tests/test_server/test_app.py
@@ -7,12 +7,14 @@
 请求，对外部数据源（souwen.search / souwen.web）统一 monkeypatch。
 
 Fixtures：
-- ``client``：不设任何密码的裸客户端，管理/搜索端点默认均开放。
+- ``client``：不设任何密码的裸客户端，搜索端点开放，管理端点默认锁定。
 - ``authed_client``：预先设 ``SOUWEN_API_PASSWORD=test-secret-123``，
   用于验证旧版统一密码 Bearer Token 鉴权通路。
 - ``dual_key_client``：设 visitor_password 和 admin_password 为不同值，
   验证双密钥独立认证。
 """
+
+from types import SimpleNamespace
 
 import pytest
 
@@ -27,7 +29,7 @@ except ImportError:
 
 @pytest.fixture()
 def client():
-    """裸 TestClient：不设任何密码，所有端点默认开放（用于公开行为测试）。"""
+    """裸 TestClient：不设任何密码，管理端点默认锁定。"""
     from souwen.server.app import app
 
     return TestClient(app, raise_server_exceptions=False)
@@ -84,9 +86,20 @@ class TestHealth:
 
 
 class TestAdminAuth:
-    # --- 无密码时默认开放 ---
-    def test_admin_open_without_any_password(self, client):
-        """无任何密码配置时，管理端点默认开放。"""
+    # --- 无密码时默认锁定，需显式开放 ---
+    def test_admin_locked_without_any_password(self, client):
+        """无任何密码且未设 SOUWEN_ADMIN_OPEN 时，管理端点默认锁定。"""
+        resp = client.get("/api/v1/admin/config")
+        assert resp.status_code == 401
+
+    def test_admin_open_without_any_password_when_explicitly_enabled(
+        self, client, monkeypatch
+    ):
+        """SOUWEN_ADMIN_OPEN=1 时，无管理密码才显式开放管理端点。"""
+        monkeypatch.setenv("SOUWEN_ADMIN_OPEN", "1")
+        from souwen.config import get_config
+
+        get_config.cache_clear()
         resp = client.get("/api/v1/admin/config")
         assert resp.status_code == 200
 
@@ -161,23 +174,36 @@ class TestAdminAuth:
         assert resp.status_code == 200
 
     def test_dual_key_visitor_password_rejected_for_admin(self, dual_key_client):
-        """visitor_password 不能访问管理端点。"""
+        """visitor_password 有效但权限不足，访问管理端点返回 403。"""
         resp = dual_key_client.get(
             "/api/v1/admin/config",
             headers={"Authorization": "Bearer visitor-pw"},
         )
-        assert resp.status_code == 401
+        assert resp.status_code == 403
 
     def test_dual_key_no_token_rejected(self, dual_key_client):
         """admin_password 已设时，无 Token 必须 401。"""
         resp = dual_key_client.get("/api/v1/admin/config")
         assert resp.status_code == 401
 
-    # --- admin_password 显式空字符串 → 强制开放 ---
-    def test_admin_explicit_empty_overrides_api_password(self, client, monkeypatch):
-        """admin_password="" 时即使 api_password 已设也强制开放管理端点。"""
+    # --- admin_password 显式空字符串 → 忽略 api_password 回退，但仍需显式开放 ---
+    def test_admin_explicit_empty_overrides_api_password_but_stays_locked(
+        self, client, monkeypatch
+    ):
+        """admin_password="" 时忽略 api_password 回退，未设 SOUWEN_ADMIN_OPEN 仍锁定。"""
         monkeypatch.setenv("SOUWEN_API_PASSWORD", "legacy-pw")
         monkeypatch.setenv("SOUWEN_ADMIN_PASSWORD", "")
+        from souwen.config import get_config
+
+        get_config.cache_clear()
+        resp = client.get("/api/v1/admin/config")
+        assert resp.status_code == 401
+
+    def test_admin_explicit_empty_can_open_with_admin_open(self, client, monkeypatch):
+        """admin_password="" 且 SOUWEN_ADMIN_OPEN=1 时才开放管理端点。"""
+        monkeypatch.setenv("SOUWEN_API_PASSWORD", "legacy-pw")
+        monkeypatch.setenv("SOUWEN_ADMIN_PASSWORD", "")
+        monkeypatch.setenv("SOUWEN_ADMIN_OPEN", "1")
         from souwen.config import get_config
 
         get_config.cache_clear()
@@ -223,6 +249,18 @@ class TestSearchAuth:
         assert "patent" in data
         assert "general" in data
 
+    def test_sources_omits_disabled_entries(self, client, monkeypatch):
+        """sources.<name>.enabled=false 后，/sources 不应再展示该源。"""
+        monkeypatch.setenv("SOUWEN_SOURCES", '{"duckduckgo": {"enabled": false}}')
+        from souwen.config import get_config
+
+        get_config.cache_clear()
+        resp = client.get("/api/v1/sources")
+        assert resp.status_code == 200
+        data = resp.json()
+        names = {item["name"] for entries in data.values() for item in entries}
+        assert "duckduckgo" not in names
+
     # --- 双密钥：visitor 和 admin 密码均可访问搜索端点 ---
     def test_dual_key_visitor_password_accepted(self, dual_key_client):
         """visitor_password 可以访问搜索端点。"""
@@ -264,15 +302,15 @@ class TestSearchAuth:
         resp = client.get("/api/v1/sources")
         assert resp.status_code == 200
 
-    # --- 仅 visitor_password 时 admin 端开放 ---
-    def test_only_visitor_password_leaves_admin_open(self, client, monkeypatch):
-        """仅设 visitor_password，管理端点应开放。"""
+    # --- 仅 visitor_password 时 admin 端仍锁定 ---
+    def test_only_visitor_password_leaves_admin_locked(self, client, monkeypatch):
+        """仅设 visitor_password，管理端点仍需 admin 密码或 SOUWEN_ADMIN_OPEN。"""
         monkeypatch.setenv("SOUWEN_VISITOR_PASSWORD", "visitor-pw")
         from souwen.config import get_config
 
         get_config.cache_clear()
         resp = client.get("/api/v1/admin/config")
-        assert resp.status_code == 200
+        assert resp.status_code == 401
 
 
 # ---------------------------------------------------------------------------
@@ -283,8 +321,21 @@ class TestSearchAuth:
 class TestThreeRoleAuth:
     """三角色认证系统测试（Guest/User/Admin）。"""
 
-    def test_whoami_no_password_returns_admin(self, client):
-        """无密码配置时 /whoami 返回 admin 角色。"""
+    def test_whoami_no_password_returns_user_when_admin_locked(self, client):
+        """无密码但未显式开放 admin 时，/whoami 只返回 user 权限。"""
+        resp = client.get("/api/v1/whoami")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["role"] == "user"
+        assert data["features"]["fetch"] is False
+        assert data["features"]["config_write"] is False
+
+    def test_whoami_no_password_admin_open_returns_admin(self, client, monkeypatch):
+        """SOUWEN_ADMIN_OPEN=1 时，无密码 /whoami 才返回 admin 权限。"""
+        monkeypatch.setenv("SOUWEN_ADMIN_OPEN", "1")
+        from souwen.config import get_config
+
+        get_config.cache_clear()
         resp = client.get("/api/v1/whoami")
         assert resp.status_code == 200
         data = resp.json()
@@ -344,6 +395,43 @@ class TestThreeRoleAuth:
         )
         assert resp.status_code == 200
 
+
+
+# ---------------------------------------------------------------------------
+# Wayback admin save route
+# ---------------------------------------------------------------------------
+
+
+class TestWaybackAdminSave:
+    def test_public_wayback_save_route_is_not_mounted(self, authed_client):
+        """写入操作不应暴露在公开 /wayback/save 路径。"""
+        resp = authed_client.post(
+            "/api/v1/wayback/save",
+            headers={"Authorization": "Bearer test-secret-123"},
+            json={"url": "https://example.com", "timeout": 10},
+        )
+        assert resp.status_code == 404
+
+    def test_admin_wayback_save_route_is_mounted(self, authed_client, monkeypatch):
+        """前端应调用 /api/v1/admin/wayback/save，且管理认证后能命中路由。"""
+
+        class FakeWaybackClient:
+            async def save_page(self, url, timeout):
+                return SimpleNamespace(
+                    success=True,
+                    snapshot_url="https://web.archive.org/web/20240101000000/https://example.com",
+                    timestamp="20240101000000",
+                    error=None,
+                )
+
+        monkeypatch.setattr("souwen.web.wayback.WaybackClient", FakeWaybackClient)
+        resp = authed_client.post(
+            "/api/v1/admin/wayback/save",
+            headers={"Authorization": "Bearer test-secret-123"},
+            json={"url": "https://example.com", "timeout": 10},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
 
 # ---------------------------------------------------------------------------
 # Rate limiter

--- a/tests/test_server/test_app.py
+++ b/tests/test_server/test_app.py
@@ -92,9 +92,7 @@ class TestAdminAuth:
         resp = client.get("/api/v1/admin/config")
         assert resp.status_code == 401
 
-    def test_admin_open_without_any_password_when_explicitly_enabled(
-        self, client, monkeypatch
-    ):
+    def test_admin_open_without_any_password_when_explicitly_enabled(self, client, monkeypatch):
         """SOUWEN_ADMIN_OPEN=1 时，无管理密码才显式开放管理端点。"""
         monkeypatch.setenv("SOUWEN_ADMIN_OPEN", "1")
         from souwen.config import get_config
@@ -396,7 +394,6 @@ class TestThreeRoleAuth:
         assert resp.status_code == 200
 
 
-
 # ---------------------------------------------------------------------------
 # Wayback admin save route
 # ---------------------------------------------------------------------------
@@ -432,6 +429,7 @@ class TestWaybackAdminSave:
         )
         assert resp.status_code == 200
         assert resp.json()["success"] is True
+
 
 # ---------------------------------------------------------------------------
 # Rate limiter

--- a/tests/test_server/test_fetch_route.py
+++ b/tests/test_server/test_fetch_route.py
@@ -19,8 +19,9 @@ from souwen.models import FetchResponse, FetchResult
 
 
 @pytest.fixture()
-def client():
-    """裸 TestClient（无密码、无鉴权）。"""
+def client(monkeypatch):
+    """显式开放 admin 的 TestClient，用于聚焦 fetch 入参校验。"""
+    monkeypatch.setenv("SOUWEN_ADMIN_OPEN", "1")
     from souwen.server.app import app
 
     return TestClient(app, raise_server_exceptions=False)


### PR DESCRIPTION
## 概述

收敛 SouWen 管理端默认访问策略，修复配置加载优先级、Sources 启用状态过滤、Wayback 保存路径与 Panel 权限展示问题。

**⚠️ 破坏性变更：** 无管理密码场景从"默认开放"调整为"默认锁定"。HF Spaces 等部署需在环境变量中设置 `SOUWEN_ADMIN_PASSWORD` 或 `SOUWEN_ADMIN_OPEN=1`。

## 核心改动

### 1. Admin API 默认锁定（破坏性）
- 未配置 `admin_password` / `api_password` 时，`/api/v1/admin/*` 默认返回 401
- 需设 `SOUWEN_ADMIN_OPEN=1` 环境变量才显式开放无密码 Admin
- User token 访问 Admin 端点返回 403（权限不足）而非 401

### 2. 配置加载优先级修复
- `load_dotenv()` → `dotenv_values()`，不再污染 `os.environ`
- 明确优先级：**环境变量 > YAML > .env > 默认值**
- 修复 .env 意外覆盖 YAML 配置的 bug

### 3. Panel 前端权限控制
- 新增 `access.ts` 统一路由/导航权限判断
- Admin 功能页面（Fetch/Sources/Network/WARP/Config）对非 Admin 隐藏
- `AuthGuard` 无权限路由重定向到 `/search/paper`
- 仅 401 触发重登录，403 仅展示权限不足提示

### 4. Sources 过滤 + Wayback 路径
- `/api/v1/sources` 过滤 `sources.<name>.enabled=false` 的数据源
- Wayback Save 迁移到 `/api/v1/admin/wayback/save`（写操作收归管理端点）
- 公开 `/api/v1/wayback/save` 路径返回 404

## 部署注意

| 场景 | 需要操作 |
|------|---------|
| 已设 `admin_password` | 无需操作 |
| 已设 `api_password` | 无需操作（自动回退） |
| 未设任何密码 | 需加 `SOUWEN_ADMIN_OPEN=1` 或设密码 |
| HF Spaces 部署 | Settings → Secrets 添加 `SOUWEN_ADMIN_PASSWORD` |

## 文件清单（31 文件）

**新增：**
- `panel/src/core/lib/access.ts` — 前端权限判断
- `panel/src/core/test/access.test.ts` — 权限测试
- `panel/src/core/test/wayback.test.ts` — Wayback 路径测试

**后端：**
- `src/souwen/server/auth.py` — Admin 默认锁定逻辑
- `src/souwen/server/app.py` — 启动日志 Admin 状态
- `src/souwen/config/loader.py` — dotenv_values + 优先级修复
- `src/souwen/config/models.py` — Pydantic 2.11 兼容
- `src/souwen/server/routes/sources.py` — enabled 过滤

**前端（5 skins）：**
- 导航过滤 Admin 入口
- ToolsPage Save tab 权限控制
- 错误处理：401 触发 auth error，403 不触发

**测试：**
- `tests/test_server/test_app.py` — Admin 锁定/开放、双密钥、whoami、disabled source、wayback 路径

## CI

14/14 checks passed（CodeQL + 多平台测试 + Panel 构建 + 插件系统）