### PR TITLE
ci(actions): AI Review 信任边界加固 + Workflow 配置收敛

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -16,6 +16,7 @@ name: AI PR Review
 # 2. workflow_dispatch — 手动触发
 #    - 可指定 pr_number 直接评审某个 PR
 #    - 可指定 target_branch 查找该分支关联的 open PR
+#    - 仅仓库 OWNER 可手动触发；仅评审 base 为 main 的 PR
 #    - 可调整 effort（low/medium/high/xhigh）和 run_local_checks
 #
 # 【评审模式】
@@ -168,6 +169,10 @@ jobs:
                 skipReason = '跳过 fork PR，避免暴露 AI API key。';
               }
             } else {
+              if (process.env.ACTOR !== process.env.REPO_OWNER) {
+                throw new Error('只有 repository owner 可以手动触发 AI Review，避免自定义 endpoint 或手动目标解析暴露 AI secrets。');
+              }
+
               const prNumberInput = (process.env.PR_NUMBER_INPUT || '').trim();
               const targetBranchInput = (process.env.TARGET_BRANCH || '').trim();
               const selectedBranch = process.env.REF_TYPE === 'branch'
@@ -216,6 +221,11 @@ jobs:
                 shouldReview = false;
                 skipReason = `跳过 PR #${pr.number}，它来自 fork (${pr.head.repo.full_name})。`;
               }
+            }
+
+            if (shouldReview && pr && pr.base.ref !== 'main') {
+              shouldReview = false;
+              skipReason = `跳过 PR #${pr.number}，base 分支是 ${pr.base.ref}，AI Review 只评审 base 为 main 的 PR。`;
             }
 
             core.setOutput('should_review', shouldReview ? 'true' : 'false');

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -27,7 +27,7 @@ name: AI PR Review
 # - Fork PR 直接跳过（避免暴露 AI API key 和仓库 secrets）
 # - Codex 不获取 GH_TOKEN（review 是纯只读操作，由 workflow 后续步骤发布评论）
 # - persist-credentials: false 防止 git 凭据泄露
-# - Codex prompt 从 workflow_sha 物化，不信任目标 PR 中的 prompt 文件
+# - Codex prompt 从目标 PR base SHA 物化，不信任目标 PR 中的 prompt 文件
 # - PR 内容在 prompt 中明确标记为不可信来源（防 prompt injection）
 # - 评审内容有 45,000 字符上限保护（超长自动压缩）
 #
@@ -687,12 +687,12 @@ jobs:
 
       - name: Materialize trusted review prompt
         env:
-          WORKFLOW_SHA: ${{ github.workflow_sha || github.sha }}
+          TRUSTED_PROMPT_SHA: ${{ needs.resolve-pr.outputs.base_sha }}
         run: |
           set -euo pipefail
           mkdir -p .ai-review-context
-          git fetch --no-tags --depth=1 origin "$WORKFLOW_SHA"
-          git show "$WORKFLOW_SHA:.github/prompts/ai-review.md" > .ai-review-context/trusted-ai-review.md
+          git fetch --no-tags --depth=1 origin "$TRUSTED_PROMPT_SHA"
+          git show "$TRUSTED_PROMPT_SHA:.github/prompts/ai-review.md" > .ai-review-context/trusted-ai-review.md
           test -s .ai-review-context/trusted-ai-review.md
 
       - name: Run Codex review

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -27,7 +27,8 @@ name: AI PR Review
 # - Fork PR 直接跳过（避免暴露 AI API key 和仓库 secrets）
 # - Codex 不获取 GH_TOKEN（review 是纯只读操作，由 workflow 后续步骤发布评论）
 # - persist-credentials: false 防止 git 凭据泄露
-# - Prompt 中明确标记 PR 内容为不可信来源（防 prompt injection）
+# - Codex prompt 从 workflow_sha 物化，不信任目标 PR 中的 prompt 文件
+# - PR 内容在 prompt 中明确标记为不可信来源（防 prompt injection）
 # - 评审内容有 45,000 字符上限保护（超长自动压缩）
 #
 # 【工作流程】
@@ -55,9 +56,11 @@ on:
   pull_request:
     branches: [main]
     paths-ignore:
-      - '**/*.md'
       - 'docs/**'
       - 'local/**'
+      - 'README.md'
+      - 'README.en.md'
+      - 'CHANGELOG.md'
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:
@@ -113,8 +116,8 @@ permissions:
   contents: read
   actions: read
   checks: read
-  pull-requests: write
-  issues: write
+  pull-requests: read
+  issues: read
 
 jobs:
   resolve-pr:
@@ -509,8 +512,11 @@ jobs:
     needs: [resolve-pr, collect-review-context]
     if: needs.resolve-pr.outputs.should_review == 'true'
 
-    outputs:
-      final_message: ${{ steps.prepare-comment.outputs.final_message }}
+    permissions:
+      contents: read
+      actions: read
+      checks: read
+      pull-requests: read
 
     steps:
       - name: Checkout PR head commit
@@ -679,6 +685,16 @@ jobs:
             echo "AI secrets are present. Enable log_level=debug to print non-sensitive lengths."
           fi
 
+      - name: Materialize trusted review prompt
+        env:
+          WORKFLOW_SHA: ${{ github.workflow_sha || github.sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p .ai-review-context
+          git fetch --no-tags --depth=1 origin "$WORKFLOW_SHA"
+          git show "$WORKFLOW_SHA:.github/prompts/ai-review.md" > .ai-review-context/trusted-ai-review.md
+          test -s .ai-review-context/trusted-ai-review.md
+
       - name: Run Codex review
         id: run-codex
         env:
@@ -692,7 +708,7 @@ jobs:
           codex-args: ${{ vars.CODEX_ARGS }}
           sandbox: read-only
           safety-strategy: read-only
-          prompt-file: .github/prompts/ai-review.md
+          prompt-file: .ai-review-context/trusted-ai-review.md
 
       - name: Post-Codex diagnostic
         if: always()
@@ -845,36 +861,51 @@ jobs:
             ].join('\n')
           );
 
-          const delimiter = `codex_review_${Date.now()}`;
-          fs.appendFileSync(
-            process.env.GITHUB_OUTPUT,
-            `final_message<<${delimiter}\n${finalMessage}\n${delimiter}\n`
-          );
+          fs.mkdirSync('.ai-review-context', { recursive: true });
+          fs.writeFileSync('.ai-review-context/final-review-comment.md', finalMessage);
           NODE
+
+      - name: Upload final review comment
+        uses: actions/upload-artifact@v4
+        with:
+          name: ai-review-final-comment-${{ needs.resolve-pr.outputs.pr_number }}
+          path: .ai-review-context/final-review-comment.md
+          if-no-files-found: error
+          retention-days: 3
+          include-hidden-files: true
 
   post-review-comment:
     name: 发布评审评论
     runs-on: ubuntu-latest
     needs: [resolve-pr, codex-review]
     timeout-minutes: 5
-    if: needs.codex-review.outputs.final_message != ''
+    if: needs.resolve-pr.outputs.should_review == 'true' && needs.codex-review.result == 'success'
 
     permissions:
+      contents: read
+      actions: read
       issues: write
       pull-requests: write
 
     steps:
+      - name: Download final review comment
+        uses: actions/download-artifact@v4
+        with:
+          name: ai-review-final-comment-${{ needs.resolve-pr.outputs.pr_number }}
+          path: .ai-review-comment
+
       - name: Create or update sticky PR comment
         uses: actions/github-script@v7
         env:
-          CODEX_FINAL_MESSAGE: ${{ needs.codex-review.outputs.final_message }}
+          COMMENT_FILE: .ai-review-comment/final-review-comment.md
           PR_NUMBER: ${{ needs.resolve-pr.outputs.pr_number }}
         with:
           github-token: ${{ github.token }}
           script: |
+            const fs = require('fs');
             const marker = '<!-- codex-ai-pr-review -->';
             const prNumber = Number.parseInt(process.env.PR_NUMBER, 10);
-            const raw = process.env.CODEX_FINAL_MESSAGE || '';
+            const raw = fs.readFileSync(process.env.COMMENT_FILE, 'utf8');
             const body = [
               marker,
               '## AI PR Review',
@@ -888,7 +919,7 @@ jobs:
               `Workflow: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
             ].join('\n');
 
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber,

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -11,7 +11,7 @@ name: AI PR Review
 #
 # 【触发条件】
 # 1. pull_request (open/synchronize/reopened/ready_for_review) — 自动触发
-#    - 忽略 *.md 和 docs/、local/ 目录变更
+#    - 忽略 docs/、local/、README 和 CHANGELOG 变更；.github/prompts/** 会触发评审
 #    - Draft PR 和 Fork PR 自动跳过
 # 2. workflow_dispatch — 手动触发
 #    - 可指定 pr_number 直接评审某个 PR

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -24,11 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     # 仅处理同仓库 PR（fork PR 无写入权限，跳过）
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.head_ref || github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-python@v6
@@ -57,16 +57,18 @@ jobs:
         if: steps.auto-commit.outputs.changes_detected == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FORMAT_REF: ${{ github.head_ref || github.ref_name }}
         run: |
           echo "🔄 格式化已修复，触发 CI 重新运行..."
-          gh workflow run ci.yml --ref "${{ github.head_ref }}"
+          gh workflow run ci.yml --ref "$FORMAT_REF"
 
       - name: PR 评论通知
         if: steps.auto-commit.outputs.changes_detected == 'true' && github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh pr comment "${{ github.event.pull_request.number }}" \
+          gh pr comment "$PR_NUMBER" \
             --body "🤖 **Auto-format**: 已自动修复代码格式并提交，CI 已触发重新检查。"
 
       - name: 最终格式检查（Gate）

--- a/.github/workflows/build-nuitka.yml
+++ b/.github/workflows/build-nuitka.yml
@@ -223,7 +223,8 @@ jobs:
 
       - name: Rename artifact (Windows)
         if: runner.os == 'Windows'
-        run: move dist\${{ env.APP_NAME }}.exe dist\${{ matrix.artifact_name }}
+        shell: pwsh
+        run: Move-Item -Path "dist/${{ env.APP_NAME }}.exe" -Destination "dist/${{ matrix.artifact_name }}"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
+      contents: read
       id-token: write  # PyPI trusted publisher
     steps:
       - uses: actions/checkout@v4
@@ -55,5 +56,3 @@ jobs:
 
       - name: 发布到 PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## 概述

本 PR 聚焦 GitHub Actions 配置加固与静态校准，实际变更限定在 4 个 workflow 文件：`ai-review.yml`、`auto-format.yml`、`build-nuitka.yml`、`publish.yml`。

核心目标是让 `AI PR Review` 的执行链路更符合当前安全边界：Codex review job 不再信任 PR checkout 中的 prompt 文件，不再通过 job output 传递长评审正文，并将写权限限制在发布评论 job 内。其余 workflow 变更用于修复手动触发、Windows rename 和 PyPI 发布配置的一致性问题。

## 变更内容

### AI Review 信任边界与评论链路

- 移除 `ai-review.yml` 中 `paths-ignore: '**/*.md'`，改为仅忽略 `docs/**`、`local/**`、`README.md`、`README.en.md`、`CHANGELOG.md`，避免 `.github/prompts/**` 这类控制面 Markdown 变更被跳过。
- 同步更新 `ai-review.yml` 顶部触发条件注释，明确 `.github/prompts/**` 会触发评审，避免注释继续描述旧的全量 Markdown 忽略策略。
- `workflow_dispatch` 手动触发增加 repository owner gate，非 owner 不能进入手动 PR 解析路径，避免自定义 endpoint 或手动目标解析暴露 AI secrets。
- 手动/自动解析出的 PR 必须以 `main` 为 base；非 `main` base 的 PR 会被跳过，保证 trusted prompt 来源固定在受信任 base 语境内。
- 将 workflow 顶层权限从 `pull-requests: write` / `issues: write` 收窄为只读权限。
- 为 `codex-review` job 显式声明只读权限，保持 Codex review 阶段只读。
- 新增 `Materialize trusted review prompt` 步骤，从目标 PR 的 `needs.resolve-pr.outputs.base_sha` 读取 `.github/prompts/ai-review.md` 并写入 `.ai-review-context/trusted-ai-review.md`。
- 将 `openai/codex-action@v1` 的 `prompt-file` 改为 `.ai-review-context/trusted-ai-review.md`，不再读取 PR checkout 工作区内的 prompt。
- 将最终评审正文写入 `.ai-review-context/final-review-comment.md`，并通过 `actions/upload-artifact@v4` / `actions/download-artifact@v4` 在 job 间传递，替代原来的 `GITHUB_OUTPUT final_message`。
- `post-review-comment` job 改为在 `codex-review` 成功后下载 artifact，并只在该 job 内授予 `issues: write` / `pull-requests: write`。
- sticky comment 查询从单页 `listComments(per_page: 100)` 改为 `github.paginate(...)`，避免长生命周期 PR 中旧评论超出第一页后重复发布。

### Auto Format 手动触发与表达式收敛

- `auto-format.yml` 的 job 条件改为兼容 `workflow_dispatch`，避免手动触发时因缺少 `pull_request` payload 被跳过。
- checkout ref 改为 `${{ github.head_ref || github.ref_name }}`，同时兼容 PR 与手动分支触发。
- 将 shell 中使用的 ref 和 PR number 改为通过环境变量传入，消除 actionlint 对 inline script 中直接使用 untrusted expression 的提醒。

### Nuitka Windows artifact rename

- `build-nuitka.yml` 的 Windows rename 步骤改为显式 `shell: pwsh` + `Move-Item`，替代原 `move dist\...` 写法，避免 shellcheck 对反斜杠路径的提示和跨 shell 歧义。

### PyPI 发布权限与认证方式

- `publish.yml` 显式补充 `contents: read`。
- 保留 `id-token: write` 的 PyPI Trusted Publisher / OIDC 发布路径。
- 移除 `pypa/gh-action-pypi-publish` 中的 `password: ${{ secrets.PYPI_API_TOKEN }}` 输入，避免 OIDC 与 token 发布方式混用。

## 评审意见处理

- 已处理 AI Review sticky comment 中指出的阻塞问题：trusted prompt 来源从 `github.workflow_sha || github.sha` 改为 `needs.resolve-pr.outputs.base_sha`。
- 已根据子代理安全评审补充 owner gate 与 base main gate，收紧 `workflow_dispatch` 下的 endpoint override 和手动目标解析边界。
- 已处理后续非阻塞建议：同步更新 `ai-review.yml` 顶部注释，使触发条件说明与当前 `paths-ignore` 配置一致。
- 处理后，PR 修改 `.github/prompts/ai-review.md` 时，该 prompt 变更仍会进入本次 diff 审查，但不会影响本次 review 使用的 trusted prompt；只有变更合并进 `main` 后才会成为后续 review 的 prompt 来源。

## 影响范围

- 不涉及业务代码、测试代码、前端代码或打包脚本内容。
- 不改变 `openai/codex-action@v1` 的模型、effort、sandbox、safety-strategy 或 endpoint 配置来源。
- `AI PR Review` 的发布链路已从 job output 改为 artifact 传递；同一 PR 的前序远端 run 已验证 `Codex 代码评审` 与 `发布评审评论` 可成功完成。
- `publish.yml` 现在依赖 PyPI Trusted Publisher 配置；若 PyPI 项目未配置 trusted publisher，发布时需要先在 PyPI 侧完成 OIDC 信任配置。

## 验证

- `python3` + `yaml.BaseLoader` 解析 `.github/workflows/*.yml` 通过。
- `actionlint .github/workflows/*.yml` 通过。
- `git diff --check` 通过。
- 子代理批处理评审：
  - 初轮 security 子代理发现 `workflow_dispatch` owner gate 与 base branch gate 缺口，已修复。
  - runtime 子代理未发现阻塞问题。
  - 修复后 security 子代理复核结论为 `no blocking findings`。
- targeted assertion 确认：
  - `ai-review.yml` 使用 `.ai-review-context/trusted-ai-review.md` 作为 Codex review prompt；
  - 不再引用 PR checkout 中的 `.github/prompts/ai-review.md` 作为 `prompt-file`；
  - 不再通过 `final_message` job output 跨 job 传递评审正文。
- 最新 head 回读时，CI 全矩阵、CodeQL、Auto Format、PR Labeler、PR Size Label 已通过；云端 `Codex 代码评审` 是旁路自动评审，不作为本次更新的前置门禁。

## 文件清单

- `.github/workflows/ai-review.yml`
- `.github/workflows/auto-format.yml`
- `.github/workflows/build-nuitka.yml`
- `.github/workflows/publish.yml`

