### PR TITLE
chore(ci): 支持 AI Codex 模型与端点覆盖

### DIFF
--- a/.github/workflows/ai-agent.yml
+++ b/.github/workflows/ai-agent.yml
@@ -47,7 +47,10 @@ name: AI Agent
 #
 # 【依赖的 Secrets/Variables】
 # - secrets.CUSTOM_AI_API_KEY — OpenAI/兼容 API 密钥
-# - secrets.CUSTOM_AI_RESPONSES_ENDPOINT — AI API 端点 URL
+# - workflow_dispatch inputs.model — 手动指定模型，优先级最高
+# - workflow_dispatch inputs.responses_endpoint — 手动指定 Responses API 端点，优先级最高
+# - vars.CUSTOM_AI_RESPONSES_ENDPOINT — 可选，environment 级 AI API 端点 URL
+# - secrets.CUSTOM_AI_RESPONSES_ENDPOINT — 可选，secret 级 AI API 端点 URL
 # - secrets.AI_FIX_TOKEN (可选) — PAT, 让 fix PR 触发 CI; 缺省用 github.token
 # - vars.CODEX_MODEL — 模型名（默认 gpt-5.4）
 # - vars.CODEX_EFFORT — 推理强度（默认 xhigh）
@@ -93,6 +96,14 @@ on:
         default: fix-pr
       base_ref:
         description: '可选：覆盖 base 分支（默认：PR 的 base / branch 自身 / 仓库默认分支）'
+        required: false
+        type: string
+      model:
+        description: '可选：覆盖 Codex 模型；留空则使用 environment 变量或默认值'
+        required: false
+        type: string
+      responses_endpoint:
+        description: '可选：覆盖 Responses API endpoint URL；留空则使用 environment 变量/secret 或 action 默认端点'
         required: false
         type: string
       effort:
@@ -470,7 +481,7 @@ jobs:
       - name: Validate AI secrets
         env:
           CUSTOM_AI_API_KEY: ${{ secrets.CUSTOM_AI_API_KEY }}
-          CUSTOM_AI_RESPONSES_ENDPOINT: ${{ secrets.CUSTOM_AI_RESPONSES_ENDPOINT }}
+          CUSTOM_AI_RESPONSES_ENDPOINT: ${{ inputs.responses_endpoint || vars.CUSTOM_AI_RESPONSES_ENDPOINT || secrets.CUSTOM_AI_RESPONSES_ENDPOINT }}
           LOG_LEVEL: ${{ steps.log-config.outputs.log_level }}
         run: |
           set -euo pipefail
@@ -478,22 +489,27 @@ jobs:
             echo "::error::CUSTOM_AI_API_KEY is empty"
             exit 1
           fi
-          if [ -z "${CUSTOM_AI_RESPONSES_ENDPOINT:-}" ]; then
-            echo "::error::CUSTOM_AI_RESPONSES_ENDPOINT is empty"
-            exit 1
+          if [ -n "${CUSTOM_AI_RESPONSES_ENDPOINT:-}" ]; then
+            RESPONSES_ENDPOINT_STATUS="present"
+          else
+            RESPONSES_ENDPOINT_STATUS="action default"
           fi
 
           {
-            echo "## AI Agent Secret 校验"
+            echo "## AI Agent 凭据校验"
             echo
             echo "- CUSTOM_AI_API_KEY: present"
-            echo "- CUSTOM_AI_RESPONSES_ENDPOINT: present"
+            echo "- Responses endpoint: $RESPONSES_ENDPOINT_STATUS"
             echo
           } >> "$GITHUB_STEP_SUMMARY"
 
           if [ "$LOG_LEVEL" = "debug" ]; then
             echo "CUSTOM_AI_API_KEY length: ${#CUSTOM_AI_API_KEY}"
-            echo "CUSTOM_AI_RESPONSES_ENDPOINT length: ${#CUSTOM_AI_RESPONSES_ENDPOINT}"
+            if [ -n "${CUSTOM_AI_RESPONSES_ENDPOINT:-}" ]; then
+              echo "CUSTOM_AI_RESPONSES_ENDPOINT length: ${#CUSTOM_AI_RESPONSES_ENDPOINT}"
+            else
+              echo "CUSTOM_AI_RESPONSES_ENDPOINT: action default"
+            fi
           else
             echo "AI secrets are present. Enable log_level=debug to print non-sensitive lengths."
           fi
@@ -661,7 +677,12 @@ jobs:
       - name: Context summary (pre-Codex diagnostic)
         env:
           LOG_LEVEL: ${{ steps.log-config.outputs.log_level }}
-          MODEL: ${{ vars.CODEX_MODEL || 'gpt-5.4' }}
+          MODEL: ${{ inputs.model || vars.CODEX_MODEL || 'gpt-5.4' }}
+          INPUT_MODEL: ${{ inputs.model }}
+          VAR_MODEL: ${{ vars.CODEX_MODEL }}
+          INPUT_RESPONSES_ENDPOINT: ${{ inputs.responses_endpoint }}
+          VAR_RESPONSES_ENDPOINT: ${{ vars.CUSTOM_AI_RESPONSES_ENDPOINT }}
+          SECRET_RESPONSES_ENDPOINT: ${{ secrets.CUSTOM_AI_RESPONSES_ENDPOINT }}
           EFFORT: ${{ inputs.effort || vars.CODEX_EFFORT || 'xhigh' }}
           CODEX_ARGS: ${{ vars.CODEX_ARGS }}
           TARGET_TYPE: ${{ needs.gate.outputs.target_type }}
@@ -673,6 +694,22 @@ jobs:
           set -euo pipefail
           CONTEXT_SIZE="$(du -sh .ai-agent-context/ 2>/dev/null | awk '{print $1}' || echo 'missing')"
           CONTEXT_FILES="$(find .ai-agent-context -type f 2>/dev/null | wc -l | tr -d ' ')"
+          if [ -n "${INPUT_MODEL:-}" ]; then
+            MODEL_SOURCE="workflow_dispatch input"
+          elif [ -n "${VAR_MODEL:-}" ]; then
+            MODEL_SOURCE="environment variable"
+          else
+            MODEL_SOURCE="workflow default"
+          fi
+          if [ -n "${INPUT_RESPONSES_ENDPOINT:-}" ]; then
+            RESPONSES_ENDPOINT_STATUS="configured (workflow_dispatch input)"
+          elif [ -n "${VAR_RESPONSES_ENDPOINT:-}" ]; then
+            RESPONSES_ENDPOINT_STATUS="configured (environment variable)"
+          elif [ -n "${SECRET_RESPONSES_ENDPOINT:-}" ]; then
+            RESPONSES_ENDPOINT_STATUS="configured (secret)"
+          else
+            RESPONSES_ENDPOINT_STATUS="action default"
+          fi
           if [ -n "${CODEX_ARGS:-}" ]; then
             CODEX_ARGS_STATUS="configured"
           else
@@ -686,7 +723,9 @@ jobs:
             echo "|---|---|"
             echo "| Log level | \`$LOG_LEVEL\` |"
             echo "| Model | \`$MODEL\` |"
+            echo "| Model source | \`$MODEL_SOURCE\` |"
             echo "| Effort | \`$EFFORT\` |"
+            echo "| Responses endpoint | \`$RESPONSES_ENDPOINT_STATUS\` |"
             echo "| Codex args | \`$CODEX_ARGS_STATUS\` |"
             echo "| Sandbox | \`workspace-write\` |"
             echo "| Target | \`${TARGET_TYPE}=${TARGET_ID}\` |"
@@ -725,8 +764,8 @@ jobs:
         uses: openai/codex-action@v1
         with:
           openai-api-key: ${{ secrets.CUSTOM_AI_API_KEY }}
-          responses-api-endpoint: ${{ secrets.CUSTOM_AI_RESPONSES_ENDPOINT }}
-          model: ${{ vars.CODEX_MODEL || 'gpt-5.4' }}
+          responses-api-endpoint: ${{ inputs.responses_endpoint || vars.CUSTOM_AI_RESPONSES_ENDPOINT || secrets.CUSTOM_AI_RESPONSES_ENDPOINT }}
+          model: ${{ inputs.model || vars.CODEX_MODEL || 'gpt-5.4' }}
           effort: ${{ inputs.effort || vars.CODEX_EFFORT || 'xhigh' }}
           codex-args: ${{ vars.CODEX_ARGS }}
           sandbox: workspace-write
@@ -827,8 +866,8 @@ jobs:
         uses: openai/codex-action@v1
         with:
           openai-api-key: ${{ secrets.CUSTOM_AI_API_KEY }}
-          responses-api-endpoint: ${{ secrets.CUSTOM_AI_RESPONSES_ENDPOINT }}
-          model: ${{ vars.CODEX_MODEL || 'gpt-5.4' }}
+          responses-api-endpoint: ${{ inputs.responses_endpoint || vars.CUSTOM_AI_RESPONSES_ENDPOINT || secrets.CUSTOM_AI_RESPONSES_ENDPOINT }}
+          model: ${{ inputs.model || vars.CODEX_MODEL || 'gpt-5.4' }}
           effort: ${{ inputs.effort || vars.CODEX_EFFORT || 'xhigh' }}
           codex-args: ${{ vars.CODEX_ARGS }}
           sandbox: read-only

--- a/.github/workflows/ai-agent.yml
+++ b/.github/workflows/ai-agent.yml
@@ -49,8 +49,9 @@ name: AI Agent
 # - secrets.CUSTOM_AI_API_KEY — OpenAI/兼容 API 密钥
 # - secrets.CUSTOM_AI_RESPONSES_ENDPOINT — AI API 端点 URL
 # - secrets.AI_FIX_TOKEN (可选) — PAT, 让 fix PR 触发 CI; 缺省用 github.token
-# - vars.CODEX_MODEL — 模型名（默认 gpt-5.5）
+# - vars.CODEX_MODEL — 模型名（默认 gpt-5.4）
 # - vars.CODEX_EFFORT — 推理强度（默认 xhigh）
+# - vars.CODEX_ARGS — 可选，额外传给 codex exec；适合用 -c 覆盖 config.toml 项
 # - environment: auto-ai — 需在 repo settings 中配置
 #
 # 【fix 分支命名规则】
@@ -660,8 +661,9 @@ jobs:
       - name: Context summary (pre-Codex diagnostic)
         env:
           LOG_LEVEL: ${{ steps.log-config.outputs.log_level }}
-          MODEL: ${{ vars.CODEX_MODEL || 'gpt-5.5' }}
+          MODEL: ${{ vars.CODEX_MODEL || 'gpt-5.4' }}
           EFFORT: ${{ inputs.effort || vars.CODEX_EFFORT || 'xhigh' }}
+          CODEX_ARGS: ${{ vars.CODEX_ARGS }}
           TARGET_TYPE: ${{ needs.gate.outputs.target_type }}
           TARGET_ID: ${{ needs.gate.outputs.target_id }}
           MODE: ${{ needs.gate.outputs.mode }}
@@ -671,6 +673,11 @@ jobs:
           set -euo pipefail
           CONTEXT_SIZE="$(du -sh .ai-agent-context/ 2>/dev/null | awk '{print $1}' || echo 'missing')"
           CONTEXT_FILES="$(find .ai-agent-context -type f 2>/dev/null | wc -l | tr -d ' ')"
+          if [ -n "${CODEX_ARGS:-}" ]; then
+            CODEX_ARGS_STATUS="configured"
+          else
+            CODEX_ARGS_STATUS="unset"
+          fi
 
           {
             echo "## AI Agent 配置摘要"
@@ -680,6 +687,7 @@ jobs:
             echo "| Log level | \`$LOG_LEVEL\` |"
             echo "| Model | \`$MODEL\` |"
             echo "| Effort | \`$EFFORT\` |"
+            echo "| Codex args | \`$CODEX_ARGS_STATUS\` |"
             echo "| Sandbox | \`workspace-write\` |"
             echo "| Target | \`${TARGET_TYPE}=${TARGET_ID}\` |"
             echo "| Mode | \`$MODE\` |"
@@ -718,8 +726,9 @@ jobs:
         with:
           openai-api-key: ${{ secrets.CUSTOM_AI_API_KEY }}
           responses-api-endpoint: ${{ secrets.CUSTOM_AI_RESPONSES_ENDPOINT }}
-          model: ${{ vars.CODEX_MODEL || 'gpt-5.5' }}
+          model: ${{ vars.CODEX_MODEL || 'gpt-5.4' }}
           effort: ${{ inputs.effort || vars.CODEX_EFFORT || 'xhigh' }}
+          codex-args: ${{ vars.CODEX_ARGS }}
           sandbox: workspace-write
           safety-strategy: drop-sudo
           prompt-file: .ai-agent-context/trusted-ai-agent.md
@@ -819,8 +828,9 @@ jobs:
         with:
           openai-api-key: ${{ secrets.CUSTOM_AI_API_KEY }}
           responses-api-endpoint: ${{ secrets.CUSTOM_AI_RESPONSES_ENDPOINT }}
-          model: ${{ vars.CODEX_MODEL || 'gpt-5.5' }}
+          model: ${{ vars.CODEX_MODEL || 'gpt-5.4' }}
           effort: ${{ inputs.effort || vars.CODEX_EFFORT || 'xhigh' }}
+          codex-args: ${{ vars.CODEX_ARGS }}
           sandbox: read-only
           safety-strategy: read-only
           prompt-file: .ai-agent-context/condense-prompt.md

--- a/.github/workflows/ai-repo-audit.yml
+++ b/.github/workflows/ai-repo-audit.yml
@@ -47,7 +47,10 @@ name: AI Repo Audit
 #
 # 【依赖的 Secrets/Variables】
 # - secrets.CUSTOM_AI_API_KEY — OpenAI/兼容 API 密钥
-# - secrets.CUSTOM_AI_RESPONSES_ENDPOINT — AI API 端点 URL
+# - workflow_dispatch inputs.model — 手动指定模型，优先级最高
+# - workflow_dispatch inputs.responses_endpoint — 手动指定 Responses API 端点，优先级最高
+# - vars.CUSTOM_AI_RESPONSES_ENDPOINT — 可选，environment 级 AI API 端点 URL
+# - secrets.CUSTOM_AI_RESPONSES_ENDPOINT — 可选，secret 级 AI API 端点 URL
 # - secrets.AI_FIX_TOKEN (可选) — PAT，让 audit PR 触发 CI；缺省用 github.token
 # - vars.CODEX_MODEL — 模型名（默认 gpt-5.4）
 # - vars.CODEX_EFFORT — 推理强度（默认 xhigh）
@@ -65,6 +68,14 @@ on:
         description: '重点审计最近多少天的提交（默认 7）'
         required: false
         default: '7'
+        type: string
+      model:
+        description: '可选：覆盖 Codex 模型；留空则使用 environment 变量或默认值'
+        required: false
+        type: string
+      responses_endpoint:
+        description: '可选：覆盖 Responses API endpoint URL；留空则使用 environment 变量/secret 或 action 默认端点'
+        required: false
         type: string
       effort:
         description: 'Codex reasoning effort'
@@ -386,7 +397,7 @@ jobs:
       - name: Validate AI secrets
         env:
           CUSTOM_AI_API_KEY: ${{ secrets.CUSTOM_AI_API_KEY }}
-          CUSTOM_AI_RESPONSES_ENDPOINT: ${{ secrets.CUSTOM_AI_RESPONSES_ENDPOINT }}
+          CUSTOM_AI_RESPONSES_ENDPOINT: ${{ inputs.responses_endpoint || vars.CUSTOM_AI_RESPONSES_ENDPOINT || secrets.CUSTOM_AI_RESPONSES_ENDPOINT }}
           LOG_LEVEL: ${{ steps.log-config.outputs.log_level }}
         run: |
           set -euo pipefail
@@ -394,22 +405,27 @@ jobs:
             echo "::error::CUSTOM_AI_API_KEY is empty"
             exit 1
           fi
-          if [ -z "${CUSTOM_AI_RESPONSES_ENDPOINT:-}" ]; then
-            echo "::error::CUSTOM_AI_RESPONSES_ENDPOINT is empty"
-            exit 1
+          if [ -n "${CUSTOM_AI_RESPONSES_ENDPOINT:-}" ]; then
+            RESPONSES_ENDPOINT_STATUS="present"
+          else
+            RESPONSES_ENDPOINT_STATUS="action default"
           fi
 
           {
-            echo "## AI Audit Secret 校验"
+            echo "## AI Audit 凭据校验"
             echo
             echo "- CUSTOM_AI_API_KEY: present"
-            echo "- CUSTOM_AI_RESPONSES_ENDPOINT: present"
+            echo "- Responses endpoint: $RESPONSES_ENDPOINT_STATUS"
             echo
           } >> "$GITHUB_STEP_SUMMARY"
 
           if [ "$LOG_LEVEL" = "debug" ]; then
             echo "CUSTOM_AI_API_KEY length: ${#CUSTOM_AI_API_KEY}"
-            echo "CUSTOM_AI_RESPONSES_ENDPOINT length: ${#CUSTOM_AI_RESPONSES_ENDPOINT}"
+            if [ -n "${CUSTOM_AI_RESPONSES_ENDPOINT:-}" ]; then
+              echo "CUSTOM_AI_RESPONSES_ENDPOINT length: ${#CUSTOM_AI_RESPONSES_ENDPOINT}"
+            else
+              echo "CUSTOM_AI_RESPONSES_ENDPOINT: action default"
+            fi
           else
             echo "AI secrets are present. Enable log_level=debug to print non-sensitive lengths."
           fi
@@ -462,7 +478,12 @@ jobs:
       - name: Pre-Codex diagnostic
         env:
           LOG_LEVEL: ${{ steps.log-config.outputs.log_level }}
-          MODEL: ${{ vars.CODEX_MODEL || 'gpt-5.4' }}
+          MODEL: ${{ inputs.model || vars.CODEX_MODEL || 'gpt-5.4' }}
+          INPUT_MODEL: ${{ inputs.model }}
+          VAR_MODEL: ${{ vars.CODEX_MODEL }}
+          INPUT_RESPONSES_ENDPOINT: ${{ inputs.responses_endpoint }}
+          VAR_RESPONSES_ENDPOINT: ${{ vars.CUSTOM_AI_RESPONSES_ENDPOINT }}
+          SECRET_RESPONSES_ENDPOINT: ${{ secrets.CUSTOM_AI_RESPONSES_ENDPOINT }}
           EFFORT: ${{ inputs.effort || vars.CODEX_EFFORT || 'xhigh' }}
           CODEX_ARGS: ${{ vars.CODEX_ARGS }}
           LOOKBACK: ${{ needs.gate.outputs.lookback_days }}
@@ -473,6 +494,22 @@ jobs:
           set -euo pipefail
           CONTEXT_SIZE="$(du -sh .ai-audit-context/ 2>/dev/null | awk '{print $1}' || echo 'missing')"
           CONTEXT_FILES="$(find .ai-audit-context -type f 2>/dev/null | wc -l | tr -d ' ')"
+          if [ -n "${INPUT_MODEL:-}" ]; then
+            MODEL_SOURCE="workflow_dispatch input"
+          elif [ -n "${VAR_MODEL:-}" ]; then
+            MODEL_SOURCE="environment variable"
+          else
+            MODEL_SOURCE="workflow default"
+          fi
+          if [ -n "${INPUT_RESPONSES_ENDPOINT:-}" ]; then
+            RESPONSES_ENDPOINT_STATUS="configured (workflow_dispatch input)"
+          elif [ -n "${VAR_RESPONSES_ENDPOINT:-}" ]; then
+            RESPONSES_ENDPOINT_STATUS="configured (environment variable)"
+          elif [ -n "${SECRET_RESPONSES_ENDPOINT:-}" ]; then
+            RESPONSES_ENDPOINT_STATUS="configured (secret)"
+          else
+            RESPONSES_ENDPOINT_STATUS="action default"
+          fi
           if [ -n "${CODEX_ARGS:-}" ]; then
             CODEX_ARGS_STATUS="configured"
           else
@@ -486,7 +523,9 @@ jobs:
             echo "|---|---|"
             echo "| Log level | \`$LOG_LEVEL\` |"
             echo "| Model | \`$MODEL\` |"
+            echo "| Model source | \`$MODEL_SOURCE\` |"
             echo "| Effort | \`$EFFORT\` |"
+            echo "| Responses endpoint | \`$RESPONSES_ENDPOINT_STATUS\` |"
             echo "| Codex args | \`$CODEX_ARGS_STATUS\` |"
             echo "| Sandbox | \`workspace-write\` |"
             echo "| Lookback | \`${LOOKBACK} days\` |"
@@ -523,8 +562,8 @@ jobs:
         uses: openai/codex-action@v1
         with:
           openai-api-key: ${{ secrets.CUSTOM_AI_API_KEY }}
-          responses-api-endpoint: ${{ secrets.CUSTOM_AI_RESPONSES_ENDPOINT }}
-          model: ${{ vars.CODEX_MODEL || 'gpt-5.4' }}
+          responses-api-endpoint: ${{ inputs.responses_endpoint || vars.CUSTOM_AI_RESPONSES_ENDPOINT || secrets.CUSTOM_AI_RESPONSES_ENDPOINT }}
+          model: ${{ inputs.model || vars.CODEX_MODEL || 'gpt-5.4' }}
           effort: ${{ inputs.effort || vars.CODEX_EFFORT || 'xhigh' }}
           codex-args: ${{ vars.CODEX_ARGS }}
           sandbox: workspace-write
@@ -625,8 +664,8 @@ jobs:
         uses: openai/codex-action@v1
         with:
           openai-api-key: ${{ secrets.CUSTOM_AI_API_KEY }}
-          responses-api-endpoint: ${{ secrets.CUSTOM_AI_RESPONSES_ENDPOINT }}
-          model: ${{ vars.CODEX_MODEL || 'gpt-5.4' }}
+          responses-api-endpoint: ${{ inputs.responses_endpoint || vars.CUSTOM_AI_RESPONSES_ENDPOINT || secrets.CUSTOM_AI_RESPONSES_ENDPOINT }}
+          model: ${{ inputs.model || vars.CODEX_MODEL || 'gpt-5.4' }}
           effort: ${{ inputs.effort || vars.CODEX_EFFORT || 'xhigh' }}
           codex-args: ${{ vars.CODEX_ARGS }}
           sandbox: read-only

--- a/.github/workflows/ai-repo-audit.yml
+++ b/.github/workflows/ai-repo-audit.yml
@@ -49,8 +49,9 @@ name: AI Repo Audit
 # - secrets.CUSTOM_AI_API_KEY — OpenAI/兼容 API 密钥
 # - secrets.CUSTOM_AI_RESPONSES_ENDPOINT — AI API 端点 URL
 # - secrets.AI_FIX_TOKEN (可选) — PAT，让 audit PR 触发 CI；缺省用 github.token
-# - vars.CODEX_MODEL — 模型名（默认 gpt-5.5）
+# - vars.CODEX_MODEL — 模型名（默认 gpt-5.4）
 # - vars.CODEX_EFFORT — 推理强度（默认 xhigh）
+# - vars.CODEX_ARGS — 可选，额外传给 codex exec；适合用 -c 覆盖 config.toml 项
 # - environment: auto-ai — 需在 repo settings 中配置
 #
 # 注意：使用 GITHUB_TOKEN 推送的分支不会触发其它 workflow（CI 等）。
@@ -461,8 +462,9 @@ jobs:
       - name: Pre-Codex diagnostic
         env:
           LOG_LEVEL: ${{ steps.log-config.outputs.log_level }}
-          MODEL: ${{ vars.CODEX_MODEL || 'gpt-5.5' }}
+          MODEL: ${{ vars.CODEX_MODEL || 'gpt-5.4' }}
           EFFORT: ${{ inputs.effort || vars.CODEX_EFFORT || 'xhigh' }}
+          CODEX_ARGS: ${{ vars.CODEX_ARGS }}
           LOOKBACK: ${{ needs.gate.outputs.lookback_days }}
           SEVERITY: ${{ needs.gate.outputs.severity_threshold }}
           DRY_RUN: ${{ needs.gate.outputs.dry_run }}
@@ -471,6 +473,11 @@ jobs:
           set -euo pipefail
           CONTEXT_SIZE="$(du -sh .ai-audit-context/ 2>/dev/null | awk '{print $1}' || echo 'missing')"
           CONTEXT_FILES="$(find .ai-audit-context -type f 2>/dev/null | wc -l | tr -d ' ')"
+          if [ -n "${CODEX_ARGS:-}" ]; then
+            CODEX_ARGS_STATUS="configured"
+          else
+            CODEX_ARGS_STATUS="unset"
+          fi
 
           {
             echo "## AI Audit 配置摘要"
@@ -480,6 +487,7 @@ jobs:
             echo "| Log level | \`$LOG_LEVEL\` |"
             echo "| Model | \`$MODEL\` |"
             echo "| Effort | \`$EFFORT\` |"
+            echo "| Codex args | \`$CODEX_ARGS_STATUS\` |"
             echo "| Sandbox | \`workspace-write\` |"
             echo "| Lookback | \`${LOOKBACK} days\` |"
             echo "| Severity | \`$SEVERITY\` |"
@@ -516,8 +524,9 @@ jobs:
         with:
           openai-api-key: ${{ secrets.CUSTOM_AI_API_KEY }}
           responses-api-endpoint: ${{ secrets.CUSTOM_AI_RESPONSES_ENDPOINT }}
-          model: ${{ vars.CODEX_MODEL || 'gpt-5.5' }}
+          model: ${{ vars.CODEX_MODEL || 'gpt-5.4' }}
           effort: ${{ inputs.effort || vars.CODEX_EFFORT || 'xhigh' }}
+          codex-args: ${{ vars.CODEX_ARGS }}
           sandbox: workspace-write
           safety-strategy: drop-sudo
           prompt-file: .ai-audit-context/trusted-ai-repo-audit.md
@@ -617,8 +626,9 @@ jobs:
         with:
           openai-api-key: ${{ secrets.CUSTOM_AI_API_KEY }}
           responses-api-endpoint: ${{ secrets.CUSTOM_AI_RESPONSES_ENDPOINT }}
-          model: ${{ vars.CODEX_MODEL || 'gpt-5.5' }}
+          model: ${{ vars.CODEX_MODEL || 'gpt-5.4' }}
           effort: ${{ inputs.effort || vars.CODEX_EFFORT || 'xhigh' }}
+          codex-args: ${{ vars.CODEX_ARGS }}
           sandbox: read-only
           safety-strategy: read-only
           prompt-file: .ai-audit-context/condense-prompt.md

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -43,8 +43,9 @@ name: AI PR Review
 # 【依赖的 Secrets/Variables】
 # - secrets.CUSTOM_AI_API_KEY — OpenAI/兼容 API 密钥
 # - secrets.CUSTOM_AI_RESPONSES_ENDPOINT — AI API 端点 URL
-# - vars.CODEX_MODEL — 模型名（默认 gpt-5.5）
+# - vars.CODEX_MODEL — 模型名（默认 gpt-5.4）
 # - vars.CODEX_EFFORT — 推理强度（默认 xhigh）
+# - vars.CODEX_ARGS — 可选，额外传给 codex exec；适合用 -c 覆盖 config.toml 项
 # ═══════════════════════════════════════════════════════════════════════════
 
 on:
@@ -559,12 +560,18 @@ jobs:
       - name: Context summary (pre-Codex diagnostic)
         env:
           LOG_LEVEL: ${{ steps.log-config.outputs.log_level }}
-          MODEL: ${{ vars.CODEX_MODEL || 'gpt-5.5' }}
+          MODEL: ${{ vars.CODEX_MODEL || 'gpt-5.4' }}
           EFFORT: ${{ inputs.effort || vars.CODEX_EFFORT || 'xhigh' }}
+          CODEX_ARGS: ${{ vars.CODEX_ARGS }}
         run: |
           set -euo pipefail
           CONTEXT_SIZE="$(du -sh .ai-review-context/ 2>/dev/null | awk '{print $1}' || echo 'missing')"
           CONTEXT_FILES="$(find .ai-review-context -type f 2>/dev/null | wc -l | tr -d ' ')"
+          if [ -n "${CODEX_ARGS:-}" ]; then
+            CODEX_ARGS_STATUS="configured"
+          else
+            CODEX_ARGS_STATUS="unset"
+          fi
 
           {
             echo "## AI Review 配置摘要"
@@ -574,6 +581,7 @@ jobs:
             echo "| Log level | \`$LOG_LEVEL\` |"
             echo "| Model | \`$MODEL\` |"
             echo "| Effort | \`$EFFORT\` |"
+            echo "| Codex args | \`$CODEX_ARGS_STATUS\` |"
             echo "| Sandbox | \`read-only\` |"
             echo "| Context size | \`$CONTEXT_SIZE\` |"
             echo "| Context files | \`$CONTEXT_FILES\` |"
@@ -640,8 +648,9 @@ jobs:
         with:
           openai-api-key: ${{ secrets.CUSTOM_AI_API_KEY }}
           responses-api-endpoint: ${{ secrets.CUSTOM_AI_RESPONSES_ENDPOINT }}
-          model: ${{ vars.CODEX_MODEL || 'gpt-5.5' }}
+          model: ${{ vars.CODEX_MODEL || 'gpt-5.4' }}
           effort: ${{ inputs.effort || vars.CODEX_EFFORT || 'xhigh' }}
+          codex-args: ${{ vars.CODEX_ARGS }}
           sandbox: read-only
           safety-strategy: read-only
           prompt-file: .github/prompts/ai-review.md
@@ -739,8 +748,9 @@ jobs:
         with:
           openai-api-key: ${{ secrets.CUSTOM_AI_API_KEY }}
           responses-api-endpoint: ${{ secrets.CUSTOM_AI_RESPONSES_ENDPOINT }}
-          model: ${{ vars.CODEX_MODEL || 'gpt-5.5' }}
+          model: ${{ vars.CODEX_MODEL || 'gpt-5.4' }}
           effort: ${{ inputs.effort || vars.CODEX_EFFORT || 'xhigh' }}
+          codex-args: ${{ vars.CODEX_ARGS }}
           sandbox: read-only
           safety-strategy: read-only
           prompt-file: .codex-review-condense-prompt.md

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -42,7 +42,10 @@ name: AI PR Review
 #
 # 【依赖的 Secrets/Variables】
 # - secrets.CUSTOM_AI_API_KEY — OpenAI/兼容 API 密钥
-# - secrets.CUSTOM_AI_RESPONSES_ENDPOINT — AI API 端点 URL
+# - workflow_dispatch inputs.model — 手动指定模型，优先级最高
+# - workflow_dispatch inputs.responses_endpoint — 手动指定 Responses API 端点，优先级最高
+# - vars.CUSTOM_AI_RESPONSES_ENDPOINT — 可选，environment 级 AI API 端点 URL
+# - secrets.CUSTOM_AI_RESPONSES_ENDPOINT — 可选，secret 级 AI API 端点 URL
 # - vars.CODEX_MODEL — 模型名（默认 gpt-5.4）
 # - vars.CODEX_EFFORT — 推理强度（默认 xhigh）
 # - vars.CODEX_ARGS — 可选，额外传给 codex exec；适合用 -c 覆盖 config.toml 项
@@ -64,6 +67,14 @@ on:
         type: string
       pr_number:
         description: '可选：直接指定 PR number；填写后优先于 target_branch'
+        required: false
+        type: string
+      model:
+        description: '可选：覆盖 Codex 模型；留空则使用 environment 变量或默认值'
+        required: false
+        type: string
+      responses_endpoint:
+        description: '可选：覆盖 Responses API endpoint URL；留空则使用 environment 变量/secret 或 action 默认端点'
         required: false
         type: string
       effort:
@@ -560,13 +571,34 @@ jobs:
       - name: Context summary (pre-Codex diagnostic)
         env:
           LOG_LEVEL: ${{ steps.log-config.outputs.log_level }}
-          MODEL: ${{ vars.CODEX_MODEL || 'gpt-5.4' }}
+          MODEL: ${{ inputs.model || vars.CODEX_MODEL || 'gpt-5.4' }}
+          INPUT_MODEL: ${{ inputs.model }}
+          VAR_MODEL: ${{ vars.CODEX_MODEL }}
+          INPUT_RESPONSES_ENDPOINT: ${{ inputs.responses_endpoint }}
+          VAR_RESPONSES_ENDPOINT: ${{ vars.CUSTOM_AI_RESPONSES_ENDPOINT }}
+          SECRET_RESPONSES_ENDPOINT: ${{ secrets.CUSTOM_AI_RESPONSES_ENDPOINT }}
           EFFORT: ${{ inputs.effort || vars.CODEX_EFFORT || 'xhigh' }}
           CODEX_ARGS: ${{ vars.CODEX_ARGS }}
         run: |
           set -euo pipefail
           CONTEXT_SIZE="$(du -sh .ai-review-context/ 2>/dev/null | awk '{print $1}' || echo 'missing')"
           CONTEXT_FILES="$(find .ai-review-context -type f 2>/dev/null | wc -l | tr -d ' ')"
+          if [ -n "${INPUT_MODEL:-}" ]; then
+            MODEL_SOURCE="workflow_dispatch input"
+          elif [ -n "${VAR_MODEL:-}" ]; then
+            MODEL_SOURCE="environment variable"
+          else
+            MODEL_SOURCE="workflow default"
+          fi
+          if [ -n "${INPUT_RESPONSES_ENDPOINT:-}" ]; then
+            RESPONSES_ENDPOINT_STATUS="configured (workflow_dispatch input)"
+          elif [ -n "${VAR_RESPONSES_ENDPOINT:-}" ]; then
+            RESPONSES_ENDPOINT_STATUS="configured (environment variable)"
+          elif [ -n "${SECRET_RESPONSES_ENDPOINT:-}" ]; then
+            RESPONSES_ENDPOINT_STATUS="configured (secret)"
+          else
+            RESPONSES_ENDPOINT_STATUS="action default"
+          fi
           if [ -n "${CODEX_ARGS:-}" ]; then
             CODEX_ARGS_STATUS="configured"
           else
@@ -580,7 +612,9 @@ jobs:
             echo "|---|---|"
             echo "| Log level | \`$LOG_LEVEL\` |"
             echo "| Model | \`$MODEL\` |"
+            echo "| Model source | \`$MODEL_SOURCE\` |"
             echo "| Effort | \`$EFFORT\` |"
+            echo "| Responses endpoint | \`$RESPONSES_ENDPOINT_STATUS\` |"
             echo "| Codex args | \`$CODEX_ARGS_STATUS\` |"
             echo "| Sandbox | \`read-only\` |"
             echo "| Context size | \`$CONTEXT_SIZE\` |"
@@ -612,7 +646,7 @@ jobs:
       - name: Validate AI secrets
         env:
           CUSTOM_AI_API_KEY: ${{ secrets.CUSTOM_AI_API_KEY }}
-          CUSTOM_AI_RESPONSES_ENDPOINT: ${{ secrets.CUSTOM_AI_RESPONSES_ENDPOINT }}
+          CUSTOM_AI_RESPONSES_ENDPOINT: ${{ inputs.responses_endpoint || vars.CUSTOM_AI_RESPONSES_ENDPOINT || secrets.CUSTOM_AI_RESPONSES_ENDPOINT }}
           LOG_LEVEL: ${{ steps.log-config.outputs.log_level }}
         run: |
           set -euo pipefail
@@ -620,22 +654,27 @@ jobs:
             echo "::error::CUSTOM_AI_API_KEY is empty"
             exit 1
           fi
-          if [ -z "${CUSTOM_AI_RESPONSES_ENDPOINT:-}" ]; then
-            echo "::error::CUSTOM_AI_RESPONSES_ENDPOINT is empty"
-            exit 1
+          if [ -n "${CUSTOM_AI_RESPONSES_ENDPOINT:-}" ]; then
+            RESPONSES_ENDPOINT_STATUS="present"
+          else
+            RESPONSES_ENDPOINT_STATUS="action default"
           fi
 
           {
-            echo "## AI Review Secret 校验"
+            echo "## AI Review 凭据校验"
             echo
             echo "- CUSTOM_AI_API_KEY: present"
-            echo "- CUSTOM_AI_RESPONSES_ENDPOINT: present"
+            echo "- Responses endpoint: $RESPONSES_ENDPOINT_STATUS"
             echo
           } >> "$GITHUB_STEP_SUMMARY"
 
           if [ "$LOG_LEVEL" = "debug" ]; then
             echo "CUSTOM_AI_API_KEY length: ${#CUSTOM_AI_API_KEY}"
-            echo "CUSTOM_AI_RESPONSES_ENDPOINT length: ${#CUSTOM_AI_RESPONSES_ENDPOINT}"
+            if [ -n "${CUSTOM_AI_RESPONSES_ENDPOINT:-}" ]; then
+              echo "CUSTOM_AI_RESPONSES_ENDPOINT length: ${#CUSTOM_AI_RESPONSES_ENDPOINT}"
+            else
+              echo "CUSTOM_AI_RESPONSES_ENDPOINT: action default"
+            fi
           else
             echo "AI secrets are present. Enable log_level=debug to print non-sensitive lengths."
           fi
@@ -647,8 +686,8 @@ jobs:
         uses: openai/codex-action@v1
         with:
           openai-api-key: ${{ secrets.CUSTOM_AI_API_KEY }}
-          responses-api-endpoint: ${{ secrets.CUSTOM_AI_RESPONSES_ENDPOINT }}
-          model: ${{ vars.CODEX_MODEL || 'gpt-5.4' }}
+          responses-api-endpoint: ${{ inputs.responses_endpoint || vars.CUSTOM_AI_RESPONSES_ENDPOINT || secrets.CUSTOM_AI_RESPONSES_ENDPOINT }}
+          model: ${{ inputs.model || vars.CODEX_MODEL || 'gpt-5.4' }}
           effort: ${{ inputs.effort || vars.CODEX_EFFORT || 'xhigh' }}
           codex-args: ${{ vars.CODEX_ARGS }}
           sandbox: read-only
@@ -747,8 +786,8 @@ jobs:
         uses: openai/codex-action@v1
         with:
           openai-api-key: ${{ secrets.CUSTOM_AI_API_KEY }}
-          responses-api-endpoint: ${{ secrets.CUSTOM_AI_RESPONSES_ENDPOINT }}
-          model: ${{ vars.CODEX_MODEL || 'gpt-5.4' }}
+          responses-api-endpoint: ${{ inputs.responses_endpoint || vars.CUSTOM_AI_RESPONSES_ENDPOINT || secrets.CUSTOM_AI_RESPONSES_ENDPOINT }}
+          model: ${{ inputs.model || vars.CODEX_MODEL || 'gpt-5.4' }}
           effort: ${{ inputs.effort || vars.CODEX_EFFORT || 'xhigh' }}
           codex-args: ${{ vars.CODEX_ARGS }}
           sandbox: read-only


### PR DESCRIPTION
## 背景

当前三个 AI workflow 需要统一支持 Codex 运行参数覆盖：模型应允许手动触发时指定，并按“手动输入 > environment variable > workflow 默认值”的顺序解析；Responses API endpoint 也应允许手动指定，同时保留 environment variable / secret 兜底。

## 变更内容

- 将 `ai-review.yml`、`ai-agent.yml`、`ai-repo-audit.yml` 中的 Codex 模型 fallback 从 `gpt-5.5` 调整为 `gpt-5.4`。
- 为三个 workflow 的 `workflow_dispatch` 增加 `model` 和 `responses_endpoint` 输入。
- 将 Codex 模型解析统一为 `inputs.model || vars.CODEX_MODEL || 'gpt-5.4'`。
- 将 Responses API endpoint 解析统一为 `inputs.responses_endpoint || vars.CUSTOM_AI_RESPONSES_ENDPOINT || secrets.CUSTOM_AI_RESPONSES_ENDPOINT`；全部为空时使用 `openai/codex-action` 的默认 endpoint 行为。
- 为三个 workflow 的主 Codex step 和长输出压缩 step 增加 `codex-args: ${{ vars.CODEX_ARGS }}`。
- 在配置摘要中显示模型来源、endpoint 来源和 `CODEX_ARGS` 配置状态，避免输出 endpoint 实际值。

## 运行配置

本次已同步更新 `auto-ai` environment variables：

- `CODEX_MODEL=gpt-5.4`
- `CODEX_ARGS=["-c","model_context_window=250000","-c","model_auto_compact_token_limit=200000","-c","tool_output_token_limit=32000"]`

当前 `CUSTOM_AI_RESPONSES_ENDPOINT` 仍可继续走现有 secret；如需把 endpoint 作为非敏感环境变量管理，可在 `auto-ai` environment variables 中增加同名变量，它的优先级高于 secret。

## 验证

- `ruby -e 'require "yaml"; %w[.github/workflows/ai-review.yml .github/workflows/ai-agent.yml .github/workflows/ai-repo-audit.yml].each { |f| YAML.load_file(f); puts "OK #{f}" }'`
- `actionlint .github/workflows/ai-review.yml .github/workflows/ai-agent.yml .github/workflows/ai-repo-audit.yml`
- `git diff --check`
- `codex debug prompt-input -c model_context_window=250000 -c model_auto_compact_token_limit=200000 -c tool_output_token_limit=32000 'test prompt'`
