### PR TITLE
fix(panel): 适配全主题移动端布局

### DIFF
--- a/panel/src/core/styles/base.scss
+++ b/panel/src/core/styles/base.scss
@@ -11,11 +11,26 @@
 html {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  width: 100%;
+  max-width: 100%;
+  min-height: 100%;
+  overflow-x: clip;
 }
 
 body {
   min-height: 100vh;
+  min-height: 100dvh;
+  width: 100%;
+  max-width: 100%;
   overflow-x: hidden;
+}
+
+#root {
+  width: 100%;
+  max-width: 100%;
+  min-height: 100vh;
+  min-height: 100dvh;
+  overflow-x: clip;
 }
 
 input,

--- a/panel/src/skins/apple/components/layout/MainLayout.module.scss
+++ b/panel/src/skins/apple/components/layout/MainLayout.module.scss
@@ -4,8 +4,12 @@
 
 .layout {
   min-height: 100vh;
+  min-height: 100dvh;
+  width: 100%;
+  max-width: 100%;
   display: flex;
   flex-direction: column;
+  overflow-x: clip;
 }
 
 /* ── Glass Navigation Bar — Always Dark ── */
@@ -28,24 +32,28 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  min-width: 0;
 }
 
 .navLeft {
   display: flex;
   align-items: center;
   gap: 24px;
+  min-width: 0;
 }
 
 .brand {
   display: flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
   font-family: $font-display;
   font-weight: 600;
   font-size: 17px;
   color: var(--nav-text);
   text-decoration: none;
   letter-spacing: -0.022em;
+  white-space: nowrap;
 
   &:hover {
     text-decoration: none;
@@ -196,6 +204,7 @@
   flex: 1;
   width: 100%;
   max-width: $content-max-data;
+  min-width: 0;
   margin: 0 auto;
   padding: $content-padding;
 }
@@ -242,13 +251,15 @@
   left: 0;
   bottom: 0;
   z-index: 100;
-  width: 280px;
+  width: calc(100vw - 32px);
+  max-width: 280px;
   background: var(--bg-card-solid);
   border-right: 1px solid var(--border);
   padding: 16px;
   display: flex;
   flex-direction: column;
   gap: 4px;
+  overflow-y: auto;
 }
 
 .drawerHeader {
@@ -301,6 +312,18 @@
 
 /* ── Responsive ── */
 @media (max-width: 768px) {
+  .navInner {
+    padding: 0 12px;
+  }
+
+  .navLeft {
+    gap: 10px;
+  }
+
+  .palette {
+    max-width: calc(100vw - 32px);
+  }
+
   .main {
     padding: 16px;
   }

--- a/panel/src/skins/apple/pages/SearchPage.module.scss
+++ b/panel/src/skins/apple/pages/SearchPage.module.scss
@@ -389,6 +389,24 @@
     font-size: 40px;
   }
 
+  .tabGroup {
+    display: flex;
+    width: 100%;
+    max-width: 100%;
+    justify-content: flex-start;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  .tabBtn {
+    flex: 0 0 auto;
+  }
+
   .searchBar {
     flex-direction: column;
     border-radius: $radius-md;

--- a/panel/src/skins/carbon/components/layout/MainLayout.module.scss
+++ b/panel/src/skins/carbon/components/layout/MainLayout.module.scss
@@ -2,9 +2,13 @@
 
 .layout {
   min-height: 100vh;
+  min-height: 100dvh;
+  width: 100%;
+  max-width: 100%;
   display: flex;
   flex-direction: column;
   background: var(--bg);
+  overflow-x: clip;
 }
 
 /* ── Top Navigation Bar ── */
@@ -21,18 +25,21 @@
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   border-bottom: 1px solid var(--border);
+  min-width: 0;
 }
 
 .headerLeft {
   display: flex;
   align-items: center;
   gap: 24px;
+  min-width: 0;
 }
 
 .brand {
   display: flex;
   align-items: center;
   gap: 10px;
+  min-width: 0;
   text-decoration: none;
   color: var(--text);
   font-weight: 700;
@@ -41,6 +48,7 @@
   letter-spacing: -0.02em;
   cursor: default;
   user-select: none;
+  white-space: nowrap;
 }
 
 .brandIcon {
@@ -97,6 +105,7 @@
   display: flex;
   align-items: center;
   gap: 16px;
+  flex-shrink: 0;
 }
 
 .statusBadge {
@@ -314,6 +323,7 @@
   flex: 1;
   width: 100%;
   max-width: $content-max-width;
+  min-width: 0;
   margin: 0 auto;
   padding: $content-padding;
 }
@@ -358,13 +368,15 @@
   left: 0;
   bottom: 0;
   z-index: 100;
-  width: 260px;
+  width: calc(100vw - 32px);
+  max-width: 260px;
   background: var(--bg-card-solid);
   border-right: 1px solid var(--border);
   padding: 20px 16px;
   display: flex;
   flex-direction: column;
   gap: 8px;
+  overflow-y: auto;
 }
 
 .drawerBrand {
@@ -412,6 +424,22 @@
 
 /* ── Responsive ── */
 @media (max-width: 768px) {
+  .header {
+    padding: 0 12px;
+  }
+
+  .headerLeft {
+    gap: 10px;
+  }
+
+  .brand {
+    font-size: 16px;
+  }
+
+  .headerRight {
+    gap: 8px;
+  }
+
   .nav {
     display: none;
   }
@@ -422,6 +450,24 @@
 
   .logoutBtn span {
     display: none;
+  }
+
+  .skinSwitcherBtn {
+    width: 32px;
+    height: 32px;
+    padding: 0;
+  }
+
+  .skinSwitcherBtn span {
+    display: none;
+  }
+
+  .avatar {
+    display: none;
+  }
+
+  .palette {
+    max-width: calc(100vw - 32px);
   }
 
   .main {

--- a/panel/src/skins/carbon/pages/SearchPage.module.scss
+++ b/panel/src/skins/carbon/pages/SearchPage.module.scss
@@ -413,6 +413,22 @@
     font-size: 40px;
   }
 
+  .tabGroup {
+    display: flex;
+    max-width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  .tabBtn {
+    flex: 0 0 auto;
+  }
+
   .searchBar {
     flex-direction: column;
   }

--- a/panel/src/skins/ios/components/layout/MainLayout.module.scss
+++ b/panel/src/skins/ios/components/layout/MainLayout.module.scss
@@ -4,8 +4,12 @@
 
 .layout {
   min-height: 100vh;
+  min-height: 100dvh;
+  width: 100%;
+  max-width: 100%;
   display: flex;
   background: var(--bg);
+  overflow-x: clip;
 }
 
 /* ── Desktop Sidebar ── */
@@ -241,6 +245,8 @@
   margin-left: $sidebar-width;
   overflow-y: auto;
   min-height: 100vh;
+  min-height: 100dvh;
+  min-width: 0;
 
   @media (max-width: 768px) {
     margin-left: 0;
@@ -252,6 +258,7 @@
   max-width: 960px;
   margin: 0 auto;
   padding: 24px;
+  min-width: 0;
 
   @media (min-width: 1280px) {
     max-width: 1100px;
@@ -316,7 +323,8 @@
   left: 0;
   bottom: 0;
   z-index: 100;
-  width: $sidebar-width;
+  width: calc(100vw - 32px);
+  max-width: $sidebar-width;
   background: var(--bg-nav);
   border-right: 1px solid var(--nav-border);
   padding: 12px;

--- a/panel/src/skins/ios/pages/SearchPage.module.scss
+++ b/panel/src/skins/ios/pages/SearchPage.module.scss
@@ -403,6 +403,24 @@
     font-size: 40px;
   }
 
+  .tabGroup {
+    display: flex;
+    width: 100%;
+    max-width: 100%;
+    justify-content: flex-start;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  .tabBtn {
+    flex: 0 0 auto;
+  }
+
   .searchBar {
     flex-direction: column;
     border-radius: $radius-md;

--- a/panel/src/skins/souwen-google/components/layout/MainLayout.module.scss
+++ b/panel/src/skins/souwen-google/components/layout/MainLayout.module.scss
@@ -10,6 +10,9 @@ $sw-card-gap: 12px;
 .layout {
   display: flex;
   min-height: 100vh;
+  min-height: 100dvh;
+  width: 100%;
+  max-width: 100%;
   background: var(--bg);
   color: var(--text);
   overflow: hidden;
@@ -40,6 +43,7 @@ $sw-card-gap: 12px;
   top: 0;
   left: 0;
   height: 100vh;
+  height: 100dvh;
   z-index: var(--z-sidebar);
   transition:
     width 0.32s cubic-bezier(0.4, 0, 0.2, 1),
@@ -59,7 +63,8 @@ $sw-card-gap: 12px;
 
 .mobileDrawer {
   display: flex;
-  width: $sw-sidebar-width !important;
+  width: calc(100vw - #{$space-6}) !important;
+  max-width: $sw-sidebar-width;
   z-index: calc(var(--z-overlay) + 10);
   box-shadow: var(--shadow-lg);
 }
@@ -362,6 +367,7 @@ $sw-card-gap: 12px;
   @media (max-width: $mobile-bp) {
     margin: $sw-card-gap;
     margin-left: $sw-card-gap !important;
+    max-width: calc(100vw - #{$sw-card-gap * 2});
   }
 }
 
@@ -387,6 +393,10 @@ $sw-card-gap: 12px;
 
   [data-mode='dark'] & {
     background: var(--bg-card);
+  }
+
+  @media (max-width: $mobile-bp) {
+    padding: 0 $space-3;
   }
 }
 
@@ -430,6 +440,11 @@ $sw-card-gap: 12px;
   display: flex;
   align-items: center;
   gap: $space-2;
+  flex-shrink: 0;
+
+  @media (max-width: $mobile-bp) {
+    gap: 2px;
+  }
 }
 
 /* ===== Connection badge (Google pill) ===== */
@@ -528,6 +543,25 @@ $sw-card-gap: 12px;
   &:hover {
     background: var(--bg, #f0f4f9);
     color: var(--primary);
+  }
+}
+
+@media (max-width: $mobile-bp) {
+  .skinSwitcherBtn {
+    width: 40px;
+    padding: 0;
+  }
+
+  .skinSwitcherBtn span {
+    display: none;
+  }
+
+  .userAvatar {
+    display: none;
+  }
+
+  .themePalette {
+    max-width: calc(100vw - #{$space-6});
   }
 }
 

--- a/panel/src/skins/souwen-google/pages/SearchPage.module.scss
+++ b/panel/src/skins/souwen-google/pages/SearchPage.module.scss
@@ -792,9 +792,8 @@
   .heroHeading { font-size: 30px; }
   .heroSubtitle { font-size: 14px; }
 
-  .commandHeader { padding: $space-2 $space-3 0; }
-
   .commandHeader {
+    padding: $space-2 $space-3 0;
     flex-wrap: nowrap;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;

--- a/panel/src/skins/souwen-google/pages/SearchPage.module.scss
+++ b/panel/src/skins/souwen-google/pages/SearchPage.module.scss
@@ -794,7 +794,24 @@
 
   .commandHeader { padding: $space-2 $space-3 0; }
 
+  .commandHeader {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  .tabGroup {
+    flex: 0 0 auto;
+    min-width: max-content;
+  }
+
   .tabBtn {
+    flex: 0 0 auto;
     padding: 10px 14px;
     font-size: 13px;
   }

--- a/panel/src/skins/souwen-nebula/components/layout/MainLayout.module.scss
+++ b/panel/src/skins/souwen-nebula/components/layout/MainLayout.module.scss
@@ -4,7 +4,11 @@
 .layout {
   display: flex;
   min-height: 100vh;
+  min-height: 100dvh;
+  width: 100%;
+  max-width: 100%;
   background: var(--bg);
+  overflow-x: clip;
 }
 
 /* ===== Overlay (mobile frosted glass) ===== */
@@ -32,6 +36,7 @@
   top: 0;
   left: 0;
   height: 100vh;
+  height: 100dvh;
   z-index: var(--z-sidebar);
   transition:
     width 0.32s cubic-bezier(0.4, 0, 0.2, 1),
@@ -52,7 +57,8 @@
 
 .mobileDrawer {
   display: flex;
-  width: $sidebar-width !important;
+  width: calc(100vw - #{$space-6}) !important;
+  max-width: $sidebar-width;
   z-index: calc(var(--z-overlay) + 10);
 }
 
@@ -265,10 +271,13 @@
 .main {
   flex: 1;
   margin-left: $sidebar-width;
+  min-width: 0;
+  width: 100%;
   transition: margin-left 0.32s cubic-bezier(0.4, 0, 0.2, 1);
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  min-height: 100dvh;
 
   @media (max-width: $mobile-bp) {
     margin-left: 0 !important;
@@ -294,18 +303,35 @@
   top: 0;
   z-index: var(--z-header);
   transition: background var(--transition-slow);
+
+  @media (max-width: $mobile-bp) {
+    padding: 0 $space-3;
+  }
 }
 
 .headerLeft {
   display: flex;
   align-items: center;
   gap: $space-4;
+  min-width: 0;
 
   h2 {
     font-size: $text-lg;
     font-weight: $font-semibold;
     letter-spacing: $tracking-tight;
     color: var(--text);
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    @media (max-width: $mobile-bp) {
+      font-size: $text-md;
+    }
+  }
+
+  @media (max-width: $mobile-bp) {
+    gap: $space-2;
   }
 }
 
@@ -334,6 +360,11 @@
   display: flex;
   align-items: center;
   gap: $space-3;
+  flex-shrink: 0;
+
+  @media (max-width: $mobile-bp) {
+    gap: $space-1;
+  }
 }
 
 .connBadge {
@@ -423,6 +454,26 @@
   &:active {
     transform: scale(0.97);
     transition-duration: 60ms;
+  }
+}
+
+@media (max-width: $mobile-bp) {
+  .connBadge,
+  .logoutBtn span,
+  .skinSwitcherBtn span {
+    display: none;
+  }
+
+  .logoutBtn,
+  .skinSwitcherBtn {
+    width: 34px;
+    height: 34px;
+    padding: 0;
+    flex-shrink: 0;
+  }
+
+  .themePalette {
+    max-width: calc(100vw - #{$space-6});
   }
 }
 
@@ -529,6 +580,8 @@
   padding: $space-10 $space-8;
   max-width: $content-max;
   width: 100%;
+  min-width: 0;
+  overflow-x: clip;
 
   @media (max-width: $mobile-bp) {
     padding: $space-6 $space-4;

--- a/panel/src/skins/souwen-nebula/pages/SearchPage.module.scss
+++ b/panel/src/skins/souwen-nebula/pages/SearchPage.module.scss
@@ -802,11 +802,24 @@
 
   .commandHeader {
     padding: $space-3 $space-4;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     gap: $space-2;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  .tabGroup {
+    flex: 0 0 auto;
+    min-width: max-content;
   }
 
   .tabBtn {
+    flex: 0 0 auto;
     padding: 8px $space-3;
     font-size: 13px;
   }


### PR DESCRIPTION
## 背景

本 PR 针对 Panel 全部 skin 做移动端适配收敛，参考 iPhone 17 Pro Max portrait viewport（440×956 CSS px）进行真实浏览器巡检。

## 变更

- 在共享 base 样式中补齐 `html` / `body` / `#root` 的宽度、`100dvh` 和横向溢出边界。
- 按 `souwen-google`、`souwen-nebula`、`carbon`、`apple`、`ios` 五个 skin 的实际布局结构，分别补齐移动端主布局宽度边界、内容区 `min-width`、drawer 最大宽度、顶部工具区收缩、brand 换行控制、按钮文字隐藏和 palette 最大宽度等约束。
- 为五个 skin 的 Search 页补齐移动端 tabs 局部横向滚动和 tab 固定收缩边界，避免长 tab 组撑开页面根宽度。
- 本轮 follow-up 合并 `souwen-google` Search 页移动端 `.commandHeader` 重复规则块，保持样式行为不变。

## 验证

- `npm run build`
- `npm run test`（13 个 test files、76 个 tests 通过）
- `git diff --check`
- `npm run build:google`
- Playwright 真实浏览器巡检：`440×956` viewport 下，5 个 skin × 10 条核心路由的 `root.scrollWidth` / `body.scrollWidth` 均为 `440`。
- Playwright drawer 巡检：5 个 skin 的移动端 drawer 实测宽度为 `280/260/260/280/280px`，均未超过 `440px` viewport，打开后 root/body 宽度仍为 `440`。