### PR TITLE
ci: 引入五层测试 profile runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
       - 'tests/**'
       - 'panel/**'
       - 'scripts/_functional_common.py'
+      - 'scripts/ci/**'
       - 'scripts/scrapling_functional_check.py'
       - 'scripts/crawl4ai_functional_check.py'
       - 'scripts/plugin_functional_check.py'
@@ -39,10 +40,10 @@ jobs:
         run: pip install ruff
 
       - name: Ruff 语法检查
-        run: ruff check src/ tests/ scripts/_functional_common.py scripts/scrapling_functional_check.py scripts/crawl4ai_functional_check.py scripts/plugin_functional_check.py
+        run: ruff check src/ tests/ scripts/_functional_common.py scripts/ci/run_profile.py scripts/scrapling_functional_check.py scripts/crawl4ai_functional_check.py scripts/plugin_functional_check.py
 
       - name: Ruff 格式检查
-        run: ruff format --check src/ tests/ scripts/_functional_common.py scripts/scrapling_functional_check.py scripts/crawl4ai_functional_check.py scripts/plugin_functional_check.py
+        run: ruff format --check src/ tests/ scripts/_functional_common.py scripts/ci/run_profile.py scripts/scrapling_functional_check.py scripts/crawl4ai_functional_check.py scripts/plugin_functional_check.py
 
   test:
     name: 测试 (Python ${{ matrix.python }}, ${{ matrix.os }})
@@ -92,37 +93,23 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.python == '3.11'
         run: pip install "curl-cffi>=0.14.0"
 
-      - name: 验证全部导入
+      - name: 运行 full runtime profile
         if: matrix.os == 'ubuntu-latest' && matrix.python == '3.11'
         run: |
-          python -c "
-          from souwen.paper import (
-              OpenAlexClient, SemanticScholarClient, CrossrefClient,
-              ArxivClient, DblpClient, CoreClient, PubMedClient, UnpaywallClient,
-          )
-          from souwen.patent import (
-              PatentsViewClient, PqaiClient, EpoOpsClient, UsptoOdpClient,
-              TheLensClient, CnipaClient, PatSnapClient, GooglePatentsClient,
-          )
-          from souwen.web import (
-              DuckDuckGoClient, YahooClient, BraveClient,
-              GoogleClient, BingClient,
-              SearXNGClient, TavilyClient, ExaClient, SerperClient, BraveApiClient,
-              SerpApiClient, FirecrawlClient, PerplexityClient,
-              LinkupClient, ScrapingDogClient,
-              StartpageClient, BaiduClient, MojeekClient, YandexClient,
-              WhoogleClient, WebsurfxClient,
-              GitHubClient, StackOverflowClient, RedditClient, BilibiliClient,
-              WikipediaClient, YouTubeClient, ZhihuClient, WeiboClient,
-              BuiltinFetcherClient, JinaReaderClient,
-              web_search, fetch_content,
-          )
-          from souwen.doctor import check_all
-          print('全部数据源 + doctor 导入成功 ✅')
-          "
-          python -c "from souwen.plugin import discover_entrypoint_plugins, load_plugins; print('plugin OK')"
-          python -c "from souwen.web.fetch import register_fetch_handler, get_fetch_handlers; print('fetch_handlers OK')"
-          python -c "from souwen.registry.views import external_plugins; print('external_plugins OK')"
+          mkdir -p artifacts
+          python scripts/ci/run_profile.py \
+            --profile full \
+            --json-report artifacts/runtime-profile-full.json \
+            --markdown-report artifacts/runtime-profile-full.md
+
+      - name: 上传 full runtime profile 报告
+        if: always() && matrix.os == 'ubuntu-latest' && matrix.python == '3.11'
+        uses: actions/upload-artifact@v7
+        with:
+          name: runtime-profile-full-report
+          path: artifacts/
+          if-no-files-found: warn
+          retention-days: 7
 
   plugin-test:
     name: 插件系统测试

--- a/.github/workflows/deploy-hf-space.yml
+++ b/.github/workflows/deploy-hf-space.yml
@@ -13,6 +13,7 @@ on:
       - "docs/**"
       - "souwen.example.yaml"
       - "entrypoint.sh"
+      - "scripts/ci/**"
       - "cli.py"
       - "scripts/hf_space_smoke.py"
       - "scripts/warp-init.sh"
@@ -31,6 +32,7 @@ on:
       - "docs/**"
       - "souwen.example.yaml"
       - "entrypoint.sh"
+      - "scripts/ci/**"
       - "cli.py"
       - "scripts/hf_space_smoke.py"
       - "scripts/warp-init.sh"
@@ -139,20 +141,25 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev,server,tls]"
 
-      - name: Run API and smoke unit tests
-        run: |
-          pytest tests/test_server tests/test_hf_space_smoke.py -v --tb=short
-
-      - name: Run source CLI smoke commands
+      - name: Run API and source CLI profiles
         env:
           PYTHONIOENCODING: utf-8
         run: |
-          python cli.py --help
-          python cli.py --version
-          python cli.py sources
-          python cli.py config show
-          python cli.py config backend
-          python -m souwen --help
+          mkdir -p artifacts
+          python scripts/ci/run_profile.py \
+            --profile server \
+            --profile minimal \
+            --json-report artifacts/api-source-cli-profile.json \
+            --markdown-report artifacts/api-source-cli-profile.md
+
+      - name: Upload API and source CLI profile report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: api-source-cli-profile-report
+          path: artifacts/
+          if-no-files-found: warn
+          retention-days: 7
 
   pyinstaller-cli:
     name: PyInstaller CLI smoke

--- a/docs/hf-space-cd.md
+++ b/docs/hf-space-cd.md
@@ -22,7 +22,7 @@
 | Job | 覆盖内容 | 说明 |
 |---|---|---|
 | `Resolve deploy eligibility` | `main` push / 手动触发的部署路径判断 | 文档或测试-only 变更仍跑本地预检，但不会触发远端部署 |
-| `API surface and source CLI` | `tests/test_server`、`tests/test_hf_space_smoke.py`、源码 CLI 真实进程 | 覆盖服务端基础路由、smoke 脚本契约和 `python cli.py ...` / `python -m souwen ...` |
+| `API surface and source CLI` | `scripts/ci/run_profile.py --profile server --profile minimal` | 覆盖服务端基础路由、smoke 脚本契约和 `python cli.py ...` / `python -m souwen ...`，并上传 JSON/Markdown profile report |
 | `PyInstaller CLI smoke` | Linux CLI-only 单文件构建后执行 | 验证 PyInstaller 产物至少能完成帮助、版本、sources、config show 等非网络命令 |
 | `HF Space Docker surface smoke` | 使用 `cloud/hfs/Dockerfile` 从当前 PR head SHA 构建并本地启动容器 | 验证 `/health`、`/readiness`、`/docs`、`/panel` 和核心 admin API surface |
 
@@ -63,7 +63,7 @@
 
 ## 本地复现策略
 
-- API 与源码 CLI：直接运行 `pytest tests/test_server tests/test_hf_space_smoke.py`，再执行 `python cli.py --help`、`python cli.py --version`、`python cli.py sources`、`python cli.py config show`、`python cli.py config backend`、`python -m souwen --help`。
+- API 与源码 CLI：直接运行 `python scripts/ci/run_profile.py --profile server --profile minimal`。该 runner 内部执行 `pytest tests/test_server tests/test_hf_space_smoke.py` 和 `python cli.py --help`、`python cli.py --version`、`python cli.py sources`、`python cli.py config show`、`python cli.py config backend`、`python -m souwen --help`，并可通过 `--json-report` / `--markdown-report` 生成排障报告。
 - PyInstaller CLI：使用干净 virtualenv 复现，避免全局 Python 环境把 unrelated 包带入分析。CLI-only 构建需要固定 `setuptools<82`，并显式 `--collect-submodules=rich._unicode_data`，否则单文件包可能在启动或 Rich help 输出时失败。
 - Docker / `act`：这层依赖 Docker daemon，会拉取 `node:*` 和 `python:*` 基础镜像，并按 PR head SHA 重新构建 HFS 镜像。没有 Docker 的本机不应把该层视为已验证；以 GitHub-hosted runner 的 `HF Space Docker surface smoke` 为准。
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -7,6 +7,44 @@ SouWen 的测试体系分成两层：
 
 这个分层的目标是让本地开发反馈保持稳定，同时让 CI 能发现 mock 测试覆盖不到的真实运行问题。
 
+## GitHub Actions 五层语义
+
+GitHub Actions 中的 job 应尽量回答单一问题，避免把单元测试、真实外部能力、
+部署可用性和完整系统流程混在同一个日志里。当前测试体系按五层归因：
+
+| 层级 | 目标 | 典型入口 |
+|---|---|---|
+| 单元测试 | 验证函数、模型、parser、配置合并等局部契约 | `pytest tests/` |
+| 集成测试 | 验证 server、registry、plugin、handler 等模块组合 | `server-test`、`plugin-test` |
+| 功能测试 | 验证真实 runtime / package / plugin 安装后的可用性 | `*_functional_check.py` |
+| 冒烟测试 | 验证 CLI、API surface、Docker/HF Space 入口仍活着 | `scripts/ci/run_profile.py`、`hf_space_smoke.py` |
+| 系统测试 | 验证完整用户路径和多 profile 环境组合 | manual / nightly / release gate |
+
+## 环境 Profile Runner
+
+`scripts/ci/run_profile.py` 承接稳定、可重复的环境完整度 profile。它不安装依赖、
+不下载 browser runtime，也不访问真实外部服务；workflow 仍负责显式安装环境，
+runner 只负责运行场景并输出 JSON/Markdown report。
+
+当前 profile：
+
+| Profile | 覆盖内容 | 运行位置 |
+|---|---|---|
+| `minimal` | 源码 CLI 的 help/version/sources/config 等无网络入口 | `HF Space CD / API surface and source CLI` |
+| `server` | `tests/test_server` 与 `tests/test_hf_space_smoke.py` 的本地 API/smoke 契约 | `HF Space CD / API surface and source CLI` |
+| `full` | 全部 source、doctor、plugin、fetch handler 的 import surface | `CI / 测试 (Python 3.11, ubuntu-latest)` |
+| `plugin` | 本地插件契约、示例插件测试和 entry point discovery | 后续 plugin profile job 或手动验证 |
+
+示例：
+
+```bash
+python scripts/ci/run_profile.py \
+  --profile server \
+  --profile minimal \
+  --json-report artifacts/api-source-cli-profile.json \
+  --markdown-report artifacts/api-source-cli-profile.md
+```
+
 ## 本地确定性测试
 
 默认本地测试不应依赖真实互联网、浏览器运行时、真实 API key 或云端服务。

--- a/scripts/ci/__init__.py
+++ b/scripts/ci/__init__.py
@@ -1,0 +1,1 @@
+"""CI helper scripts."""

--- a/scripts/ci/run_profile.py
+++ b/scripts/ci/run_profile.py
@@ -1,0 +1,281 @@
+"""Run deterministic CI profiles and emit machine-readable reports."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts._functional_common import Outcome, ResultRecorder  # noqa: E402
+
+
+DEFAULT_TIMEOUT_SECONDS = 300.0
+OUTPUT_TAIL_CHARS = 4000
+PYTHON = sys.executable or "python"
+
+
+FULL_IMPORT_CODE = "\n".join(
+    [
+        "from souwen.paper import (",
+        "    OpenAlexClient, SemanticScholarClient, CrossrefClient,",
+        "    ArxivClient, DblpClient, CoreClient, PubMedClient, UnpaywallClient,",
+        ")",
+        "from souwen.patent import (",
+        "    PatentsViewClient, PqaiClient, EpoOpsClient, UsptoOdpClient,",
+        "    TheLensClient, CnipaClient, PatSnapClient, GooglePatentsClient,",
+        ")",
+        "from souwen.web import (",
+        "    DuckDuckGoClient, YahooClient, BraveClient, GoogleClient, BingClient,",
+        "    SearXNGClient, TavilyClient, ExaClient, SerperClient, BraveApiClient,",
+        "    SerpApiClient, FirecrawlClient, PerplexityClient, LinkupClient,",
+        "    ScrapingDogClient, StartpageClient, BaiduClient, MojeekClient,",
+        "    YandexClient, WhoogleClient, WebsurfxClient, GitHubClient,",
+        "    StackOverflowClient, RedditClient, BilibiliClient, WikipediaClient,",
+        "    YouTubeClient, ZhihuClient, WeiboClient, BuiltinFetcherClient,",
+        "    JinaReaderClient, web_search, fetch_content,",
+        ")",
+        "from souwen.doctor import check_all",
+        "from souwen.plugin import discover_entrypoint_plugins, load_plugins",
+        "from souwen.web.fetch import register_fetch_handler, get_fetch_handlers",
+        "from souwen.registry.views import external_plugins",
+        "print('all source, doctor, plugin and fetch handler imports OK')",
+    ]
+)
+
+
+PLUGIN_DISCOVERY_CODE = "\n".join(
+    [
+        "from souwen.plugin import load_plugins",
+        "from souwen.registry.views import external_plugins",
+        "load_plugins()",
+        "plugins = external_plugins()",
+        "assert 'example_echo' in plugins, plugins",
+        "print('example_echo plugin discovered')",
+    ]
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CommandSpec:
+    name: str
+    command: tuple[str, ...]
+    required: bool = True
+    env: tuple[tuple[str, str], ...] = ()
+
+
+PROFILE_COMMANDS: Mapping[str, tuple[CommandSpec, ...]] = {
+    "minimal": (
+        CommandSpec("cli_help", (PYTHON, "cli.py", "--help")),
+        CommandSpec("cli_version", (PYTHON, "cli.py", "--version")),
+        CommandSpec("sources_list", (PYTHON, "cli.py", "sources")),
+        CommandSpec("config_show", (PYTHON, "cli.py", "config", "show")),
+        CommandSpec("config_backend", (PYTHON, "cli.py", "config", "backend")),
+        CommandSpec("module_help", (PYTHON, "-m", "souwen", "--help")),
+    ),
+    "server": (
+        CommandSpec(
+            "api_surface_tests",
+            (
+                PYTHON,
+                "-m",
+                "pytest",
+                "tests/test_server",
+                "tests/test_hf_space_smoke.py",
+                "-v",
+                "--tb=short",
+            ),
+        ),
+    ),
+    "full": (CommandSpec("all_optional_imports", (PYTHON, "-c", FULL_IMPORT_CODE)),),
+    "plugin": (
+        CommandSpec(
+            "plugin_contract_tests",
+            (
+                PYTHON,
+                "-m",
+                "pytest",
+                "tests/test_plugin.py",
+                "tests/test_fetch_handlers.py",
+                "-v",
+                "--tb=short",
+            ),
+        ),
+        CommandSpec(
+            "example_plugin_contract",
+            (
+                PYTHON,
+                "-m",
+                "pytest",
+                "examples/minimal-plugin/tests",
+                "-v",
+                "--tb=short",
+            ),
+        ),
+        CommandSpec("example_plugin_discovery", (PYTHON, "-c", PLUGIN_DISCOVERY_CODE)),
+    ),
+}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run deterministic SouWen CI profiles.")
+    parser.add_argument(
+        "--profile",
+        action="append",
+        choices=sorted(PROFILE_COMMANDS),
+        help="Profile to run. Repeat this option to run multiple profiles in order.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=_positive_float,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help="Per-command timeout in seconds.",
+    )
+    parser.add_argument("--json-report", type=Path, default=None)
+    parser.add_argument("--markdown-report", type=Path, default=None)
+    parser.add_argument(
+        "--list-profiles",
+        action="store_true",
+        help="List available profiles and exit.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.list_profiles:
+        for profile in sorted(PROFILE_COMMANDS):
+            print(profile)
+        return 0
+    if not args.profile:
+        parser.error("at least one --profile is required unless --list-profiles is used")
+
+    recorder = run_profiles(args.profile, timeout=args.timeout)
+    recorder.write_reports(json_report=args.json_report, markdown_report=args.markdown_report)
+    _print_summary(recorder)
+    return recorder.exit_code()
+
+
+def run_profiles(profiles: Sequence[str], *, timeout: float) -> ResultRecorder:
+    recorder = ResultRecorder(
+        script="ci_profile_runner",
+        mode=",".join(profiles),
+        environment={"profiles": list(profiles)},
+    )
+    for profile in profiles:
+        for command in PROFILE_COMMANDS[profile]:
+            _run_command(recorder, profile, command, timeout=timeout)
+    return recorder
+
+
+def _run_command(
+    recorder: ResultRecorder,
+    profile: str,
+    spec: CommandSpec,
+    *,
+    timeout: float,
+) -> None:
+    start = time.perf_counter()
+    env = os.environ.copy()
+    env.setdefault("PYTHONIOENCODING", "utf-8")
+    env.update(dict(spec.env))
+    command_text = shlex.join(spec.command)
+    try:
+        completed = _run_subprocess(
+            spec.command,
+            check=False,
+            capture_output=True,
+            env=env,
+            text=True,
+            timeout=timeout,
+        )
+        duration = time.perf_counter() - start
+        details = {
+            "command": command_text,
+            "returncode": completed.returncode,
+            "stdout_tail": _tail(completed.stdout),
+            "stderr_tail": _tail(completed.stderr),
+        }
+        if completed.returncode == 0:
+            outcome = Outcome.PASS
+            message = "ok"
+        else:
+            outcome = Outcome.FAIL if spec.required else Outcome.WARN
+            message = f"exit code {completed.returncode}"
+        recorder.record(
+            f"{profile}/{spec.name}",
+            outcome,
+            required=spec.required,
+            duration_seconds=duration,
+            message=message,
+            details=details,
+        )
+    except subprocess.TimeoutExpired as exc:
+        duration = time.perf_counter() - start
+        recorder.record(
+            f"{profile}/{spec.name}",
+            Outcome.FAIL if spec.required else Outcome.WARN,
+            required=spec.required,
+            duration_seconds=duration,
+            message=f"timeout after {timeout:.1f}s",
+            details={
+                "command": command_text,
+                "timeout": timeout,
+                "stdout_tail": _tail(exc.stdout),
+                "stderr_tail": _tail(exc.stderr),
+            },
+        )
+    except OSError as exc:
+        duration = time.perf_counter() - start
+        recorder.record(
+            f"{profile}/{spec.name}",
+            Outcome.FAIL if spec.required else Outcome.WARN,
+            required=spec.required,
+            duration_seconds=duration,
+            message=str(exc),
+            details={
+                "command": command_text,
+                "exception_type": type(exc).__name__,
+            },
+        )
+
+
+def _tail(value: str | bytes | None, *, limit: int = OUTPUT_TAIL_CHARS) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        value = value.decode("utf-8", errors="replace")
+    if len(value) <= limit:
+        return value
+    return value[-limit:]
+
+
+def _run_subprocess(command: tuple[str, ...], **kwargs) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, **kwargs)
+
+
+def _positive_float(value: str) -> float:
+    number = float(value)
+    if number <= 0:
+        raise argparse.ArgumentTypeError("must be greater than 0")
+    return number
+
+
+def _print_summary(recorder: ResultRecorder) -> None:
+    print(f"ci_profile_runner overall={recorder.overall.value}")
+    for check in recorder.checks:
+        print(f"{check.outcome.value:4} {check.name} {check.message}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_profile_runner.py
+++ b/tests/test_ci_profile_runner.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+from scripts.ci import run_profile
+from scripts._functional_common import Outcome
+
+
+def test_list_profiles(capsys):
+    assert run_profile.main(["--list-profiles"]) == 0
+
+    output = capsys.readouterr().out
+    assert "minimal" in output
+    assert "server" in output
+    assert "full" in output
+    assert "plugin" in output
+
+
+def test_main_requires_profile():
+    with pytest.raises(SystemExit) as exc_info:
+        run_profile.main([])
+
+    assert exc_info.value.code == 2
+
+
+def test_run_profiles_records_success(monkeypatch, tmp_path):
+    calls: list[tuple[str, ...]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append(tuple(command))
+        return subprocess.CompletedProcess(command, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(run_profile, "_run_subprocess", fake_run)
+
+    json_report = tmp_path / "profile.json"
+    markdown_report = tmp_path / "profile.md"
+    exit_code = run_profile.main(
+        [
+            "--profile",
+            "minimal",
+            "--json-report",
+            str(json_report),
+            "--markdown-report",
+            str(markdown_report),
+        ]
+    )
+
+    assert exit_code == 0
+    assert len(calls) == len(run_profile.PROFILE_COMMANDS["minimal"])
+    payload = json.loads(json_report.read_text(encoding="utf-8"))
+    assert payload["script"] == "ci_profile_runner"
+    assert payload["mode"] == "minimal"
+    assert payload["overall"] == "PASS"
+    assert payload["checks"][0]["name"].startswith("minimal/")
+    assert "Overall: **PASS**" in markdown_report.read_text(encoding="utf-8")
+
+
+def test_required_command_failure_sets_overall_fail(monkeypatch):
+    def fake_run(command, **kwargs):
+        return subprocess.CompletedProcess(command, 2, stdout="", stderr="boom")
+
+    monkeypatch.setattr(run_profile, "_run_subprocess", fake_run)
+
+    recorder = run_profile.run_profiles(["server"], timeout=1)
+
+    assert recorder.overall == Outcome.FAIL
+    assert recorder.exit_code() == 1
+    assert recorder.checks[0].message == "exit code 2"
+    assert recorder.checks[0].details["stderr_tail"] == "boom"
+
+
+def test_timeout_is_recorded(monkeypatch):
+    def fake_run(command, **kwargs):
+        raise subprocess.TimeoutExpired(command, timeout=3, output="partial", stderr="late")
+
+    monkeypatch.setattr(run_profile, "_run_subprocess", fake_run)
+
+    recorder = run_profile.run_profiles(["full"], timeout=3)
+
+    assert recorder.overall == Outcome.FAIL
+    assert recorder.checks[0].message == "timeout after 3.0s"
+    assert recorder.checks[0].details["stdout_tail"] == "partial"
+
+
+def test_tail_truncates_from_end():
+    assert run_profile._tail("abcdef", limit=3) == "def"


### PR DESCRIPTION
## 概述

本 PR 落地 `local/actions-five-layer-testing-design.md` 中的 P1 profile runner。它先不重排全部 Actions，而是把现有的源码 CLI smoke、server/API smoke 与 full import surface 收敛到一个可复用的确定性脚本中。

## 变更内容

- 新增 `scripts/ci/run_profile.py`，支持 `minimal` / `server` / `full` / `plugin` profile，并复用统一 JSON/Markdown report 结构。
- `.github/workflows/ci.yml` 中 Ubuntu + Python 3.11 的 full import surface 改为 `--profile full`，并上传 `runtime-profile-full-report`。
- `.github/workflows/deploy-hf-space.yml` 的 API surface + source CLI smoke 改为 `--profile server --profile minimal`，并上传 `api-source-cli-profile-report`。
- `docs/testing.md` 补充 GitHub Actions 五层测试语义、profile runner 定位和 profile 矩阵。
- `docs/hf-space-cd.md` 更新 API/CLI smoke 的本地复现方式和 report 说明。
- 新增 `tests/test_ci_profile_runner.py`，覆盖 profile 列表、参数校验、成功 report、失败退出码、timeout 记录和输出截断。

## 验证

- `PYTHONPATH=src python3 -m pytest tests/test_ci_profile_runner.py tests/test_functional_common.py tests/test_hf_space_smoke.py -q`
- `PYTHONPATH=src python3 scripts/ci/run_profile.py --profile minimal --json-report /tmp/souwen-profile-minimal.json --markdown-report /tmp/souwen-profile-minimal.md`
- `PYTHONPATH=src python3 scripts/ci/run_profile.py --profile server --json-report /tmp/souwen-profile-server.json --markdown-report /tmp/souwen-profile-server.md`
- `PYTHONPATH=src python3 scripts/ci/run_profile.py --profile full --json-report /tmp/souwen-profile-full.json --markdown-report /tmp/souwen-profile-full.md`
- `python3 -m ruff check src/ tests/ scripts`
- `python3 -m ruff format --check src/ tests/ scripts`
- `actionlint .github/workflows/ci.yml .github/workflows/deploy-hf-space.yml`
- workflow YAML `yaml.safe_load`
- `git diff --check`

## 说明

本 PR 没有在本机执行 Docker、browser runtime 安装、Scrapling/Crawl4AI runtime 安装或真实外部能力测试；这些仍由 GitHub Actions 对应 job 承接。