### PR TITLE
fix(audit): Wayback Save 路径修复 + 皮肤导航补齐 + Fetch 文档校准

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [Unreleased] — 全面评审修复（2026-04-29）
+
+### Bug Fixes
+- **fix(panel)**：修正 Wayback Save 前端调用路径（`/api/v1/wayback/save` → `/api/v1/admin/wayback/save`）。原路径与后端 admin 路由前缀不一致，导致所有 5 个皮肤的 ToolsPage 中"存档"按钮固定 404。
+- **fix(panel)**：补齐 `souwen-google` 皮肤 `PAGE_TITLE_KEYS` 缺失的 `/warp` 路径标题映射，避免落到默认 `nav.dashboard`。
+- **fix(panel/skins)**：carbon / apple / ios 三个皮肤补齐 `/video` 与 `/tools` 导航入口，与 souwen-google / souwen-nebula 保持一致；之前路由已注册但侧栏不可达。
+- **fix(panel/skins)**：更新 souwen-google / souwen-nebula 的 `MainLayout.tsx` 顶部注释，反映当前 9 个 NAV_ITEMS（dashboard / search / fetch / video / tools / sources / network / warp / config）。
+
+### Refactor
+- **refactor(server/routes)**：把 `/admin/wayback/save` 端点从 `routes/admin/warp.py` 拆出到独立的 `routes/admin/wayback.py`，保持 SRP；`admin_router` 在 `routes/admin/__init__.py` 中合并新模块。
+
+### Docs
+- **docs(README)**：更正 fetch 横切能力计数（15+4 → 16+4 = 20 源），与 `docs/data-sources.md` 自动生成结果对齐。
+- **docs(api-reference)**：更新示例 JSON 中过期的 `version` 字段（0.6.3 → 1.1.1），并补充"动态返回，示例值仅作参考"的说明。
+- **docs(api-reference)**：补齐 fetch provider 列表中遗漏的 `arxiv_fulltext`，并把"19 个提供者"修正为"20 个"，与 registry 实际注册一致。
+
 ## v1.1.2 — AI Workflow 安全加固与功能深化（2026-05-04）
 
 ### Features

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -353,10 +353,10 @@ SouWen 支持三级角色认证（Guest/User/Admin），并向后兼容旧版密
 
 **响应示例：**
 ```json
-{ "status": "ok", "version": "0.6.3" }
+{ "status": "ok", "version": "1.1.1" }
 ```
 
-> `version` 字段动态返回当前 `souwen.__version__`。
+> `version` 字段动态返回当前 `souwen.__version__`，示例值仅作参考。
 
 #### `GET /readiness`
 
@@ -364,12 +364,12 @@ K8s readiness 探针（v0.6.1 引入）。仅做本地检查（配置可加载 +
 
 **响应示例（就绪）：**
 ```json
-{ "ready": true, "version": "0.6.3", "error": null }
+{ "ready": true, "version": "1.1.1", "error": null }
 ```
 
 **响应示例（503 未就绪）：**
 ```json
-{ "ready": false, "version": "0.6.3", "error": "source registry is empty" }
+{ "ready": false, "version": "1.1.1", "error": "source registry is empty" }
 ```
 
 #### `GET /` 与 `GET /panel`
@@ -771,7 +771,7 @@ python -m souwen.integrations.mcp_server
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `urls` | array | — | 待抓取的 URL 列表 |
-| `provider` | string | `"builtin"` | 内容提取提供者，默认 `builtin`（零配置）。可选：`jina_reader` / `tavily` / `firecrawl` / `exa` / `crawl4ai` / `scrapfly` / `diffbot` / `scrapingbee` / `zenrows` / `scraperapi` / `apify` / `cloudflare` / `wayback` / `newspaper` / `readability` / `mcp` / `site_crawler` / `deepwiki` |
+| `provider` | string | `"builtin"` | 内容提取提供者，默认 `builtin`（零配置）。可选：`jina_reader` / `arxiv_fulltext` / `tavily` / `firecrawl` / `exa` / `crawl4ai` / `scrapfly` / `diffbot` / `scrapingbee` / `zenrows` / `scraperapi` / `apify` / `cloudflare` / `wayback` / `newspaper` / `readability` / `mcp` / `site_crawler` / `deepwiki` |
 
 返回：JSON `FetchResponse` 对象（含 `results`、`total`、`total_ok`、`total_failed`）。
 

--- a/panel/src/skins/apple/components/layout/MainLayout.tsx
+++ b/panel/src/skins/apple/components/layout/MainLayout.tsx
@@ -39,6 +39,8 @@ import {
   Layers,
   Check,
   FileText,
+  Play,
+  Wrench,
 } from 'lucide-react'
 import { useAuthStore } from '@core/stores/authStore'
 import { canAccessNavItem } from '@core/lib/access'
@@ -54,6 +56,8 @@ const NAV_ITEMS = [
   { to: '/', icon: LayoutDashboard, labelKey: 'nav.dashboard' },
   { to: '/search', icon: Search, labelKey: 'nav.search' },
   { to: '/fetch', icon: FileText, labelKey: 'nav.fetch' },
+  { to: '/video', icon: Play, labelKey: 'nav.video' },
+  { to: '/tools', icon: Wrench, labelKey: 'nav.tools' },
   { to: '/sources', icon: Database, labelKey: 'nav.sources' },
   { to: '/network', icon: Wifi, labelKey: 'nav.network' },
   { to: '/warp', icon: Shield, labelKey: 'nav.warp' },

--- a/panel/src/skins/carbon/components/layout/MainLayout.tsx
+++ b/panel/src/skins/carbon/components/layout/MainLayout.tsx
@@ -23,6 +23,8 @@ import {
   Sun,
   Check,
   FileText,
+  Play,
+  Wrench,
 } from 'lucide-react'
 import { useAuthStore } from '@core/stores/authStore'
 import { canAccessNavItem } from '@core/lib/access'
@@ -35,6 +37,8 @@ const NAV_ITEMS = [
   { to: '/search', icon: Search, labelKey: 'nav.search' },
   { to: '/', icon: LayoutDashboard, labelKey: 'nav.dashboard' },
   { to: '/fetch', icon: FileText, labelKey: 'nav.fetch' },
+  { to: '/video', icon: Play, labelKey: 'nav.video' },
+  { to: '/tools', icon: Wrench, labelKey: 'nav.tools' },
   { to: '/sources', icon: Database, labelKey: 'nav.sources' },
   { to: '/network', icon: Wifi, labelKey: 'nav.network' },
   { to: '/warp', icon: Shield, labelKey: 'nav.warp' },

--- a/panel/src/skins/ios/components/layout/MainLayout.tsx
+++ b/panel/src/skins/ios/components/layout/MainLayout.tsx
@@ -39,6 +39,8 @@ import {
   Layers,
   Check,
   FileText,
+  Play,
+  Wrench,
 } from 'lucide-react'
 import { useAuthStore } from '@core/stores/authStore'
 import { canAccessNavItem } from '@core/lib/access'
@@ -51,6 +53,8 @@ const NAV_ITEMS = [
   { to: '/', icon: LayoutDashboard, labelKey: 'nav.dashboard', color: '#007aff' },
   { to: '/search', icon: Search, labelKey: 'nav.search', color: '#5ac8fa' },
   { to: '/fetch', icon: FileText, labelKey: 'nav.fetch', color: '#ff9500' },
+  { to: '/video', icon: Play, labelKey: 'nav.video', color: '#ff2d55' },
+  { to: '/tools', icon: Wrench, labelKey: 'nav.tools', color: '#af52de' },
   { to: '/sources', icon: Database, labelKey: 'nav.sources', color: '#5856d6' },
   { to: '/network', icon: Globe, labelKey: 'nav.network', color: '#34c759' },
   { to: '/warp', icon: Shield, labelKey: 'nav.warp', color: '#32d74b' },

--- a/panel/src/skins/souwen-google/components/layout/MainLayout.tsx
+++ b/panel/src/skins/souwen-google/components/layout/MainLayout.tsx
@@ -11,7 +11,7 @@
  *   - 主题系统：支持 light/dark 模式和多种配色方案（nebula/aurora/obsidian）
  *
  * 常量定义：
- *   NAV_ITEMS - 导航菜单项列表（dashboard/search/sources/network/config）
+ *   NAV_ITEMS - 导航菜单项列表（dashboard / search / fetch / video / tools / sources / network / warp / config）
  *   PAGE_TITLE_KEYS - URL 路径到标题 i18n 键的映射
  *   pageVariants / pageTransition - 页面进出动画配置
  *   overlayVariants / drawerVariants - 移动端抽屉动画配置
@@ -91,6 +91,7 @@ const PAGE_TITLE_KEYS: Record<string, string> = {
   '/tools': 'nav.tools',
   '/sources': 'nav.sources',
   '/network': 'nav.network',
+  '/warp': 'nav.warp',
   '/config': 'nav.config',
 }
 

--- a/panel/src/skins/souwen-nebula/components/layout/MainLayout.tsx
+++ b/panel/src/skins/souwen-nebula/components/layout/MainLayout.tsx
@@ -11,7 +11,7 @@
  *   - 主题系统：支持 light/dark 模式和多种配色方案（nebula/aurora/obsidian）
  *
  * 常量定义：
- *   NAV_ITEMS - 导航菜单项列表（dashboard/search/sources/network/config）
+ *   NAV_ITEMS - 导航菜单项列表（dashboard / search / fetch / video / tools / sources / network / warp / config）
  *   PAGE_TITLE_KEYS - URL 路径到标题 i18n 键的映射
  *   pageVariants / pageTransition - 页面进出动画配置
  *   overlayVariants / drawerVariants - 移动端抽屉动画配置

--- a/src/souwen/server/routes/admin/__init__.py
+++ b/src/souwen/server/routes/admin/__init__.py
@@ -16,6 +16,7 @@ from souwen.server.routes.admin.http_backend import router as http_backend_route
 from souwen.server.routes.admin.proxy import router as proxy_router
 from souwen.server.routes.admin.sources import router as sources_router
 from souwen.server.routes.admin.warp import router as warp_router
+from souwen.server.routes.admin.wayback import router as wayback_router
 
 admin_router = APIRouter(dependencies=[Depends(require_auth)])
 
@@ -25,5 +26,6 @@ admin_router.include_router(sources_router)
 admin_router.include_router(proxy_router)
 admin_router.include_router(http_backend_router)
 admin_router.include_router(warp_router)
+admin_router.include_router(wayback_router)
 
 __all__ = ["admin_router"]

--- a/src/souwen/server/routes/admin/warp.py
+++ b/src/souwen/server/routes/admin/warp.py
@@ -1,4 +1,4 @@
-"""WARP 代理管理与 Wayback 写入 — /admin/warp/*、/admin/wayback/save"""
+"""WARP 代理管理 — /admin/warp/*"""
 
 from __future__ import annotations
 
@@ -10,7 +10,6 @@ from fastapi import APIRouter, HTTPException, Query
 from starlette.responses import StreamingResponse
 
 from souwen.server.routes._common import logger
-from souwen.server.schemas import WaybackSaveRequest, WaybackSaveResponse
 
 router = APIRouter()
 
@@ -372,34 +371,3 @@ async def warp_events():
             "X-Accel-Buffering": "no",
         },
     )
-
-
-# ---------------------------------------------------------------------------
-# Wayback Machine — 写入操作（管理认证）
-# ---------------------------------------------------------------------------
-
-
-@router.post("/wayback/save", response_model=WaybackSaveResponse)
-async def api_wayback_save(body: WaybackSaveRequest):
-    """触发 Wayback Machine 立即存档 — 需要管理认证。"""
-    from souwen.web.wayback import WaybackClient
-
-    try:
-        client = WaybackClient()
-        resp = await asyncio.wait_for(
-            client.save_page(url=body.url, timeout=body.timeout),
-            timeout=body.timeout + 15,
-        )
-        return {
-            "url": body.url,
-            "success": resp.success,
-            "snapshot_url": resp.snapshot_url,
-            "timestamp": resp.timestamp,
-            "error": resp.error,
-        }
-    except asyncio.TimeoutError:
-        logger.warning("Wayback save 超时: url=%s timeout=%ss", body.url, body.timeout)
-        raise HTTPException(status_code=504, detail=f"存档超时（{body.timeout}s）")
-    except Exception:
-        logger.warning("Wayback save 错误: url=%s", body.url, exc_info=True)
-        raise

--- a/src/souwen/server/routes/admin/wayback.py
+++ b/src/souwen/server/routes/admin/wayback.py
@@ -1,0 +1,47 @@
+"""Wayback Machine 写入端点 — /admin/wayback/save
+
+文件用途：
+    存档（Save）属于会触发外网写入的操作，需要管理认证；查询类（CDX、availability）
+    在 routes/wayback.py 中以访客权限暴露。
+
+模块依赖：
+    - WaybackSaveRequest / WaybackSaveResponse  请求/响应模型
+    - souwen.web.wayback.WaybackClient          实际调用
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from fastapi import APIRouter, HTTPException
+
+from souwen.server.routes._common import logger
+from souwen.server.schemas import WaybackSaveRequest, WaybackSaveResponse
+
+router = APIRouter()
+
+
+@router.post("/wayback/save", response_model=WaybackSaveResponse)
+async def api_wayback_save(body: WaybackSaveRequest):
+    """触发 Wayback Machine 立即存档 — 需要管理认证。"""
+    from souwen.web.wayback import WaybackClient
+
+    try:
+        client = WaybackClient()
+        resp = await asyncio.wait_for(
+            client.save_page(url=body.url, timeout=body.timeout),
+            timeout=body.timeout + 15,
+        )
+        return {
+            "url": body.url,
+            "success": resp.success,
+            "snapshot_url": resp.snapshot_url,
+            "timestamp": resp.timestamp,
+            "error": resp.error,
+        }
+    except asyncio.TimeoutError:
+        logger.warning("Wayback save 超时: url=%s timeout=%ss", body.url, body.timeout)
+        raise HTTPException(status_code=504, detail=f"存档超时（{body.timeout}s）")
+    except Exception:
+        logger.warning("Wayback save 错误: url=%s", body.url, exc_info=True)
+        raise


### PR DESCRIPTION
## 概述

根据全面评审结果，修复 SouWen 前后端路径、皮肤导航和文档计数的一组一致性问题。

## 修复内容

### 1. Wayback Save 路径修复 — `POST /api/v1/admin/wayback/save`
- 前端请求路径从 `/api/v1/wayback/save` 修正为 `/api/v1/admin/wayback/save`
- 对齐 `admin_router` 的 `/api/v1/admin` 前缀，避免 ToolsPage 存档操作请求到不存在的公开路径
- 保持原有请求体、响应模型和管理认证要求不变

### 2. Admin 路由拆分 — `routes/admin/wayback.py`
- 新增 `src/souwen/server/routes/admin/wayback.py` 承载 Wayback Save 写入端点
- `src/souwen/server/routes/admin/warp.py` 移除 Wayback Save 逻辑，回归 WARP 管理职责
- `src/souwen/server/routes/admin/__init__.py` 注册 `wayback_router`

### 3. 皮肤导航补齐
- carbon / apple / ios 三个皮肤补齐 `/video` 与 `/tools` 导航入口
- souwen-google 补齐 `/warp` 页面标题映射
- souwen-google / souwen-nebula 更新 `NAV_ITEMS` 注释，与当前 9 项导航保持一致

### 4. Fetch 文档校准
- README / README.en：fetch 横切能力计数从 `15 + 4` 修正为 `16 + 4 = 20 源`
- docs/api-reference：fetch provider 数量从 19 修正为 20，并补充 `arxiv_fulltext`
- docs/api-reference：health / readiness 示例版本从 `0.6.3` 更新为 `1.1.1`，并说明版本字段动态返回当前 `souwen.__version__`
- CHANGELOG：新增 `[Unreleased]` 条目记录本批修复

## 兼容性

- 不新增依赖
- 不变更公开 schema
- 不调整认证模型
- 不改变 Wayback Save 的最终管理端路径与业务处理语义

## 测试

- GitHub Actions：Panel 构建检查通过
- GitHub Actions：代码检查通过
- GitHub Actions：服务端测试通过
- GitHub Actions：Python 3.10 / 3.11 / 3.12 / 3.13 测试矩阵通过
- GitHub Actions：插件系统测试通过
- GitHub Actions：CodeQL 通过
- 当前 `Codex 代码评审` 自动化 job 失败，`发布评审评论` job 被跳过

## 文件清单

**新增（1 文件）：**
- `src/souwen/server/routes/admin/wayback.py` — Wayback Save 管理端写入路由

**修改（12 文件）：**
- `panel/src/core/services/wayback.ts` — Wayback Save API 路径
- `panel/src/skins/{apple,carbon,ios}/components/layout/MainLayout.tsx` — `/video`、`/tools` 导航入口
- `panel/src/skins/{souwen-google,souwen-nebula}/components/layout/MainLayout.tsx` — `/warp` 标题映射与导航注释
- `src/souwen/server/routes/admin/{__init__.py,warp.py}` — admin router 注册与 WARP 路由职责拆分
- `README.md` / `README.en.md` / `docs/api-reference.md` / `CHANGELOG.md` — provider 数量、版本示例与变更记录
