### PR TITLE
chore(v2): 初始化 v2-dev 开发基线

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -1,0 +1,62 @@
+name: V2 CI
+
+on:
+  push:
+    branches: [v2-dev]
+  pull_request:
+    branches: [v2-dev]
+  workflow_dispatch:
+
+concurrency:
+  group: v2-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  bootstrap:
+    name: v2 bootstrap checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      PYTHONPATH: src
+      SOUWEN_PLUGIN_AUTOLOAD: "0"
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Ruff check
+        run: ruff check src tests scripts
+
+      - name: Ruff format check
+        run: ruff format --check src tests scripts
+
+      - name: Registry and docs tests
+        run: |
+          pytest tests/registry/test_consistency.py tests/test_gen_docs.py -q
+          python tools/gen_docs.py --check
+
+      - name: Registry baseline
+        run: |
+          python - <<'PY'
+          from collections import Counter
+
+          from souwen.registry import all_adapters, fetch_providers
+
+          adapters_by_name = all_adapters()
+          adapters = list(adapters_by_name.values())
+          print("runtime_adapters", len(adapters))
+          print("fetch_providers", len(fetch_providers()))
+          for domain, count in sorted(Counter(adapter.domain for adapter in adapters).items()):
+              print(f"{domain} {count}")
+          PY

--- a/docs/v2-development.md
+++ b/docs/v2-development.md
@@ -1,0 +1,71 @@
+# SouWen v2 Development Branching
+
+SouWen v2 is a breaking migration. Development must happen on `v2-dev` first,
+then merge back to `main` only after the v2 release surface is complete.
+
+## Branch Roles
+
+```text
+main
+  Stable v1 line. Do not use it for direct v2 refactor commits.
+
+v2-dev
+  Long-lived v2 integration line. All staged v2 pull requests target this branch.
+
+v2/*
+  Short-lived implementation branches. Each branch should live in its own worktree.
+```
+
+`v2-dev` must not be rebased after publication. If `main` receives important
+changes during the v2 migration, merge `origin/main` into `v2-dev` and resolve
+conflicts there.
+
+## Worktree Flow
+
+Create each implementation branch from the latest `origin/v2-dev`:
+
+```bash
+git fetch origin
+git worktree add ../SouWen-v2-01-registry -b v2/01-registry-meta origin/v2-dev
+```
+
+Open pull requests to `v2-dev`, not `main`:
+
+```bash
+gh pr create --base v2-dev --head v2/01-registry-meta
+```
+
+After a PR merges into `v2-dev`, create the next implementation branch from the
+updated `origin/v2-dev`.
+
+## PR Order
+
+1. `v2/00-bootstrap`: v2 branch policy, v2 CI entry, AI workflow quarantine.
+2. `v2/01-registry-meta`: registry package split and `registry/meta.py`.
+3. `v2/02-search-facade-removal`: search/fetch consolidation and facade deletion.
+4. `v2/03-core-path-migration`: core imports, scraper removal, top-level stub deletion.
+5. `v2/04-reexport-cleanup`: domain and web re-export directory deletion.
+6. `v2/05-docs-tests-release`: docs, tests, package surface, and `2.0.0-rc1`.
+
+## CI/CD Policy
+
+The existing v1 workflows remain focused on `main`. v2 uses `V2 CI` for staged
+pull requests to `v2-dev` while the import surface and test contracts are being
+rewritten.
+
+Do not mechanically copy v1 deployment or external smoke workflows to `v2-dev`.
+Deployment, package builds, HF Space updates, Nuitka/PyInstaller builds, and
+external smoke gates must be reviewed again after the v2 public surface is
+stable.
+
+## AI Workflow Policy
+
+During v2 migration, AI workflows keep manual `workflow_dispatch` entrypoints
+but automatic triggers stay disabled:
+
+- `ai-review.yml`: automatic `pull_request` review is commented out.
+- `ai-agent.yml`: automatic `issue_comment` ChatOps is commented out.
+- `ai-repo-audit.yml`: manual audit only.
+
+Manual AI runs are optional side checks. They are not completion gates for v2
+implementation PRs.


### PR DESCRIPTION
## 概述

为 v2 完全迁移建立独立开发基线，后续 v2 重构 PR 均以 `v2-dev` 为 base，并通过独立 worktree / branch 分阶段合入。

## 主要改动

- 新增 `V2 CI` workflow，仅面向 `v2-dev` 的 push、pull_request 和手动触发。
- 新增 `docs/v2-development.md`，记录 `main`、`v2-dev`、`v2/*` 分支职责，以及 worktree 开发和 PR base 规则。
- 明确 v2 期间不机械复用 v1 的部署、外部 smoke、打包发布等 CI/CD 触发面。
- 明确三个 AI workflow 在 v2 迁移期间只作为手动旁路，不作为完成 gate。

## 验证

- `actionlint .github/workflows/v2-ci.yml .github/workflows/ai-review.yml .github/workflows/ai-agent.yml .github/workflows/ai-repo-audit.yml`
- `git diff --check`
- `python3 -m ruff check src tests scripts`
- `python3 -m ruff format --check src tests scripts`
- `SOUWEN_PLUGIN_AUTOLOAD=0 PYTHONPATH=src python3 tools/gen_docs.py --check`
- `SOUWEN_PLUGIN_AUTOLOAD=0 PYTHONPATH=src python3 -m pytest tests/registry/test_consistency.py tests/test_gen_docs.py -q`

## 文件清单

- `.github/workflows/v2-ci.yml`
- `docs/v2-development.md`
