### PR TITLE
chore(ci): 新增 Hugging Face Space 自动部署与重建流程

### DIFF
--- a/.github/workflows/deploy-hf-space.yml
+++ b/.github/workflows/deploy-hf-space.yml
@@ -1,0 +1,133 @@
+name: Deploy Hugging Face Space
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "panel/**"
+      - "pyproject.toml"
+      - "README.md"
+      - "souwen.example.yaml"
+      - "entrypoint.sh"
+      - "scripts/warp-init.sh"
+      - "cloud/hfs/**"
+      - ".github/workflows/deploy-hf-space.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-hf-space-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Sync changed wrapper files and factory rebuild
+    environment:
+      name: hf
+      url: https://huggingface.co/spaces/BlueSkyXN/SouWen
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check HF token
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          if [ -z "$HF_TOKEN" ]; then
+            echo "::error::HF_TOKEN is not configured. Add a Hugging Face write token to the hf environment secrets."
+            exit 1
+          fi
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install Hugging Face Hub client
+        run: python -m pip install --upgrade huggingface_hub
+
+      - name: Sync changed HFS wrapper files
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_SPACE_ID: BlueSkyXN/SouWen
+        run: |
+          python - <<'PY'
+          import os
+          import tempfile
+          from pathlib import Path
+
+          from huggingface_hub import CommitOperationAdd, HfApi, hf_hub_download
+          from huggingface_hub.errors import EntryNotFoundError
+
+          FILES = {
+              "cloud/hfs/Dockerfile": "Dockerfile",
+              "cloud/hfs/README.md": "README.md",
+              "cloud/hfs/.dockerignore": ".dockerignore",
+              "cloud/hfs/entrypoint.sh": "entrypoint.sh",
+          }
+
+          api = HfApi(token=os.environ["HF_TOKEN"])
+          space_id = os.environ["HF_SPACE_ID"]
+          sha = os.environ["GITHUB_SHA"][:7]
+          operations = []
+
+          with tempfile.TemporaryDirectory() as tmpdir:
+              for local_name, remote_name in FILES.items():
+                  local_path = Path(local_name)
+                  local_bytes = local_path.read_bytes()
+
+                  try:
+                      remote_path = hf_hub_download(
+                          repo_id=space_id,
+                          repo_type="space",
+                          filename=remote_name,
+                          token=os.environ["HF_TOKEN"],
+                          local_dir=tmpdir,
+                          force_download=True,
+                      )
+                      remote_bytes = Path(remote_path).read_bytes()
+                  except EntryNotFoundError:
+                      remote_bytes = None
+
+                  if remote_bytes != local_bytes:
+                      operations.append(
+                          CommitOperationAdd(
+                              path_in_repo=remote_name,
+                              path_or_fileobj=str(local_path),
+                          )
+                      )
+
+          if operations:
+              changed = ", ".join(op.path_in_repo for op in operations)
+              print(f"Sync changed HFS wrapper files: {changed}")
+              api.create_commit(
+                  repo_id=space_id,
+                  repo_type="space",
+                  operations=operations,
+                  commit_message=f"Sync HFS wrapper from GitHub {sha}",
+              )
+          else:
+              print("No HFS wrapper file changes to sync.")
+          PY
+
+      - name: Factory rebuild Space
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_SPACE_ID: BlueSkyXN/SouWen
+        run: |
+          python - <<'PY'
+          import os
+          from huggingface_hub import HfApi
+
+          api = HfApi(token=os.environ["HF_TOKEN"])
+          space_id = os.environ["HF_SPACE_ID"]
+          runtime = api.restart_space(
+              repo_id=space_id,
+              factory_reboot=True,
+          )
+          print(f"Requested factory rebuild for {space_id}; stage={runtime.stage}")
+          PY

--- a/.github/workflows/deploy-hf-space.yml
+++ b/.github/workflows/deploy-hf-space.yml
@@ -25,6 +25,7 @@ permissions:
 jobs:
   deploy:
     name: Sync changed wrapper files and factory rebuild
+    if: github.ref == 'refs/heads/main'
     environment:
       name: hf
       url: https://huggingface.co/spaces/BlueSkyXN/SouWen
@@ -48,7 +49,7 @@ jobs:
           cache: pip
 
       - name: Install Hugging Face Hub client
-        run: python -m pip install --upgrade huggingface_hub
+        run: python -m pip install "huggingface_hub>=1.8,<2"
 
       - name: Sync changed HFS wrapper files
         env:


### PR DESCRIPTION
## 概述

新增 Hugging Face Space 自动部署 workflow，用于将 GitHub `main` 的 SouWen 源码变更部署到 `BlueSkyXN/SouWen` Space。

当前 HF Space 仓库只保存 Docker 部署所需的少量包装文件，运行时镜像构建会在 Dockerfile 内部 clone GitHub 主仓。因此本 PR 不把完整源码同步到 Hugging Face，而是维护 Space 包装文件，并在每次部署时触发 `factory_reboot=True`，让 Space 重新走干净构建并拉取最新 `main`。

## 主要变更

- 新增 `.github/workflows/deploy-hf-space.yml`。
- push 到 `main` 且命中源码、panel、配置示例、HFS 包装文件或 workflow 自身时自动触发部署。
- 支持 `workflow_dispatch` 手动触发，便于需要时手动 factory rebuild。
- 部署 job 绑定 GitHub Environment `hf`，使用 environment secret `HF_TOKEN` 访问 Hugging Face。
- 同步前逐文件比对 HF Space 远端内容，只有包装文件实际变化时才向 Space 仓库提交 commit。
- 无论包装文件是否变化，最后都会调用 `HfApi.restart_space(..., factory_reboot=True)` 请求 factory rebuild。

## 评审修复

- 部署 job 增加 `if: github.ref == 'refs/heads/main'`，避免从非 `main` 分支手动触发时把分支内的 Space wrapper 同步到生产 HF Space。
- 将 Hugging Face Hub client 安装范围固定为 `huggingface_hub>=1.8,<2`，不再无约束安装最新版，降低部署链路被上游 API 变化打断的风险。

## Space 文件同步范围

本 workflow 只同步 Hugging Face Space 根目录需要的 4 个文件：

| 本仓文件 | Space 文件 |
|---|---|
| `cloud/hfs/Dockerfile` | `Dockerfile` |
| `cloud/hfs/README.md` | `README.md` |
| `cloud/hfs/.dockerignore` | `.dockerignore` |
| `cloud/hfs/entrypoint.sh` | `entrypoint.sh` |

不会同步完整 SouWen 仓库，也不会上传 `src/`、`panel/`、`docs/`、`tests/` 等主仓内容。

## 运行方式

### 自动触发

当 commit push 到 `main`，且命中以下路径之一时执行：

- `src/**`
- `panel/**`
- `pyproject.toml`
- `README.md`
- `souwen.example.yaml`
- `entrypoint.sh`
- `scripts/warp-init.sh`
- `cloud/hfs/**`
- `.github/workflows/deploy-hf-space.yml`

### 手动触发

可在 GitHub Actions 页面手动运行 `Deploy Hugging Face Space`。部署 job 只允许在 `main` ref 执行；如果手动选择非 `main` 分支，job 会跳过，不会访问 `hf` environment，也不会修改生产 Space。

## 安全与权限

- `HF_TOKEN` 放在 GitHub Environment `hf` 下，不使用仓库级全局 secret。
- workflow 开始时检查 `HF_TOKEN`，缺失则直接失败，避免出现绿色通过但实际未部署。
- GitHub token 权限仅声明 `contents: read`；对 HF Space 的写入通过 Hugging Face token 完成。
- 并发组按 `${{ github.ref }}` 收敛，同一 ref 新部署会取消旧部署。

## 验证

- 本地解析 workflow YAML 通过。
- 已确认 job 绑定 `environment.name = hf`。
- 已确认部署 job 限制为 `github.ref == 'refs/heads/main'`。
- 已确认当前验证版本 `huggingface_hub 1.8.0` 满足 `>=1.8,<2`，且 `HfApi.restart_space` 支持 `factory_reboot` 参数。
- `git diff --check` 通过。
- 已用只读方式对比当前 HF Space 远端文件，确认同步逻辑只会处理白名单文件。
- 已确认 `hf` environment 下存在 `HF_TOKEN` secret（仅查看 secret 名称，未读取值）。

## 文件清单

**新增（1 文件）：**

- `.github/workflows/deploy-hf-space.yml` — Hugging Face Space 包装文件同步与 factory rebuild 自动部署 workflow。
