### PR TITLE
docs(fetch): 修正 fetch_content providers 参数口径

### DIFF
--- a/docs/plugin-integration-spec.md
+++ b/docs/plugin-integration-spec.md
@@ -350,7 +350,7 @@ register_fetch_handler("my-source", my_handler, override=False)
 
 | 参数 | 含义 |
 |---|---|
-| `provider: str` | provider 名（CLI `--provider` 与 `fetch_content(provider=)` 用） |
+| `provider: str` | provider 名（CLI `--provider` 与 `fetch_content(providers=[...])` 用） |
 | `handler: FetchHandler` | 满足 §6 签名的异步函数 |
 | `override: bool = False` | 是否允许覆盖同名 handler；默认拒绝并记 warning |
 
@@ -374,7 +374,7 @@ entry point `ep.load()` 会执行该模块顶层代码，handler 即被注册。
 ### 何时只用 SourceAdapter（不需要 handler）
 
 - 插件只做**搜索**类 capability，不在 `fetch` 域、不实现 `fetch` capability
-- 不希望插件出现在 `fetch_content(provider=...)` 列表里
+- 不希望插件出现在 `fetch_content(providers=[...])` 列表里
 
 简言之：`SourceAdapter` 让源出现在 registry，`register_fetch_handler` 让源能被
 `souwen.web.fetch.fetch_content` 派发，二者互不依赖；fetch provider 通常需要两个都做。

--- a/src/souwen/web/scrapling_fetcher.py
+++ b/src/souwen/web/scrapling_fetcher.py
@@ -2,7 +2,7 @@
 
 Scrapling 是本地运行的抓取框架，提供普通 HTTP、动态浏览器和 stealth 浏览器三类
 fetcher。这里把它封装成 SouWen 的 fetch provider，使用户可以通过
-``souwen fetch --provider scrapling`` 或 ``fetch_content(..., provider="scrapling")``
+``souwen fetch --provider scrapling`` 或 ``fetch_content(..., providers=["scrapling"])``
 使用，而不会影响现有 ``httpx`` / ``curl_cffi`` 后端。
 """
 


### PR DESCRIPTION
## 概述

本 PR 是 v2.4 完成后的文档口径修正，清理评审中指出的 `fetch_content(provider=...)` 旧参数写法，统一为当前真实 API 的 `providers=[...]`。

## 变更内容

- `docs/plugin-integration-spec.md`：将插件文档中的 `fetch_content(provider=...)` 改为 `fetch_content(providers=[...])`。
- `src/souwen/web/scrapling_fetcher.py`：将模块 docstring 中的 Scrapling 示例改为 `fetch_content(..., providers=["scrapling"])`。

## 验证

- `rg -n "fetch_content\\([^\\n]*provider=|fetch_content\\([^\\n]*provider\\s*=|fetch_content\\([^\\n]*provider\\.\\.\\." docs src README.md README.en.md tests examples`：无输出
- `SOUWEN_PLUGIN_AUTOLOAD=0 PYTHONPATH=src python3 -m pytest tests/test_import_surface.py -q`：`24 passed`
- `python3 -m ruff check src tests scripts tools`
- `python3 -m ruff format --check src tests scripts tools`
- `SOUWEN_PLUGIN_AUTOLOAD=0 PYTHONPATH=src python3 tools/gen_docs.py --check`
- `git diff --check`