### PR TITLE
fix(hf-space): 修复 CD smoke 控制面快照与本地预检

### DIFF
--- a/.github/workflows/build-pyinstaller.yml
+++ b/.github/workflows/build-pyinstaller.yml
@@ -269,6 +269,7 @@ jobs:
           dist/${{ env.APP_NAME }} --version
           dist/${{ env.APP_NAME }} sources
           dist/${{ env.APP_NAME }} config show
+          dist/${{ env.APP_NAME }} config backend
 
       - name: Verify bundled CLI (Windows)
         if: runner.os == 'Windows'
@@ -280,6 +281,7 @@ jobs:
           ./dist/${{ env.APP_NAME }}.exe --version
           ./dist/${{ env.APP_NAME }}.exe sources
           ./dist/${{ env.APP_NAME }}.exe config show
+          ./dist/${{ env.APP_NAME }}.exe config backend
 
       # --- 重命名并上传构建产物 ---
       - name: Rename artifact (Unix)

--- a/.github/workflows/build-pyinstaller.yml
+++ b/.github/workflows/build-pyinstaller.yml
@@ -161,6 +161,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download panel.html
+        if: needs.prepare.outputs.need_panel == 'true'
         uses: actions/download-artifact@v8
         with:
           name: panel-html
@@ -177,21 +178,21 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install .
-          pip install pyinstaller
+          pip install "setuptools<82" pyinstaller
 
       - name: Install dependencies (Server)
         if: matrix.build_type == 'server'
         run: |
           python -m pip install --upgrade pip
           pip install ".[server,tls,web]"
-          pip install pyinstaller
+          pip install "setuptools<82" pyinstaller
 
       - name: Install dependencies (Full)
         if: matrix.build_type == 'full'
         run: |
           python -m pip install --upgrade pip
           pip install ".[server,tls,web,scraper,newspaper,readability,pdf,mcp,web2pdf]"
-          pip install pyinstaller
+          pip install "setuptools<82" pyinstaller
 
       - name: Verify CLI
         env:
@@ -212,6 +213,7 @@ jobs:
             --hidden-import=souwen.server.routes \
             --hidden-import=souwen.integrations \
             --hidden-import=souwen.integrations.mcp_server \
+            --collect-submodules=rich._unicode_data \
             cli.py
 
       - name: Build with PyInstaller (Unix - Server)
@@ -225,6 +227,7 @@ jobs:
             --hidden-import=souwen.server.routes \
             --exclude-module=souwen.integrations \
             --exclude-module=mcp \
+            --collect-submodules=rich._unicode_data \
             cli.py
 
       - name: Build with PyInstaller (Unix - CLI)
@@ -237,22 +240,46 @@ jobs:
             --exclude-module=fastapi \
             --exclude-module=uvicorn \
             --exclude-module=mcp \
+            --exclude-module=pkg_resources \
+            --exclude-module=setuptools \
+            --collect-submodules=rich._unicode_data \
             cli.py
 
       - name: Build with PyInstaller (Windows - Full)
         if: runner.os == 'Windows' && matrix.build_type == 'full'
         run: |
-          pyinstaller --onefile --clean --name ${{ env.APP_NAME }} --paths src --add-data "src/souwen/server/panel.html;souwen/server" --hidden-import=souwen.server --hidden-import=souwen.server.app --hidden-import=souwen.server.routes --hidden-import=souwen.integrations --hidden-import=souwen.integrations.mcp_server cli.py
+          pyinstaller --onefile --clean --name ${{ env.APP_NAME }} --paths src --add-data "src/souwen/server/panel.html;souwen/server" --hidden-import=souwen.server --hidden-import=souwen.server.app --hidden-import=souwen.server.routes --hidden-import=souwen.integrations --hidden-import=souwen.integrations.mcp_server --collect-submodules=rich._unicode_data cli.py
 
       - name: Build with PyInstaller (Windows - Server)
         if: runner.os == 'Windows' && matrix.build_type == 'server'
         run: |
-          pyinstaller --onefile --clean --name ${{ env.APP_NAME }} --paths src --add-data "src/souwen/server/panel.html;souwen/server" --hidden-import=souwen.server --hidden-import=souwen.server.app --hidden-import=souwen.server.routes --exclude-module=souwen.integrations --exclude-module=mcp cli.py
+          pyinstaller --onefile --clean --name ${{ env.APP_NAME }} --paths src --add-data "src/souwen/server/panel.html;souwen/server" --hidden-import=souwen.server --hidden-import=souwen.server.app --hidden-import=souwen.server.routes --exclude-module=souwen.integrations --exclude-module=mcp --collect-submodules=rich._unicode_data cli.py
 
       - name: Build with PyInstaller (Windows - CLI)
         if: runner.os == 'Windows' && matrix.build_type == 'cli'
         run: |
-          pyinstaller --onefile --clean --name ${{ env.APP_NAME }} --paths src --exclude-module=souwen.server --exclude-module=souwen.integrations --exclude-module=fastapi --exclude-module=uvicorn --exclude-module=mcp cli.py
+          pyinstaller --onefile --clean --name ${{ env.APP_NAME }} --paths src --exclude-module=souwen.server --exclude-module=souwen.integrations --exclude-module=fastapi --exclude-module=uvicorn --exclude-module=mcp --exclude-module=pkg_resources --exclude-module=setuptools --collect-submodules=rich._unicode_data cli.py
+
+      - name: Verify bundled CLI (Unix)
+        if: runner.os != 'Windows'
+        env:
+          PYTHONIOENCODING: utf-8
+        run: |
+          dist/${{ env.APP_NAME }} --help
+          dist/${{ env.APP_NAME }} --version
+          dist/${{ env.APP_NAME }} sources
+          dist/${{ env.APP_NAME }} config show
+
+      - name: Verify bundled CLI (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          PYTHONIOENCODING: utf-8
+        run: |
+          ./dist/${{ env.APP_NAME }}.exe --help
+          ./dist/${{ env.APP_NAME }}.exe --version
+          ./dist/${{ env.APP_NAME }}.exe sources
+          ./dist/${{ env.APP_NAME }}.exe config show
 
       # --- 重命名并上传构建产物 ---
       - name: Rename artifact (Unix)
@@ -261,7 +288,8 @@ jobs:
 
       - name: Rename artifact (Windows)
         if: runner.os == 'Windows'
-        run: move dist\${{ env.APP_NAME }}.exe dist\${{ matrix.artifact_name }}
+        shell: pwsh
+        run: Move-Item -Path "dist/${{ env.APP_NAME }}.exe" -Destination "dist/${{ matrix.artifact_name }}"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/deploy-hf-space.yml
+++ b/.github/workflows/deploy-hf-space.yml
@@ -187,7 +187,7 @@ jobs:
 
       - name: Upload post-deploy test report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: hf-space-cd-report
           path: |

--- a/.github/workflows/hf-space-local-gate.yml
+++ b/.github/workflows/hf-space-local-gate.yml
@@ -76,6 +76,7 @@ jobs:
           python cli.py --version
           python cli.py sources
           python cli.py config show
+          python cli.py config backend
           python -m souwen --help
 
   pyinstaller-cli:
@@ -118,6 +119,7 @@ jobs:
           ./dist/souwen-local --version
           ./dist/souwen-local sources
           ./dist/souwen-local config show
+          ./dist/souwen-local config backend
 
       - name: Upload PyInstaller CLI artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/hf-space-local-gate.yml
+++ b/.github/workflows/hf-space-local-gate.yml
@@ -132,9 +132,9 @@ jobs:
     timeout-minutes: 45
     env:
       PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.clone_url }}
-      PR_HEAD_REF: ${{ github.head_ref }}
+      PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       DEFAULT_REPO: https://github.com/${{ github.repository }}.git
-      DEFAULT_REF: ${{ github.ref_name }}
+      DEFAULT_REF: ${{ github.sha }}
     steps:
       - uses: actions/checkout@v6
 
@@ -142,7 +142,7 @@ jobs:
         id: source
         run: |
           SOURCE_REPO="${PR_HEAD_REPO:-$DEFAULT_REPO}"
-          SOURCE_REF="${PR_HEAD_REF:-$DEFAULT_REF}"
+          SOURCE_REF="${PR_HEAD_SHA:-$DEFAULT_REF}"
           if [ -z "$SOURCE_REPO" ] || [ -z "$SOURCE_REF" ]; then
             echo "::error::Cannot resolve source repo/ref for Docker build"
             exit 1

--- a/.github/workflows/hf-space-local-gate.yml
+++ b/.github/workflows/hf-space-local-gate.yml
@@ -1,0 +1,228 @@
+name: HF Space Local Gate
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "panel/**"
+      - "pyproject.toml"
+      - "README.md"
+      - "README.en.md"
+      - "docs/**"
+      - "scripts/hf_space_smoke.py"
+      - "scripts/warp-init.sh"
+      - "cloud/hfs/**"
+      - "entrypoint.sh"
+      - "cli.py"
+      - ".github/workflows/hf-space-local-gate.yml"
+      - ".github/workflows/deploy-hf-space.yml"
+      - ".github/workflows/build-pyinstaller.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "panel/**"
+      - "pyproject.toml"
+      - "README.md"
+      - "README.en.md"
+      - "docs/**"
+      - "scripts/hf_space_smoke.py"
+      - "scripts/warp-init.sh"
+      - "cloud/hfs/**"
+      - "entrypoint.sh"
+      - "cli.py"
+      - ".github/workflows/hf-space-local-gate.yml"
+      - ".github/workflows/deploy-hf-space.yml"
+      - ".github/workflows/build-pyinstaller.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: hf-space-local-gate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  api-source-cli:
+    name: API surface and source CLI
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install source package
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,server,tls]"
+
+      - name: Run API and smoke unit tests
+        run: |
+          pytest tests/test_server tests/test_hf_space_smoke.py -v --tb=short
+
+      - name: Run source CLI smoke commands
+        env:
+          PYTHONIOENCODING: utf-8
+        run: |
+          python cli.py --help
+          python cli.py --version
+          python cli.py sources
+          python cli.py config show
+          python -m souwen --help
+
+  pyinstaller-cli:
+    name: PyInstaller CLI smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install package and PyInstaller
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install "setuptools<82" pyinstaller
+
+      - name: Build CLI-only executable
+        run: |
+          pyinstaller --onefile --clean --name souwen-local \
+            --paths src \
+            --exclude-module=souwen.server \
+            --exclude-module=souwen.integrations \
+            --exclude-module=fastapi \
+            --exclude-module=uvicorn \
+            --exclude-module=mcp \
+            --exclude-module=pkg_resources \
+            --exclude-module=setuptools \
+            --collect-submodules=rich._unicode_data \
+            cli.py
+
+      - name: Run bundled CLI smoke commands
+        env:
+          PYTHONIOENCODING: utf-8
+        run: |
+          ./dist/souwen-local --help
+          ./dist/souwen-local --version
+          ./dist/souwen-local sources
+          ./dist/souwen-local config show
+
+      - name: Upload PyInstaller CLI artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: souwen-local-pyinstaller-cli
+          path: dist/souwen-local
+          retention-days: 7
+
+  docker-hfs:
+    name: HF Space Docker surface smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.clone_url }}
+      PR_HEAD_REF: ${{ github.head_ref }}
+      DEFAULT_REPO: https://github.com/${{ github.repository }}.git
+      DEFAULT_REF: ${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve source ref for HFS Dockerfile clone
+        id: source
+        run: |
+          SOURCE_REPO="${PR_HEAD_REPO:-$DEFAULT_REPO}"
+          SOURCE_REF="${PR_HEAD_REF:-$DEFAULT_REF}"
+          if [ -z "$SOURCE_REPO" ] || [ -z "$SOURCE_REF" ]; then
+            echo "::error::Cannot resolve source repo/ref for Docker build"
+            exit 1
+          fi
+          {
+            echo "repo=$SOURCE_REPO"
+            echo "ref=$SOURCE_REF"
+          } >> "$GITHUB_OUTPUT"
+          echo "HFS Docker source: $SOURCE_REPO @ $SOURCE_REF"
+
+      - name: Build HF Space Docker image from PR branch
+        run: |
+          docker build \
+            -f cloud/hfs/Dockerfile \
+            --build-arg SOUWEN_REPO="${{ steps.source.outputs.repo }}" \
+            --build-arg SOUWEN_REF="${{ steps.source.outputs.ref }}" \
+            --build-arg SKINS=souwen-google \
+            --build-arg WITH_WEB2PDF=0 \
+            -t "souwen-hfs-local:${GITHUB_SHA::7}" \
+            cloud/hfs
+
+      - name: Run container and wait for readiness
+        run: |
+          docker run -d --name souwen-hfs-local \
+            -p 49265:49265 \
+            -e SOUWEN_ADMIN_OPEN=1 \
+            -e SOUWEN_EXPOSE_DOCS=1 \
+            -e WARP_ENABLED=0 \
+            "souwen-hfs-local:${GITHUB_SHA::7}"
+
+          for attempt in $(seq 1 60); do
+            if curl -fsS http://127.0.0.1:49265/health; then
+              exit 0
+            fi
+            echo "Waiting for health (${attempt}/60)"
+            sleep 2
+          done
+
+          docker logs souwen-hfs-local
+          exit 1
+
+      - name: Run local API surface smoke
+        env:
+          SOUWEN_SMOKE_REPORT_FILE: hf-space-local-surface-report.md
+          SOUWEN_SMOKE_JSON_FILE: hf-space-local-surface-report.json
+        run: |
+          VERSION="$(python3 - <<'PY'
+          import tomllib
+          with open("pyproject.toml", "rb") as file:
+              print(tomllib.load(file)["project"]["version"])
+          PY
+          )"
+          python3 scripts/hf_space_smoke.py \
+            --base-url http://127.0.0.1:49265 \
+            --expected-version "$VERSION" \
+            --request-timeout 10 \
+            --surface-only
+
+      - name: Verify browser entry HTML explicitly
+        run: |
+          curl -fsSL http://127.0.0.1:49265/docs -o /tmp/souwen-docs.html
+          grep -Eiq 'Swagger UI|swagger-ui' /tmp/souwen-docs.html
+          curl -fsSL http://127.0.0.1:49265/panel -o /tmp/souwen-panel.html
+          grep -Eiq 'id="root"|SouWen|souwen' /tmp/souwen-panel.html
+
+      - name: Show container logs
+        if: always()
+        run: docker logs souwen-hfs-local || true
+
+      - name: Stop container
+        if: always()
+        run: docker rm -f souwen-hfs-local || true
+
+      - name: Upload local smoke reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: hf-space-local-surface-report
+          path: |
+            hf-space-local-surface-report.md
+            hf-space-local-surface-report.json
+          if-no-files-found: warn
+          retention-days: 7

--- a/README.en.md
+++ b/README.en.md
@@ -133,7 +133,7 @@ curl "http://localhost:8000/api/v1/paper/search?q=transformer"
 curl "http://localhost:8000/api/v1/archive/cdx?url=https://example.com"
 ```
 
-Visit `/docs` for the full OpenAPI documentation; visit `/` to enter the Web UI (default: souwen-google skin).
+Visit `/docs` for the full OpenAPI documentation; visit `/panel#/` to enter the Web UI (default: souwen-google skin). `/` redirects to `/docs` with the default configuration.
 
 ## ⚙️ Configuration
 
@@ -191,7 +191,7 @@ docker run -p 8000:8000 \
   souwen
 ```
 
-**HuggingFace Spaces**: see `cloud/hfs/`.
+**HuggingFace Spaces**: see `cloud/hfs/` and [docs/hf-space-cd.md](docs/hf-space-cd.md).
 **ModelScope**: see `cloud/modelscope/`.
 
 **WARP proxy embedding** (optional, bypass network restrictions): see the WARP section in `docs/anti-scraping.md`.
@@ -202,6 +202,7 @@ docker run -p 8000:8000 \
 - [docs/data-sources.md](docs/data-sources.md) — Full data source list (auto-generated from registry)
 - [docs/configuration.md](docs/configuration.md) — Configuration hierarchy / WARP / HTTP backend
 - [docs/api-reference.md](docs/api-reference.md) — REST API reference
+- [docs/hf-space-cd.md](docs/hf-space-cd.md) — Hugging Face Space CD / local gates / post-deploy validation
 - [docs/anti-scraping.md](docs/anti-scraping.md) — TLS fingerprinting / WARP / rate limiting
 - [docs/appearance.md](docs/appearance.md) — Multi-skin frontend
 - [docs/adding-a-source.md](docs/adding-a-source.md) — Adding a new source guide

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ curl "http://localhost:8000/api/v1/paper/search?q=transformer"
 curl "http://localhost:8000/api/v1/archive/cdx?url=https://example.com"
 ```
 
-访问 `/docs` 查看完整 OpenAPI 文档；访问 `/` 进入 Web UI（默认 souwen-google 皮肤）。
+访问 `/docs` 查看完整 OpenAPI 文档；访问 `/panel#/` 进入 Web UI（默认 souwen-google 皮肤）。`/` 在默认配置下重定向到 `/docs`。
 
 ## ⚙️ 配置
 
@@ -190,7 +190,7 @@ docker run -p 8000:8000 \
   souwen
 ```
 
-**HuggingFace Spaces**：参见 `cloud/hfs/`。
+**HuggingFace Spaces**：参见 `cloud/hfs/` 与 [docs/hf-space-cd.md](docs/hf-space-cd.md)。
 **ModelScope**：参见 `cloud/modelscope/`。
 
 **WARP 代理嵌入**（可选，绕过国内网络）：见 `docs/warp-solutions.md` 的五种模式方案对比和 `docs/anti-scraping.md` 的反爬策略。支持运行时通过 Web 面板一键安装 WARP 组件。
@@ -201,6 +201,7 @@ docker run -p 8000:8000 \
 - [docs/data-sources.md](docs/data-sources.md) — 完整数据源清单（由 registry 自动生成）
 - [docs/configuration.md](docs/configuration.md) — 配置层级 / WARP / HTTP backend
 - [docs/api-reference.md](docs/api-reference.md) — REST API 参考
+- [docs/hf-space-cd.md](docs/hf-space-cd.md) — Hugging Face Space CD / 本地预检 / 部署后验收
 - [docs/anti-scraping.md](docs/anti-scraping.md) — TLS 指纹 / WARP / 限流
 - [docs/appearance.md](docs/appearance.md) — 多皮肤前端
 - [docs/adding-a-source.md](docs/adding-a-source.md) — 新增数据源指南

--- a/cloud/hfs/Dockerfile
+++ b/cloud/hfs/Dockerfile
@@ -5,7 +5,10 @@ ARG SKINS=all
 RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /build
-RUN git clone --depth 1 --branch "${SOUWEN_REF}" "${SOUWEN_REPO}" .
+RUN git init . \
+    && git remote add origin "${SOUWEN_REPO}" \
+    && git fetch --depth 1 origin "${SOUWEN_REF}" \
+    && git checkout --detach FETCH_HEAD
 WORKDIR /build/panel
 RUN npm ci --ignore-scripts && VITE_SKINS=${SKINS} npm run build
 
@@ -45,7 +48,10 @@ RUN ARCH=$(dpkg --print-architecture) && \
 
 WORKDIR /app
 
-RUN git clone --depth 1 --branch "${SOUWEN_REF}" "${SOUWEN_REPO}" .
+RUN git init . \
+    && git remote add origin "${SOUWEN_REPO}" \
+    && git fetch --depth 1 origin "${SOUWEN_REF}" \
+    && git checkout --detach FETCH_HEAD
 
 # 前端面板：从 panel-builder 阶段复制构建产物（必须在 pip install 之前，
 # 否则 panel.html 不会被打包进 site-packages）

--- a/cloud/hfs/README.md
+++ b/cloud/hfs/README.md
@@ -18,11 +18,15 @@ pinned: false
 |------|------|------|
 | GET | `/health` | 存活探针 |
 | GET | `/readiness` | 就绪探针（v0.6.1，检查配置可加载 + 数据源注册表非空） |
+| GET | `/docs` | OpenAPI / Swagger UI 文档 |
+| GET | `/panel` | 管理面板 HTML；浏览器访问入口为 `/panel#/` |
+| GET | `/openapi.json` | OpenAPI schema |
 | GET | `/api/v1/search/paper?q=...` | 搜索学术论文 |
 | GET | `/api/v1/search/patent?q=...` | 搜索专利 |
 | GET | `/api/v1/search/web?q=...` | 搜索网页（默认 `engines=duckduckgo,bing`） |
 | GET | `/api/v1/sources` | 列出所有可用数据源 |
 | GET | `/api/v1/admin/config` | 查看配置（需认证） |
+| GET / PUT | `/api/v1/admin/http-backend` | 查看或临时切换 HTTP backend（需认证） |
 | POST | `/api/v1/admin/config/reload` | 重载配置（需认证） |
 | GET | `/api/v1/admin/doctor` | 数据源健康检查（需认证） |
 | GET | `/api/v1/admin/warp` | 查询 WARP 状态（需认证） |
@@ -53,6 +57,17 @@ pinned: false
 | ... | 其他 SOUWEN_* 环境变量均可直接设置 |
 
 > 大部分爬虫引擎（DuckDuckGo、Yahoo、Brave Scraper、Google Scraper 等）无需 API Key 即可使用。
+
+## 部署与验收
+
+GitHub 上的 PR 阶段会先运行本地预检：源码 CLI、PyInstaller CLI、HF Space Docker 容器启动和 API surface smoke。合入 `main` 后，`Deploy Hugging Face Space` workflow 会同步本目录 wrapper 文件、触发 Space factory rebuild，并在远端执行部署后 smoke。
+
+部署后人工验收至少访问：
+
+- 管理面板：<https://blueskyxn-souwen.hf.space/panel#/>
+- API 文档：<https://blueskyxn-souwen.hf.space/docs>
+
+详细边界见 `docs/hf-space-cd.md`。远端 smoke 中的 zero-key 结果会受上游风控、出口 IP 和速率限制影响，`WARN` 表示当次观测结果，不代表功能代码一定不可用。
 
 ## 源码
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -392,7 +392,7 @@ K8s readiness 探针（v0.6.1 引入）。仅做本地检查（配置可加载 +
 
 - 当 `expose_docs=true`（默认）时，`GET /` 重定向到 `/docs`（Swagger UI）。
 - 当 `expose_docs=false` 时，`GET /` 返回 JSON 元信息（`{name, version, panel, docs}`）。
-- `GET /panel` 返回管理面板 HTML（不含在 OpenAPI schema 中）。
+- `GET /panel` 返回管理面板 HTML（不含在 OpenAPI schema 中）；浏览器侧的完整入口通常写作 `/panel#/`，其中 `#` 后内容由前端 router 处理。
 
 `/panel` 的 HTML 经内存缓存，并附带：
 

--- a/docs/hf-space-cd.md
+++ b/docs/hf-space-cd.md
@@ -1,0 +1,72 @@
+# Hugging Face Space CD 与验收
+
+本文档说明 SouWen 在 Hugging Face Space 上的自动部署、PR 本地预检和部署后验收边界。
+
+## 部署对象
+
+- 远端应用入口：<https://blueskyxn-souwen.hf.space/>
+- 管理面板入口：<https://blueskyxn-souwen.hf.space/panel#/>
+- OpenAPI 文档入口：<https://blueskyxn-souwen.hf.space/docs>
+- Space 仓库：<https://huggingface.co/spaces/BlueSkyXN/SouWen>
+
+`/panel#/` 中的 `#` 是前端 hash router 片段，不会发送到服务端；服务端实际校验 `/panel` 是否返回前端 HTML。`/docs` 与 `/openapi.json` 用于确认 API 文档和 schema 暴露状态。
+
+## GitHub Actions 分层
+
+### PR 本地预检
+
+`.github/workflows/hf-space-local-gate.yml` 在 PR 阶段执行，不依赖 Hugging Face secrets，目标是提前拦截本地可复现的问题：
+
+| Job | 覆盖内容 | 说明 |
+|---|---|---|
+| `API surface and source CLI` | `tests/test_server`、`tests/test_hf_space_smoke.py`、源码 CLI 真实进程 | 覆盖服务端基础路由、smoke 脚本契约和 `python cli.py ...` / `python -m souwen ...` |
+| `PyInstaller CLI smoke` | Linux CLI-only 单文件构建后执行 | 验证 PyInstaller 产物至少能完成帮助、版本、sources、config show 等非网络命令 |
+| `HF Space Docker surface smoke` | 使用 `cloud/hfs/Dockerfile` 构建并本地启动容器 | 验证 `/health`、`/readiness`、`/docs`、`/panel` 和核心 admin API surface |
+
+这层只验证本地 API/CLI/容器启动契约，不代表外部搜索源在远端网络环境中稳定可用。
+
+### Main 部署
+
+`.github/workflows/deploy-hf-space.yml` 只在 `main` 分支运行：
+
+1. 同步 `cloud/hfs/` wrapper 文件到 Hugging Face Space 仓库。
+2. 触发 Space factory rebuild。
+3. 等待 Space runtime 进入 `RUNNING`。
+4. 运行 `scripts/hf_space_smoke.py` 做部署后 smoke。
+5. 上传 Markdown/JSON 报告 artifact。
+
+部署后 smoke 会访问真实远端地址，既检查页面/API surface，也会按矩阵验证部分 0key 能力。外部搜索源受上游风控、出口 IP、速率限制影响，报告中的 `WARN` 应理解为观测结果，不应写成固定可用承诺。
+
+## 必测入口
+
+| 类别 | 地址 / 路径 | 验收目的 |
+|---|---|---|
+| 存活 | `/health` | 进程可访问，版本与 `pyproject.toml` 一致 |
+| 就绪 | `/readiness` | 本地配置和 source registry 可加载 |
+| API schema | `/openapi.json` | OpenAPI title/version 正确 |
+| API 文档 | `/docs` | Swagger UI 可打开 |
+| 管理面板 | `/panel`（用户访问 `/panel#/`） | 前端 HTML 可返回 |
+| 鉴权状态 | `/api/v1/whoami` | 当前部署 admin 访问状态明确 |
+| 配置 | `/api/v1/admin/config` | 关键配置可读且敏感字段脱敏 |
+| HTTP 后端 | `/api/v1/admin/http-backend` | 能取得原始 backend 快照，后续矩阵测试才允许修改并恢复 |
+| WARP | `/api/v1/admin/warp`、`/warp/modes`、`/warp/config`、`/warp/components` | 能读取 WARP 状态、可用模式和组件信息 |
+| 数据源配置 | `/api/v1/admin/sources/config`、`/sources/config/openalex` | registry 与频道配置可读 |
+| Doctor | `/api/v1/admin/doctor` | 源健康摘要可生成 |
+| Plugins | `/api/v1/admin/plugins` | 插件列表 API 可读 |
+
+## Docker 是否需要拉取远端镜像
+
+当前 PR 预检不拉取线上镜像，而是用 `cloud/hfs/Dockerfile` 从 PR 分支构建临时镜像。这样可以验证即将合入的 wrapper、源码、panel 构建和 Python 依赖组合。线上 Space 的最终结果仍以 `main` 合入后的真实 factory rebuild 和远端 smoke 为准。
+
+## 本地复现策略
+
+- API 与源码 CLI：直接运行 `pytest tests/test_server tests/test_hf_space_smoke.py`，再执行 `python cli.py --help`、`python cli.py --version`、`python cli.py sources`、`python cli.py config show`、`python -m souwen --help`。
+- PyInstaller CLI：使用干净 virtualenv 复现，避免全局 Python 环境把 unrelated 包带入分析。CLI-only 构建需要固定 `setuptools<82`，并显式 `--collect-submodules=rich._unicode_data`，否则单文件包可能在启动或 Rich help 输出时失败。
+- Docker / `act`：这层依赖 Docker daemon，会拉取 `node:*` 和 `python:*` 基础镜像，并按 PR 分支重新构建 HFS 镜像。没有 Docker 的本机不应把该层视为已验证；以 GitHub-hosted runner 的 `HF Space Docker surface smoke` 为准。
+
+## 失败处理
+
+- PR 本地预检失败：优先修代码、测试或 wrapper，不应直接重跑远端部署。
+- 部署同步或 factory rebuild 失败：检查 `HF_TOKEN`、Space 仓库权限和 Hugging Face runtime 日志。
+- 远端 smoke 在 `admin/http-backend-get` 失败：视为控制面回归，因为后续矩阵无法安全恢复原始状态。
+- 远端 zero-key 源 `WARN`：先看报告中的 source/backend/WARP 组合，再判断是上游波动还是代码回归。

--- a/docs/hf-space-cd.md
+++ b/docs/hf-space-cd.md
@@ -21,7 +21,7 @@
 |---|---|---|
 | `API surface and source CLI` | `tests/test_server`、`tests/test_hf_space_smoke.py`、源码 CLI 真实进程 | 覆盖服务端基础路由、smoke 脚本契约和 `python cli.py ...` / `python -m souwen ...` |
 | `PyInstaller CLI smoke` | Linux CLI-only 单文件构建后执行 | 验证 PyInstaller 产物至少能完成帮助、版本、sources、config show 等非网络命令 |
-| `HF Space Docker surface smoke` | 使用 `cloud/hfs/Dockerfile` 构建并本地启动容器 | 验证 `/health`、`/readiness`、`/docs`、`/panel` 和核心 admin API surface |
+| `HF Space Docker surface smoke` | 使用 `cloud/hfs/Dockerfile` 从当前 PR head SHA 构建并本地启动容器 | 验证 `/health`、`/readiness`、`/docs`、`/panel` 和核心 admin API surface |
 
 这层只验证本地 API/CLI/容器启动契约，不代表外部搜索源在远端网络环境中稳定可用。
 
@@ -56,13 +56,13 @@
 
 ## Docker 是否需要拉取远端镜像
 
-当前 PR 预检不拉取线上镜像，而是用 `cloud/hfs/Dockerfile` 从 PR 分支构建临时镜像。这样可以验证即将合入的 wrapper、源码、panel 构建和 Python 依赖组合。线上 Space 的最终结果仍以 `main` 合入后的真实 factory rebuild 和远端 smoke 为准。
+当前 PR 预检不拉取线上镜像，而是用 `cloud/hfs/Dockerfile` 从当前 PR head SHA 构建临时镜像。这样可以验证本次 check 对应的固定源码状态、wrapper、panel 构建和 Python 依赖组合，避免分支名在 workflow 运行期间移动导致验证对象不准确。线上 Space 的最终结果仍以 `main` 合入后的真实 factory rebuild 和远端 smoke 为准。
 
 ## 本地复现策略
 
 - API 与源码 CLI：直接运行 `pytest tests/test_server tests/test_hf_space_smoke.py`，再执行 `python cli.py --help`、`python cli.py --version`、`python cli.py sources`、`python cli.py config show`、`python -m souwen --help`。
 - PyInstaller CLI：使用干净 virtualenv 复现，避免全局 Python 环境把 unrelated 包带入分析。CLI-only 构建需要固定 `setuptools<82`，并显式 `--collect-submodules=rich._unicode_data`，否则单文件包可能在启动或 Rich help 输出时失败。
-- Docker / `act`：这层依赖 Docker daemon，会拉取 `node:*` 和 `python:*` 基础镜像，并按 PR 分支重新构建 HFS 镜像。没有 Docker 的本机不应把该层视为已验证；以 GitHub-hosted runner 的 `HF Space Docker surface smoke` 为准。
+- Docker / `act`：这层依赖 Docker daemon，会拉取 `node:*` 和 `python:*` 基础镜像，并按 PR head SHA 重新构建 HFS 镜像。没有 Docker 的本机不应把该层视为已验证；以 GitHub-hosted runner 的 `HF Space Docker surface smoke` 为准。
 
 ## 失败处理
 

--- a/docs/zero-key-benchmark.md
+++ b/docs/zero-key-benchmark.md
@@ -24,7 +24,7 @@
 | 认证状态 | 无 Bearer Token 返回 `role=admin` | 当前部署显式开放管理端，无需密码 |
 | 搜索相关 Key | 论文/专利/网页搜索 Key 均为空 | Bilibili 凭据不属于本报告范围 |
 | HTTP backend | `default_http_backend=auto`, `http_backend={}` | `PUT /api/v1/admin/http-backend` 可用 |
-| HTTP backend GET | 500 `internal_error` | 状态读取端点异常；本次通过 `PUT` 响应确认切换成功 |
+| HTTP backend GET | 当次观测为 500 `internal_error` | 这是控制面读取端点异常，已纳入 CD 回归修复；本报告当次矩阵通过 `PUT` 响应确认切换成功 |
 | WARP 初始状态 | `disabled` | 测试结束后已恢复 |
 | WARP 可用模式 | `wireproxy=true`; `kernel/usque/warp-cli=false`; `external` 未配置 | `POST /warp/enable?mode=auto` 实际启用 `wireproxy` |
 | WARP 出口 | `104.28.196.75` | 本次启用 WARP 时观测到的出口 IP |

--- a/scripts/hf_space_smoke.py
+++ b/scripts/hf_space_smoke.py
@@ -2375,6 +2375,24 @@ def append_zero_key_matrix(lines: list[str], results: list[ProbeResult]) -> None
 def build_markdown_report(config: SmokeConfig, results: list[ProbeResult]) -> str:
     failures = required_failures(results)
     status = "failed" if failures else "passed"
+    if config.surface_only:
+        capability_lines = [
+            "- WARP enable modes: `skipped (surface-only)`",
+            "- HTTP backend mutation matrix: `skipped (surface-only)`",
+            "- Per-source matrix: `skipped (surface-only)`",
+            "- Fetch provider matrix: `skipped (surface-only)`",
+            "- Direct zero-key routes: `skipped (surface-only)`",
+        ]
+    else:
+        capability_lines = [
+            f"- WARP modes: `off,{','.join(config.warp_modes)}`",
+            f"- HTTP backend matrix: `{','.join(MATRIX_HTTP_BACKENDS)}`",
+            f"- Per-source matrix: `{'enabled' if config.full_matrix else 'quick aggregate only'}`",
+            f"- Fetch provider matrix: `{len(ZERO_KEY_FETCH_PROVIDER_TESTS)} tested, "
+            f"{len(ZERO_KEY_FETCH_SKIPPED)} skipped external-runtime`",
+            "- Direct zero-key routes: `/api/v1/sources`, `/api/v1/bilibili/*`, "
+            "`/api/v1/wayback/*`, `/api/v1/links`, `/api/v1/sitemap`",
+        ]
     lines = [
         "# SouWen HF Space CD Test Report",
         "",
@@ -2382,13 +2400,7 @@ def build_markdown_report(config: SmokeConfig, results: list[ProbeResult]) -> st
         f"- Base URL: `{config.base_url}`",
         f"- Expected version: `{config.expected_version or 'not pinned'}`",
         f"- Mode: `{'surface-only' if config.surface_only else 'post-deploy capability'}`",
-        f"- WARP modes: `off,{','.join(config.warp_modes)}`",
-        f"- HTTP backend matrix: `{','.join(MATRIX_HTTP_BACKENDS)}`",
-        f"- Per-source matrix: `{'enabled' if config.full_matrix else 'quick aggregate only'}`",
-        f"- Fetch provider matrix: `{len(ZERO_KEY_FETCH_PROVIDER_TESTS)} tested, "
-        f"{len(ZERO_KEY_FETCH_SKIPPED)} skipped external-runtime`",
-        "- Direct zero-key routes: `/api/v1/sources`, `/api/v1/bilibili/*`, "
-        "`/api/v1/wayback/*`, `/api/v1/links`, `/api/v1/sitemap`",
+        *capability_lines,
         f"- Required failures: `{len(failures)}`",
         "",
         "## Gate Summary",

--- a/scripts/hf_space_smoke.py
+++ b/scripts/hf_space_smoke.py
@@ -220,12 +220,21 @@ class SmokeConfig:
     min_default_paper_no_warp: int = 4
     min_default_paper_warp: int = 5
     min_best_web_engines: int = 1
+    surface_only: bool = False
 
 
 @dataclass(frozen=True)
 class ResponseData:
     status: int
     data: Any
+    elapsed: float
+
+
+@dataclass(frozen=True)
+class TextResponseData:
+    status: int
+    text: str
+    headers: dict[str, str]
     elapsed: float
 
 
@@ -269,7 +278,7 @@ class ApiClient:
     def __init__(self, config: SmokeConfig):
         self.config = config
 
-    def request(
+    def _request_raw(
         self,
         method: str,
         path: str,
@@ -278,7 +287,7 @@ class ApiClient:
         body: dict[str, Any] | None = None,
         auth: bool = False,
         timeout: float | None = None,
-    ) -> ResponseData:
+    ) -> tuple[int, bytes, dict[str, str], float]:
         url = urljoin(f"{self.config.base_url}/", path.lstrip("/"))
         if params:
             clean_params = {
@@ -306,13 +315,35 @@ class ApiClient:
             ) as response:
                 status = int(response.status)
                 raw = response.read()
+                response_headers = dict(response.headers.items())
         except HTTPError as exc:
             status = int(exc.code)
             raw = exc.read()
+            response_headers = dict(exc.headers.items())
         except (TimeoutError, URLError, OSError) as exc:
             raise SmokeError(f"{method.upper()} {path} failed: {exc}") from exc
 
         elapsed = time.monotonic() - started
+        return status, raw, response_headers, elapsed
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        body: dict[str, Any] | None = None,
+        auth: bool = False,
+        timeout: float | None = None,
+    ) -> ResponseData:
+        status, raw, _headers, elapsed = self._request_raw(
+            method,
+            path,
+            params=params,
+            body=body,
+            auth=auth,
+            timeout=timeout,
+        )
         try:
             decoded = json.loads(raw.decode("utf-8"))
         except Exception as exc:  # noqa: BLE001 - report endpoint behavior in CI
@@ -327,8 +358,32 @@ class ApiClient:
             )
         return ResponseData(status=status, data=decoded, elapsed=elapsed)
 
+    def request_text(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        body: dict[str, Any] | None = None,
+        auth: bool = False,
+        timeout: float | None = None,
+    ) -> TextResponseData:
+        status, raw, headers, elapsed = self._request_raw(
+            method,
+            path,
+            params=params,
+            body=body,
+            auth=auth,
+            timeout=timeout,
+        )
+        text = raw.decode("utf-8", errors="replace")
+        return TextResponseData(status=status, text=text, headers=headers, elapsed=elapsed)
+
     def get(self, path: str, **kwargs: Any) -> ResponseData:
         return self.request("GET", path, **kwargs)
+
+    def get_text(self, path: str, **kwargs: Any) -> TextResponseData:
+        return self.request_text("GET", path, **kwargs)
 
     def post(self, path: str, **kwargs: Any) -> ResponseData:
         return self.request("POST", path, **kwargs)
@@ -453,6 +508,40 @@ def run_basic_checks(client: ApiClient, config: SmokeConfig, state: RunState) ->
             else fail_result("basic", "openapi", detail, required=True, elapsed=resp.elapsed)
         )
 
+    def _docs() -> ProbeResult:
+        if not config.require_openapi:
+            return skip_result("basic", "docs", "not required")
+        resp = client.get_text("/docs")
+        content_type = resp.headers.get("content-type", resp.headers.get("Content-Type", ""))
+        text_lower = resp.text.lower()
+        ok = (
+            resp.status == 200
+            and "text/html" in content_type.lower()
+            and ("swagger ui" in text_lower or "swagger-ui" in text_lower)
+        )
+        detail = f"status={resp.status}, content_type={content_type!r}, html_len={len(resp.text)}"
+        return (
+            pass_result("basic", "docs", detail, required=True, elapsed=resp.elapsed)
+            if ok
+            else fail_result("basic", "docs", detail, required=True, elapsed=resp.elapsed)
+        )
+
+    def _panel() -> ProbeResult:
+        resp = client.get_text("/panel")
+        content_type = resp.headers.get("content-type", resp.headers.get("Content-Type", ""))
+        text_lower = resp.text.lower()
+        ok = (
+            resp.status == 200
+            and "text/html" in content_type.lower()
+            and ('<div id="root"' in text_lower or "souwen" in text_lower)
+        )
+        detail = f"status={resp.status}, content_type={content_type!r}, html_len={len(resp.text)}"
+        return (
+            pass_result("basic", "panel", detail, required=True, elapsed=resp.elapsed)
+            if ok
+            else fail_result("basic", "panel", detail, required=True, elapsed=resp.elapsed)
+        )
+
     def _whoami() -> ProbeResult:
         resp = client.get("/api/v1/whoami", auth=True)
         role = resp.data.get("role")
@@ -484,6 +573,8 @@ def run_basic_checks(client: ApiClient, config: SmokeConfig, state: RunState) ->
         ("health", _health),
         ("readiness", _readiness),
         ("openapi", _openapi),
+        ("docs", _docs),
+        ("panel", _panel),
         ("whoami", _whoami),
     ]:
         results.append(safe_call("basic", name, func, required=name != "whoami"))
@@ -2055,10 +2146,11 @@ def run_report(config: SmokeConfig) -> list[ProbeResult]:
     try:
         results.extend(run_basic_checks(client, config, state))
         results.extend(run_admin_checks(client, config, state))
-        if state.admin_available:
+        if state.admin_available and not config.surface_only:
             results.extend(run_zero_key_checks(client, config, state))
     finally:
-        results.extend(restore_state(client, state))
+        if not config.surface_only:
+            results.extend(restore_state(client, state))
     return results
 
 
@@ -2289,6 +2381,7 @@ def build_markdown_report(config: SmokeConfig, results: list[ProbeResult]) -> st
         f"- Result: **{status}**",
         f"- Base URL: `{config.base_url}`",
         f"- Expected version: `{config.expected_version or 'not pinned'}`",
+        f"- Mode: `{'surface-only' if config.surface_only else 'post-deploy capability'}`",
         f"- WARP modes: `off,{','.join(config.warp_modes)}`",
         f"- HTTP backend matrix: `{','.join(MATRIX_HTTP_BACKENDS)}`",
         f"- Per-source matrix: `{'enabled' if config.full_matrix else 'quick aggregate only'}`",
@@ -2440,6 +2533,14 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Only run aggregate 0key checks; skip per-source matrix probes.",
     )
     parser.add_argument(
+        "--surface-only",
+        action="store_true",
+        help=(
+            "Only verify health/readiness/docs/panel and admin API surface; "
+            "skip mutating backend/WARP and external zero-key capability probes."
+        ),
+    )
+    parser.add_argument(
         "--allow-locked-admin",
         action="store_true",
         help="Do not fail if admin endpoints are locked; admin-dependent checks are skipped.",
@@ -2494,6 +2595,7 @@ def main(argv: list[str] | None = None) -> int:
         min_default_paper_no_warp=args.min_default_paper_no_warp,
         min_default_paper_warp=args.min_default_paper_warp,
         min_best_web_engines=args.min_best_web_engines,
+        surface_only=args.surface_only,
     )
     results = run_report(config)
     print_console_report(results)

--- a/src/souwen/cli/config_cmds.py
+++ b/src/souwen/cli/config_cmds.py
@@ -148,7 +148,7 @@ def config_backend(
 ) -> None:
     """查看/修改 HTTP 后端配置（仅影响爬虫源）"""
     from souwen.config import get_config
-    from souwen.scraper.base import _HAS_CURL_CFFI
+    from souwen.core.scraper.base import _HAS_CURL_CFFI
 
     _VALID = {"auto", "curl_cffi", "httpx"}
     _SCRAPER_ENGINES = [

--- a/src/souwen/server/routes/admin/http_backend.py
+++ b/src/souwen/server/routes/admin/http_backend.py
@@ -27,7 +27,7 @@ _SCRAPER_ENGINES = [
 async def get_http_backend():
     """查看 HTTP 后端配置。"""
     from souwen.config import get_config
-    from souwen.scraper.base import _HAS_CURL_CFFI
+    from souwen.core.scraper.base import _HAS_CURL_CFFI
 
     cfg = get_config()
     return {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,6 +74,18 @@ def test_config_show_indicates_unconfigured(monkeypatch, tmp_path):
     assert "未配置" in result.output
 
 
+def test_config_backend_lists_current_backends(monkeypatch, tmp_path):
+    """``config backend`` 应能读取 HTTP backend 快照，不依赖 re-export 私有变量。"""
+    monkeypatch.chdir(tmp_path)
+    from souwen.config import reload_config
+
+    reload_config()
+    result = runner.invoke(app, ["config", "backend"])
+    assert result.exit_code == 0
+    assert "curl_cffi" in result.output
+    assert "duckduckgo" in result.output
+
+
 def test_sources_list():
     """``sources`` 子命令可以正常打印数据源列表（仅校验 exit 0）。"""
     result = runner.invoke(app, ["sources"])

--- a/tests/test_hf_space_smoke.py
+++ b/tests/test_hf_space_smoke.py
@@ -2,6 +2,48 @@ from scripts import hf_space_smoke as smoke
 from souwen.registry import all_adapters, fetch_providers
 
 
+class FakeSmokeClient:
+    def __init__(self):
+        self.json_routes = {
+            "/health": smoke.ResponseData(
+                200,
+                {"status": "ok", "version": "1.2.3"},
+                0.1,
+            ),
+            "/readiness": smoke.ResponseData(
+                200,
+                {"ready": True, "version": "1.2.3", "error": None},
+                0.1,
+            ),
+            "/openapi.json": smoke.ResponseData(
+                200,
+                {"info": {"title": "SouWen API", "version": "1.2.3"}},
+                0.1,
+            ),
+            "/api/v1/whoami": smoke.ResponseData(200, {"role": "admin"}, 0.1),
+        }
+        self.text_routes = {
+            "/docs": smoke.TextResponseData(
+                200,
+                "<html><title>Swagger UI</title></html>",
+                {"content-type": "text/html; charset=utf-8"},
+                0.1,
+            ),
+            "/panel": smoke.TextResponseData(
+                200,
+                '<html><body><div id="root"></div></body></html>',
+                {"content-type": "text/html; charset=utf-8"},
+                0.1,
+            ),
+        }
+
+    def get(self, path, **_kwargs):
+        return self.json_routes[path]
+
+    def get_text(self, path, **_kwargs):
+        return self.text_routes[path]
+
+
 def test_normalize_base_url_adds_scheme_and_trims_slash():
     assert smoke.normalize_base_url("blueskyxn-souwen.hf.space/") == (
         "https://blueskyxn-souwen.hf.space"
@@ -38,6 +80,46 @@ def test_build_markdown_report_includes_gate_summary():
     assert "Result: **passed**" in report
     assert "`basic/health`" in report
     assert "`curl_cffi+warp-on`" in report
+
+
+def test_basic_checks_cover_docs_and_panel_routes():
+    config = smoke.SmokeConfig(
+        base_url="https://example.test",
+        expected_version="1.2.3",
+        request_timeout=1,
+    )
+    state = smoke.RunState()
+
+    results = smoke.run_basic_checks(FakeSmokeClient(), config, state)  # type: ignore[arg-type]
+
+    by_name = {item.name: item for item in results}
+    assert by_name["openapi"].outcome == "pass"
+    assert by_name["docs"].outcome == "pass"
+    assert by_name["panel"].outcome == "pass"
+    assert by_name["whoami"].outcome == "pass"
+    assert state.admin_available is True
+
+
+def test_surface_only_report_skips_mutating_matrix_and_restore(monkeypatch):
+    config = smoke.SmokeConfig(
+        base_url="https://example.test",
+        expected_version="1.2.3",
+        request_timeout=1,
+        surface_only=True,
+    )
+    monkeypatch.setattr(smoke, "ApiClient", lambda _config: FakeSmokeClient())
+    monkeypatch.setattr(
+        smoke,
+        "run_admin_checks",
+        lambda _client, _config, state: [
+            smoke.ProbeResult("admin", "ping", "pass", "ok", required=True)
+        ],
+    )
+
+    results = smoke.run_report(config)
+
+    assert all(item.section != "matrix" for item in results)
+    assert all(item.section != "restore" for item in results)
 
 
 def test_build_markdown_report_includes_source_matrix():
@@ -155,7 +237,9 @@ def test_zero_key_search_sources_are_covered_or_explicitly_excluded():
     required_key = set(smoke.EXCLUDED_REQUIRED_KEY_SEARCH_SOURCES)
     self_hosted = set(smoke.EXCLUDED_SELF_HOSTED_SEARCH_SOURCES)
 
-    adapters = all_adapters().values()
+    adapters = [
+        adapter for adapter in all_adapters().values() if "external_plugin" not in adapter.tags
+    ]
     search_sources = [adapter for adapter in adapters if "search" in adapter.capabilities]
     zero_key_search = {
         adapter.name for adapter in search_sources if not adapter.resolved_needs_config
@@ -181,7 +265,9 @@ def test_zero_key_fetch_providers_are_covered_or_explicitly_excluded():
     skipped = {item["provider"] for item in smoke.ZERO_KEY_FETCH_SKIPPED}
     required_key = set(smoke.EXCLUDED_REQUIRED_KEY_FETCH_PROVIDERS)
 
-    providers = fetch_providers()
+    providers = [
+        provider for provider in fetch_providers() if "external_plugin" not in provider.tags
+    ]
     zero_key_fetch = {provider.name for provider in providers if not provider.resolved_needs_config}
     required_fetch = {provider.name for provider in providers if provider.resolved_needs_config}
 
@@ -198,7 +284,9 @@ def test_non_search_zero_key_capabilities_are_tested_or_explicitly_excluded():
     non_search = {
         adapter.name
         for adapter in all_adapters().values()
-        if "search" not in adapter.capabilities and not adapter.resolved_needs_config
+        if "external_plugin" not in adapter.tags
+        and "search" not in adapter.capabilities
+        and not adapter.resolved_needs_config
     }
 
     assert non_search <= covered_routes | covered_fetch | skipped_fetch | no_public_endpoint

--- a/tests/test_hf_space_smoke.py
+++ b/tests/test_hf_space_smoke.py
@@ -117,9 +117,13 @@ def test_surface_only_report_skips_mutating_matrix_and_restore(monkeypatch):
     )
 
     results = smoke.run_report(config)
+    report = smoke.build_markdown_report(config, results)
 
     assert all(item.section != "matrix" for item in results)
     assert all(item.section != "restore" for item in results)
+    assert "- HTTP backend mutation matrix: `skipped (surface-only)`" in report
+    assert "- Direct zero-key routes: `skipped (surface-only)`" in report
+    assert "- HTTP backend matrix: `auto,httpx,curl_cffi`" not in report
 
 
 def test_build_markdown_report_includes_source_matrix():

--- a/tests/test_server/test_app.py
+++ b/tests/test_server/test_app.py
@@ -125,6 +125,18 @@ class TestAdminAuth:
         data = resp.json()
         assert data.get("api_password") == "***"
 
+    def test_admin_http_backend_get_valid_token(self, authed_client):
+        """``GET /admin/http-backend`` 应返回当前后端快照，供 CD smoke 安全恢复状态。"""
+        resp = authed_client.get(
+            "/api/v1/admin/http-backend",
+            headers={"Authorization": "Bearer test-secret-123"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["default"] in {"auto", "curl_cffi", "httpx"}
+        assert isinstance(data["overrides"], dict)
+        assert isinstance(data["curl_cffi_available"], bool)
+
     def test_admin_reload_valid_token(self, authed_client):
         """``POST /admin/config/reload`` 鉴权通过后返回 ``status=ok`` 与 ``password_set=True``。"""
         resp = authed_client.post(


### PR DESCRIPTION
## 概述

修复 `Deploy Hugging Face Space` 在 `main` 上的部署后 smoke 失败，并补齐 Hugging Face Space 的 PR 本地预检链路。

失败 run：`25279829425`。当次部署与 factory rebuild 已完成，失败点集中在 `POST-deploy smoke test`：`GET /api/v1/admin/http-backend` 返回 500，导致 smoke 无法取得原始 HTTP backend 快照，后续 backend/WARP/0key 矩阵被跳过以避免无法安全恢复状态。

相关分支状态：

- `chore/hf-space-cd` 已通过 PR #82 合入 `main`，负责 Space 自动部署与 factory rebuild。
- `ci/hf-space-post-deploy-smoke` 已通过 PR #83 合入 `main`，负责部署后 smoke 与 backend/WARP/0key 矩阵。

## 修复内容

### 1. 控制面与 CLI backend 状态读取修复

- 修复 `GET /api/v1/admin/http-backend` 中 `_HAS_CURL_CFFI` 的导入来源。
- 同步修复 `souwen config backend` 的同类导入问题。
- 原实现从 `souwen.scraper.base` re-export 模块导入私有变量，运行时不会被 `import *` 重新导出。
- 改为直接从 `souwen.core.scraper.base` 导入，恢复 HTTP backend 快照读取能力和 CLI backend 状态显示。

### 2. Smoke 覆盖扩展

- `scripts/hf_space_smoke.py` 增加 HTML/text 响应读取能力。
- 基础检查新增：
  - `/docs`：验证 Swagger UI HTML。
  - `/panel`：验证管理面板 HTML，用户入口对应 `/panel#/`。
- 新增 `--surface-only` 模式，用于本地容器预检，仅检查 health/readiness/docs/panel/admin API surface，跳过会修改 backend/WARP 状态和外部 0key 能力的矩阵。
- surface-only Markdown 报告会明确标注 WARP/backend/fetch/direct zero-key 矩阵为 `skipped`，避免误读为已执行完整矩阵。

### 3. GitHub Actions 本地预检

新增 `.github/workflows/hf-space-local-gate.yml`：

- `API surface and source CLI`：运行服务端/smoke 单元测试，并真实执行源码 CLI：`python cli.py ...` 与 `python -m souwen --help`。
- `PyInstaller CLI smoke`：在 GitHub runner 上构建 CLI-only 单文件产物，并执行 `--help`、`--version`、`sources`、`config show`、`config backend`。
- `HF Space Docker surface smoke`：使用 `cloud/hfs/Dockerfile` 从当前 PR head SHA 构建临时镜像，启动容器后执行 surface-only smoke，并显式检查 `/docs` 与 `/panel` HTML。

同步加固 `.github/workflows/build-pyinstaller.yml`：

- CLI-only 构建不再依赖 panel artifact。
- PyInstaller 构建固定 `setuptools<82`，避免新版 `pkg_resources` runtime hook 破坏启动。
- 显式 `--collect-submodules=rich._unicode_data`，避免 Rich help 输出在单文件包内缺动态 Unicode 模块。
- 构建后增加 bundled CLI smoke，包含 `config backend`。

同步调整 `cloud/hfs/Dockerfile`：

- 从 `git clone --branch` 改为 `git init` + `git fetch --depth 1 origin <ref-or-sha>` + detached checkout。
- 支持 branch、tag 和固定 commit SHA，避免 Docker smoke 因分支移动验证到错误源码状态。

### 4. 文档更新

- README / README.en：明确 `/docs` 是 API 文档，`/panel#/` 是管理面板入口，`/` 默认重定向 `/docs`。
- `cloud/hfs/README.md`：补充 `/docs`、`/panel`、`/openapi.json`、`/api/v1/admin/http-backend` 与部署后人工验收入口。
- 新增 `docs/hf-space-cd.md`：说明 PR 本地预检、main 部署、必测 API/页面、Docker/act 边界和失败处理。
- `docs/zero-key-benchmark.md`：将当次 `http-backend-get` 500 表述为观测到的控制面异常，避免写成长期能力结论。

## 验证

- `pytest tests/test_server tests/test_hf_space_smoke.py tests/test_cli.py -q --tb=short`：133 passed
- `pytest tests/test_hf_space_smoke.py tests/test_server/test_app.py::TestAdminAuth::test_admin_http_backend_get_valid_token -q --tb=short`：17 passed
- `pytest tests/test_hf_space_smoke.py -q --tb=short`：16 passed
- `pytest tests/test_cli.py tests/test_hf_space_smoke.py tests/test_server/test_app.py::TestAdminAuth::test_admin_http_backend_get_valid_token -q --tb=short`：37 passed
- `ruff check src/souwen/server/routes/admin/http_backend.py scripts/hf_space_smoke.py tests/test_hf_space_smoke.py tests/test_server/test_app.py`：passed
- `ruff check scripts/hf_space_smoke.py tests/test_hf_space_smoke.py`：passed
- `ruff check src/souwen/cli/config_cmds.py tests/test_cli.py scripts/hf_space_smoke.py tests/test_hf_space_smoke.py`：passed
- `ruff format --check src/souwen/server/routes/admin/http_backend.py scripts/hf_space_smoke.py tests/test_hf_space_smoke.py tests/test_server/test_app.py`：passed
- `ruff format --check scripts/hf_space_smoke.py tests/test_hf_space_smoke.py`：passed
- `ruff format --check src/souwen/cli/config_cmds.py tests/test_cli.py scripts/hf_space_smoke.py tests/test_hf_space_smoke.py`：passed
- `python3 -m compileall -q scripts src/souwen`：passed
- `actionlint .github/workflows/hf-space-local-gate.yml .github/workflows/build-pyinstaller.yml .github/workflows/deploy-hf-space.yml`：passed
- YAML parse：`hf-space-local-gate.yml`、`build-pyinstaller.yml`、`deploy-hf-space.yml` 均通过
- 源码 CLI：`python3 cli.py --help`、`--version`、`sources`、`config show`、`config backend`、`python3 -m souwen --help` 均通过
- 干净 virtualenv PyInstaller CLI-only 构建：产物约 21MB，`--help`、`--version`、`sources`、`config show`、`config backend` 均通过
- Git fetch by SHA：`git fetch --depth 1 origin b879e30318cef5c8638058f92055f040a560d690` 可成功 checkout
- 远端当前状态确认：
  - `https://blueskyxn-souwen.hf.space/docs` 返回 Swagger UI HTML
  - `https://blueskyxn-souwen.hf.space/panel` 返回管理面板 HTML
  - 当前线上 `GET /api/v1/admin/http-backend` 仍返回 500，符合本 PR 修复合入并重新部署前的现状

## 边界说明

本机环境没有 `docker` / `act`，因此 Docker 层没有在本机执行；该层已落到 GitHub Actions 的 `HF Space Docker surface smoke`，以 GitHub-hosted runner 的实际结果作为验证来源。

