### PR TITLE
feat(v2): 建立 Source Catalog 基础投影

### DIFF
--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -1,17 +1,18 @@
 # SouWen 数据源指南与清单
 
-**总计**：**94** 个数据源（从 registry 自动生成；其中外部插件 **0** 个）。
+**总计**：**91** 个公开数据源（从正式 Source Catalog 自动生成；其中外部插件 **0** 个，隐藏/内部源 **3** 个）。
 
 ## 事实来源
 
-本页不是手工维护的静态表，而是由 `src/souwen/registry/sources/` 中的 `SourceAdapter` 声明经 `tools/gen_docs.py` 生成。`SourceAdapter` 同时驱动 CLI、REST API、doctor、Panel 和插件视图。
+本页不是手工维护的静态表，而是由 `src/souwen/registry/sources/` 中的 `SourceAdapter` 声明投影为正式 Source Catalog 后，经 `tools/gen_docs.py` 生成。`SourceAdapter` 同时驱动 CLI、REST API、doctor、Panel 和插件视图。
 
 默认生成只包含内置源，并显式关闭外部插件自动加载；这样即使本机安装了 `souwen.plugins` entry point，checked-in 文档也能稳定复现。需要把本机插件一并展示时再使用 `--include-plugins`。
 
 ## 如何阅读
 
 - 本页主表按 registry domain 展示：`paper` / `patent` / `web` / `social` / `video` / `knowledge` / `developer` / `cn_tech` / `office` / `archive` / `fetch`。
-- `/api/v1/sources` 和 Panel 使用兼容分类：`general` / `professional` 会拆分 `web` 源，`knowledge` 显示为 `wiki`，`archive` 与跨域抓取能力归入 `fetch`。
+- 正式 Source Catalog 使用展示分类：`paper`（学术论文） / `patent`（专利） / `web_general`（通用网页搜索） / `web_professional`（专业网页搜索） / `social`（社交平台） / `office`（企业/办公） / `developer`（开发者社区） / `knowledge`（百科/知识库） / `cn_tech`（中文技术社区） / `video`（视频平台） / `archive`（档案/历史） / `fetch`（内容抓取）。
+- `/api/v1/sources` 和 Panel 在过渡期仍使用兼容分类：`general` / `professional` 会拆分 `web` 源，`knowledge` 显示为 `wiki`，`archive` 与跨域抓取能力归入 `fetch`。
 - `Capabilities` 是门面层可派发能力；`fetch` 既可以是主 domain，也可以是 `tavily` / `firecrawl` / `exa` / `xcrawl` / `wayback` 等源的跨域能力。
 
 ## 配置口径
@@ -27,7 +28,7 @@
 
 <!-- BEGIN AUTO -->
 
-## 学术论文 · `paper`（19 源）
+## 学术论文 · `paper`（18 源）
 
 | Name | Integration | Auth | Risk | Distribution | Stability | Extra | Capabilities | Credentials |
 |---|---|---|---|---|---|---|---|---|
@@ -47,20 +48,17 @@
 | `pmc` | open_api | 免配置 | 低风险 | 核心内置 | 稳定 | — | search | — |
 | `pubmed` | open_api | 免配置 | 低风险 | 核心内置 | 稳定 | — | search | — |
 | `semantic_scholar` | official_api | 可选凭据 (提升限流) | 低风险 | 核心内置 | 稳定 | — | search | `semantic_scholar_api_key` |
-| `unpaywall` | official_api | 必须凭据 | 低风险 | 核心内置 | 实验性 | — | unpaywall:find_oa | `unpaywall_email` |
 | `zenodo` | official_api | 可选凭据 (提升配额) | 低风险 | 核心内置 | 稳定 | — | search | `zenodo_access_token` |
 | `zotero` | official_api | 必须凭据 | 低风险 | 核心内置 | 稳定 | — | search | `zotero_api_key`, `zotero_library_id` |
 
-## 专利 · `patent`（8 源）
+## 专利 · `patent`（6 源）
 
 | Name | Integration | Auth | Risk | Distribution | Stability | Extra | Capabilities | Credentials |
 |---|---|---|---|---|---|---|---|---|
 | `cnipa` | official_api | 必须凭据 | 低风险 | 核心内置 | 稳定 | — | search | `cnipa_client_id`, `cnipa_client_secret` |
 | `epo_ops` | official_api | 必须凭据 | 低风险 | 核心内置 | 稳定 | — | search | `epo_consumer_key`, `epo_consumer_secret` |
 | `google_patents` | scraper | 免配置 | 中风险 | 可选依赖 | 实验性 | `scraper` | search | — |
-| `patentsview` | open_api | 免配置 | 低风险 | 核心内置 | 已弃用 | — | search | — |
 | `patsnap` | official_api | 必须凭据 | 低风险 | 核心内置 | 稳定 | — | search | `patsnap_api_key` |
-| `pqai` | open_api | 免配置 | 低风险 | 核心内置 | 已弃用 | — | search | — |
 | `the_lens` | official_api | 必须凭据 | 低风险 | 核心内置 | 稳定 | — | search | `lens_api_token` |
 | `uspto_odp` | official_api | 必须凭据 | 低风险 | 核心内置 | 稳定 | — | search | `uspto_api_key` |
 

--- a/src/souwen/registry/__init__.py
+++ b/src/souwen/registry/__init__.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 from souwen.registry.adapter import (
     AUTH_REQUIREMENTS,
+    CATALOG_VISIBILITIES,
     CAPABILITIES,
     DISTRIBUTIONS,
     DOMAINS,
@@ -34,8 +35,19 @@ from souwen.registry.adapter import (
     OPTIONAL_CREDENTIAL_EFFECTS,
     RISK_LEVELS,
     RISK_REASONS,
+    SOURCE_CATEGORIES,
     SourceAdapter,
     STABILITIES,
+)
+from souwen.registry.catalog import (
+    SourceCatalogEntry,
+    SourceCategory,
+    available_source_catalog,
+    default_source_map,
+    public_source_catalog,
+    source_catalog,
+    source_categories,
+    sources_by_category,
 )
 from souwen.registry.loader import lazy
 from souwen.registry.views import (
@@ -79,6 +91,8 @@ __all__ = [
     "CAPABILITIES",
     "INTEGRATIONS",
     "AUTH_REQUIREMENTS",
+    "SOURCE_CATEGORIES",
+    "CATALOG_VISIBILITIES",
     "OPTIONAL_CREDENTIAL_EFFECTS",
     "RISK_LEVELS",
     "RISK_REASONS",
@@ -100,4 +114,13 @@ __all__ = [
     "enum_values",
     "as_all_sources_dict",
     "external_plugins",
+    # catalog
+    "SourceCatalogEntry",
+    "SourceCategory",
+    "source_catalog",
+    "public_source_catalog",
+    "sources_by_category",
+    "source_categories",
+    "default_source_map",
+    "available_source_catalog",
 ]

--- a/src/souwen/registry/adapter.py
+++ b/src/souwen/registry/adapter.py
@@ -117,6 +117,28 @@ DISTRIBUTIONS: frozenset[str] = frozenset({"core", "extra", "plugin"})
 #: 接入成熟度。
 STABILITIES: frozenset[str] = frozenset({"stable", "beta", "experimental", "deprecated"})
 
+#: 正式 source catalog 展示/治理分类。它不同于 domain：domain 描述业务能力，
+#: category 描述面向用户和治理面的目录归类。
+SOURCE_CATEGORIES: frozenset[str] = frozenset(
+    {
+        "paper",
+        "patent",
+        "web_general",
+        "web_professional",
+        "social",
+        "office",
+        "developer",
+        "knowledge",
+        "cn_tech",
+        "video",
+        "archive",
+        "fetch",
+    }
+)
+
+#: catalog 可见性。hidden 源仍可保留在 registry 中，但不进入 public catalog。
+CATALOG_VISIBILITIES: frozenset[str] = frozenset({"public", "internal", "hidden"})
+
 
 # ── 数据类 ──────────────────────────────────────────────────
 
@@ -177,6 +199,9 @@ class SourceAdapter:
         usage_note: 用户级提示，给 doctor / API / Panel 展示该源的运行时限制
             或注意事项（如 unpaywall 的 "仅支持 DOI OA 查找"）。**不参与可用性
             判定**——状态推断走 stability/auth_requirement 维度。
+        category: 正式 source catalog 分类；None 表示由 catalog 兼容层从 domain/tags 派生。
+        catalog_visibility: 正式 source catalog 可见性；旧 `v0_all_sources:exclude`
+            tag 会在 catalog 兼容层投影为 hidden。
     """
 
     name: str
@@ -201,6 +226,8 @@ class SourceAdapter:
     package_extra: str | None = None
     stability: str = "stable"
     usage_note: str | None = None
+    category: str | None = None
+    catalog_visibility: str = "public"
 
     @property
     def capabilities(self) -> frozenset[str]:
@@ -375,6 +402,15 @@ class SourceAdapter:
         if self.stability not in STABILITIES:
             raise ValueError(
                 f"SourceAdapter({self.name!r}) stability={self.stability!r} 不在 STABILITIES 中"
+            )
+        if self.category is not None and self.category not in SOURCE_CATEGORIES:
+            raise ValueError(
+                f"SourceAdapter({self.name!r}) category={self.category!r} 不在 SOURCE_CATEGORIES 中"
+            )
+        if self.catalog_visibility not in CATALOG_VISIBILITIES:
+            raise ValueError(
+                f"SourceAdapter({self.name!r}) catalog_visibility={self.catalog_visibility!r} "
+                "不在 CATALOG_VISIBILITIES 中"
             )
         effective_auth = self.resolved_auth_requirement
         resolved_fields = self.resolved_credential_fields

--- a/src/souwen/registry/catalog.py
+++ b/src/souwen/registry/catalog.py
@@ -1,0 +1,295 @@
+"""正式 source catalog 投影层。
+
+本模块从底层 ``SourceAdapter`` registry 派生面向展示、治理和后续 API
+contract 的 catalog 视图。旧 ``ALL_SOURCES`` / ``SourceMeta`` 兼容视图暂时保留；
+新代码需要目录语义时应优先从这里读取。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from souwen.registry import views as _views
+from souwen.registry.adapter import (
+    FETCH_DOMAIN,
+    SOURCE_CATEGORIES,
+    SourceAdapter,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SourceCategory:
+    """Source catalog 的展示/治理分类。"""
+
+    key: str
+    label: str
+    domain: str | None
+    order: int
+    description: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class SourceCatalogEntry:
+    """从 ``SourceAdapter`` 派生出的稳定 catalog 条目。"""
+
+    name: str
+    domain: str
+    category: str
+    capabilities: tuple[str, ...]
+    description: str
+    auth_requirement: str
+    credential_fields: tuple[str, ...]
+    optional_credential_effect: str | None
+    risk_level: str
+    risk_reasons: tuple[str, ...]
+    stability: str
+    distribution: str
+    package_extra: str | None
+    default_enabled: bool
+    default_for: tuple[str, ...]
+    visibility: str
+    available_by_default: bool
+    usage_note: str | None
+
+
+_SOURCE_CATEGORIES: tuple[SourceCategory, ...] = (
+    SourceCategory(
+        key="paper",
+        label="学术论文",
+        domain="paper",
+        order=10,
+        description="论文、预印本、开放学术索引和文献库。",
+    ),
+    SourceCategory(
+        key="patent",
+        label="专利",
+        domain="patent",
+        order=20,
+        description="专利检索、专利详情和专利数据库。",
+    ),
+    SourceCategory(
+        key="web_general",
+        label="通用网页搜索",
+        domain="web",
+        order=30,
+        description="通用搜索引擎、SERP 爬虫、自托管元搜索和传统 SERP API。",
+    ),
+    SourceCategory(
+        key="web_professional",
+        label="专业网页搜索",
+        domain="web",
+        order=40,
+        description="AI 搜索、语义搜索和商业聚合搜索 API。",
+    ),
+    SourceCategory(
+        key="social",
+        label="社交平台",
+        domain="social",
+        order=50,
+        description="社区、社媒和用户生成内容平台。",
+    ),
+    SourceCategory(
+        key="office",
+        label="企业/办公",
+        domain="office",
+        order=60,
+        description="企业协同、办公平台和内部知识入口。",
+    ),
+    SourceCategory(
+        key="developer",
+        label="开发者社区",
+        domain="developer",
+        order=70,
+        description="代码托管、技术问答和开发者内容平台。",
+    ),
+    SourceCategory(
+        key="knowledge",
+        label="百科/知识库",
+        domain="knowledge",
+        order=80,
+        description="百科、知识库和结构化知识检索。",
+    ),
+    SourceCategory(
+        key="cn_tech",
+        label="中文技术社区",
+        domain="cn_tech",
+        order=90,
+        description="中文技术社区、产品社区和本土开发者内容平台。",
+    ),
+    SourceCategory(
+        key="video",
+        label="视频平台",
+        domain="video",
+        order=100,
+        description="视频搜索、热门视频和字幕类能力。",
+    ),
+    SourceCategory(
+        key="archive",
+        label="档案/历史",
+        domain="archive",
+        order=110,
+        description="网页归档查询、快照保存和历史版本检索。",
+    ),
+    SourceCategory(
+        key="fetch",
+        label="内容抓取",
+        domain=FETCH_DOMAIN,
+        order=120,
+        description="横切内容抓取 provider 和正文抽取能力。",
+    ),
+)
+
+_SOURCE_CATEGORY_ORDER: dict[str, int] = {
+    category.key: category.order for category in _SOURCE_CATEGORIES
+}
+_DOMAIN_TO_CATALOG_CATEGORY: dict[str, str] = {
+    "paper": "paper",
+    "patent": "patent",
+    "social": "social",
+    "office": "office",
+    "developer": "developer",
+    "knowledge": "knowledge",
+    "cn_tech": "cn_tech",
+    "video": "video",
+    "archive": "archive",
+    FETCH_DOMAIN: "fetch",
+}
+
+
+def _catalog_category_for(adapter: SourceAdapter) -> str:
+    """把 adapter 投影到正式 catalog category。"""
+
+    if adapter.category is not None:
+        return adapter.category
+    if "category:general" in adapter.tags or "v0_category:general" in adapter.tags:
+        return "web_general"
+    if "category:professional" in adapter.tags or "v0_category:professional" in adapter.tags:
+        return "web_professional"
+    if adapter.domain == "web":
+        return "web_general"
+    return _DOMAIN_TO_CATALOG_CATEGORY[adapter.domain]
+
+
+def _catalog_visibility_for(adapter: SourceAdapter) -> str:
+    """兼容旧 ``v0_all_sources:exclude`` tag 的 catalog visibility。"""
+
+    if "v0_all_sources:exclude" in adapter.tags:
+        return "hidden"
+    return adapter.catalog_visibility
+
+
+def _is_available_by_default(adapter: SourceAdapter, visibility: str) -> bool:
+    """判断一个源在零配置默认体验里是否适合直接可用。"""
+
+    if visibility != "public":
+        return False
+    if not adapter.default_enabled:
+        return False
+    if adapter.resolved_auth_requirement not in {"none", "optional"}:
+        return False
+    if adapter.resolved_risk_level == "high":
+        return False
+    return adapter.resolved_stability not in {"experimental", "deprecated"}
+
+
+def _entry_from_adapter(adapter: SourceAdapter, *, external: bool = False) -> SourceCatalogEntry:
+    category = _catalog_category_for(adapter)
+    visibility = _catalog_visibility_for(adapter)
+    distribution = "plugin" if external else adapter.resolved_distribution
+    return SourceCatalogEntry(
+        name=adapter.name,
+        domain=adapter.domain,
+        category=category,
+        capabilities=tuple(sorted(adapter.capabilities)),
+        description=adapter.description,
+        auth_requirement=adapter.resolved_auth_requirement,
+        credential_fields=adapter.resolved_credential_fields,
+        optional_credential_effect=adapter.optional_credential_effect,
+        risk_level=adapter.resolved_risk_level,
+        risk_reasons=tuple(sorted(adapter.resolved_risk_reasons)),
+        stability=adapter.resolved_stability,
+        distribution=distribution,
+        package_extra=adapter.resolved_package_extra,
+        default_enabled=adapter.default_enabled,
+        default_for=tuple(sorted(adapter.default_for)),
+        visibility=visibility,
+        available_by_default=_is_available_by_default(adapter, visibility),
+        usage_note=adapter.usage_note,
+    )
+
+
+def source_categories() -> tuple[SourceCategory, ...]:
+    """返回按展示顺序排列的 catalog categories。"""
+
+    return _SOURCE_CATEGORIES
+
+
+def source_catalog() -> dict[str, SourceCatalogEntry]:
+    """返回所有注册源的正式 catalog 投影，包含 hidden/internal 条目。"""
+
+    external_names = set(_views.external_plugins())
+    entries = [
+        _entry_from_adapter(adapter, external=adapter.name in external_names)
+        for adapter in _views.all_adapters().values()
+    ]
+    entries.sort(key=lambda item: (_SOURCE_CATEGORY_ORDER[item.category], item.name))
+    return {entry.name: entry for entry in entries}
+
+
+def public_source_catalog() -> dict[str, SourceCatalogEntry]:
+    """返回 public catalog；hidden/internal 条目不对普通用户展示。"""
+
+    return {name: entry for name, entry in source_catalog().items() if entry.visibility == "public"}
+
+
+def sources_by_category(category: str) -> list[SourceCatalogEntry]:
+    """按正式 catalog category 查询所有条目。"""
+
+    if category not in SOURCE_CATEGORIES:
+        return []
+    return [entry for entry in source_catalog().values() if entry.category == category]
+
+
+def default_source_map() -> dict[str, tuple[str, ...]]:
+    """返回 ``domain:capability`` 到默认源名的声明式映射。"""
+
+    result: dict[str, list[str]] = {}
+    for entry in source_catalog().values():
+        for key in entry.default_for:
+            result.setdefault(key, []).append(entry.name)
+    return {key: tuple(names) for key, names in sorted(result.items())}
+
+
+def available_source_catalog(config: Any) -> dict[str, SourceCatalogEntry]:
+    """按运行时配置过滤 public catalog。
+
+    过滤口径与当前 ``/api/v1/sources`` 保持一致：源未禁用，且 required /
+    self_hosted 凭据已满足。
+    """
+
+    from souwen.registry.meta import get_source, has_required_credentials
+
+    result: dict[str, SourceCatalogEntry] = {}
+    for name, entry in public_source_catalog().items():
+        meta = get_source(name)
+        if meta is None:
+            continue
+        if not config.is_source_enabled(name):
+            continue
+        if not has_required_credentials(config, name, meta):
+            continue
+        result[name] = entry
+    return result
+
+
+__all__ = [
+    "SourceCategory",
+    "SourceCatalogEntry",
+    "source_categories",
+    "source_catalog",
+    "public_source_catalog",
+    "sources_by_category",
+    "default_source_map",
+    "available_source_catalog",
+]

--- a/src/souwen/registry/views.py
+++ b/src/souwen/registry/views.py
@@ -198,6 +198,21 @@ _DOMAIN_TO_CATEGORY: dict[str, str] = {
     FETCH_DOMAIN: "fetch",
 }
 
+_CATALOG_TO_V0_CATEGORY: dict[str, str] = {
+    "paper": "paper",
+    "patent": "patent",
+    "web_general": "general",
+    "web_professional": "professional",
+    "social": "social",
+    "office": "office",
+    "developer": "developer",
+    "knowledge": "wiki",
+    "cn_tech": "cn_tech",
+    "video": "video",
+    "archive": "fetch",
+    FETCH_DOMAIN: "fetch",
+}
+
 
 def _v0_category_for(adapter: SourceAdapter) -> str | None:
     """把 adapter 映射到 ALL_SOURCES key。web 分两类：general / professional。
@@ -209,6 +224,8 @@ def _v0_category_for(adapter: SourceAdapter) -> str | None:
     判定优先走 tags（"category:*" / "v0_category:*"）显式标记；
     未显式标记的 web 插件按公开 domain 语义保底归入 general。
     """
+    if adapter.category is not None:
+        return _CATALOG_TO_V0_CATEGORY.get(adapter.category)
     if "category:general" in adapter.tags or "v0_category:general" in adapter.tags:
         return "general"
     if "category:professional" in adapter.tags or "v0_category:professional" in adapter.tags:
@@ -233,7 +250,7 @@ def as_all_sources_dict() -> dict[str, list[tuple[str, bool, str]]]:
     """
     result: dict[str, list[tuple[str, bool, str]]] = {}
     for adapter in _REGISTRY.values():
-        if "v0_all_sources:exclude" in adapter.tags:
+        if "v0_all_sources:exclude" in adapter.tags or adapter.catalog_visibility == "hidden":
             continue
         category = _v0_category_for(adapter)
         if category is not None:

--- a/tests/registry/test_catalog.py
+++ b/tests/registry/test_catalog.py
@@ -1,0 +1,175 @@
+"""正式 source catalog 投影测试。"""
+
+from __future__ import annotations
+
+from souwen.config import SouWenConfig
+from souwen.registry.adapter import (
+    CATALOG_VISIBILITIES,
+    SOURCE_CATEGORIES,
+    MethodSpec,
+    SourceAdapter,
+)
+from souwen.registry.catalog import (
+    SourceCatalogEntry,
+    available_source_catalog,
+    default_source_map,
+    public_source_catalog,
+    source_catalog,
+    source_categories,
+    sources_by_category,
+)
+from souwen.registry.loader import lazy
+from souwen.registry.views import _reg_external
+
+
+def test_source_categories_have_stable_metadata() -> None:
+    categories = source_categories()
+    assert {item.key for item in categories} == SOURCE_CATEGORIES
+    assert [item.key for item in categories] == [
+        "paper",
+        "patent",
+        "web_general",
+        "web_professional",
+        "social",
+        "office",
+        "developer",
+        "knowledge",
+        "cn_tech",
+        "video",
+        "archive",
+        "fetch",
+    ]
+    for index, item in enumerate(categories):
+        assert item.label
+        assert item.order > 0
+        if index:
+            assert categories[index - 1].order < item.order
+
+
+def test_every_adapter_projects_to_catalog_entry() -> None:
+    catalog = source_catalog()
+    assert catalog
+    assert all(isinstance(entry, SourceCatalogEntry) for entry in catalog.values())
+    for name, entry in catalog.items():
+        assert entry.name == name
+        assert entry.category in SOURCE_CATEGORIES
+        assert entry.visibility in CATALOG_VISIBILITIES
+        assert entry.capabilities == tuple(sorted(entry.capabilities))
+        assert entry.risk_reasons == tuple(sorted(entry.risk_reasons))
+        assert entry.default_for == tuple(sorted(entry.default_for))
+
+
+def test_legacy_tags_project_to_formal_catalog_categories_and_visibility() -> None:
+    catalog = source_catalog()
+    assert catalog["duckduckgo"].category == "web_general"
+    assert catalog["tavily"].category == "web_professional"
+    assert catalog["wikipedia"].category == "knowledge"
+    assert catalog["wayback"].category == "archive"
+
+    assert catalog["unpaywall"].visibility == "hidden"
+    assert catalog["patentsview"].visibility == "hidden"
+    assert catalog["pqai"].visibility == "hidden"
+    assert "unpaywall" not in public_source_catalog()
+    assert "patentsview" not in public_source_catalog()
+    assert "pqai" not in public_source_catalog()
+
+
+def test_sources_by_category_uses_formal_category_keys() -> None:
+    web_general = sources_by_category("web_general")
+    web_professional = sources_by_category("web_professional")
+    assert "duckduckgo" in {entry.name for entry in web_general}
+    assert "tavily" in {entry.name for entry in web_professional}
+    assert sources_by_category("general") == []
+
+
+def test_default_source_map_references_existing_safe_entries() -> None:
+    catalog = source_catalog()
+    defaults = default_source_map()
+    assert defaults
+    for key, names in defaults.items():
+        assert ":" in key
+        for name in names:
+            entry = catalog[name]
+            assert key in entry.default_for
+            assert entry.visibility == "public"
+            assert entry.risk_level != "high"
+            assert entry.stability != "deprecated"
+
+
+def test_non_public_high_risk_and_deprecated_sources_are_not_default_available() -> None:
+    for entry in source_catalog().values():
+        unsafe = (
+            entry.visibility != "public"
+            or entry.risk_level == "high"
+            or entry.stability in {"deprecated", "experimental"}
+        )
+        if unsafe:
+            assert entry.available_by_default is False
+
+
+def test_required_and_self_hosted_sources_are_not_available_by_default() -> None:
+    catalog = source_catalog()
+    assert catalog["tavily"].auth_requirement == "required"
+    assert catalog["tavily"].available_by_default is False
+    assert catalog["searxng"].auth_requirement == "self_hosted"
+    assert catalog["searxng"].available_by_default is False
+
+
+def test_available_source_catalog_matches_runtime_credentials_and_enabled_state() -> None:
+    default_available = available_source_catalog(SouWenConfig())
+    assert "openalex" in default_available
+    assert "duckduckgo" in default_available
+    assert "tavily" not in default_available
+    assert "searxng" not in default_available
+    assert "unpaywall" not in default_available
+
+    disabled = available_source_catalog(SouWenConfig(sources={"duckduckgo": {"enabled": False}}))
+    assert "duckduckgo" not in disabled
+
+    configured = available_source_catalog(
+        SouWenConfig(sources={"searxng": {"base_url": "https://search.example"}})
+    )
+    assert "searxng" in configured
+
+
+def test_runtime_plugin_uses_public_category_tag_and_plugin_distribution(
+    clean_registry,
+) -> None:
+    adapter = SourceAdapter(
+        name="catalog_runtime_web_probe",
+        domain="web",
+        integration="official_api",
+        description="runtime catalog probe",
+        config_field="tavily_api_key",
+        client_loader=lazy("souwen.web.tavily:TavilyClient"),
+        methods={"search": MethodSpec("search")},
+        auth_requirement="required",
+        credential_fields=("tavily_api_key",),
+        tags=frozenset({"category:professional"}),
+    )
+
+    assert _reg_external(adapter) is True
+    entry = source_catalog()["catalog_runtime_web_probe"]
+    assert entry.category == "web_professional"
+    assert entry.distribution == "plugin"
+
+
+def test_explicit_category_and_visibility_override_compat_defaults(clean_registry) -> None:
+    adapter = SourceAdapter(
+        name="catalog_internal_probe",
+        domain="web",
+        integration="scraper",
+        description="internal catalog probe",
+        config_field=None,
+        client_loader=lazy("souwen.web.duckduckgo:DuckDuckGoClient"),
+        methods={"search": MethodSpec("search")},
+        category="web_professional",
+        catalog_visibility="internal",
+    )
+
+    assert _reg_external(adapter) is True
+    entry = source_catalog()["catalog_internal_probe"]
+    assert entry.category == "web_professional"
+    assert entry.visibility == "internal"
+    assert entry.available_by_default is False
+    assert "catalog_internal_probe" not in public_source_catalog()

--- a/tests/registry/test_consistency.py
+++ b/tests/registry/test_consistency.py
@@ -39,6 +39,7 @@ from souwen.registry import (
 from souwen.registry import external_plugins
 from souwen.registry.adapter import (
     AUTH_REQUIREMENTS,
+    CATALOG_VISIBILITIES,
     CAPABILITIES,
     DISTRIBUTIONS,
     DOMAINS,
@@ -48,6 +49,7 @@ from souwen.registry.adapter import (
     OPTIONAL_CREDENTIAL_EFFECTS,
     RISK_LEVELS,
     RISK_REASONS,
+    SOURCE_CATEGORIES,
     SourceAdapter,
     STABILITIES,
 )
@@ -108,6 +110,13 @@ class TestRegistryInvariants:
             )
             assert adapter.resolved_stability in STABILITIES, (
                 f"{adapter.name}: stability={adapter.resolved_stability!r} 非法"
+            )
+            if adapter.category is not None:
+                assert adapter.category in SOURCE_CATEGORIES, (
+                    f"{adapter.name}: category={adapter.category!r} 非法"
+                )
+            assert adapter.catalog_visibility in CATALOG_VISIBILITIES, (
+                f"{adapter.name}: catalog_visibility={adapter.catalog_visibility!r} 非法"
             )
 
 
@@ -206,6 +215,14 @@ class TestSourceAdapterCatalogValidation:
         )
 
         assert has_required_credentials(SouWenConfig(), "catalog_validation_probe", meta) is False
+
+    def test_invalid_catalog_category_is_rejected(self):
+        with pytest.raises(ValueError, match="category=.*SOURCE_CATEGORIES"):
+            self._adapter(category="wiki")
+
+    def test_invalid_catalog_visibility_is_rejected(self):
+        with pytest.raises(ValueError, match="catalog_visibility=.*CATALOG_VISIBILITIES"):
+            self._adapter(catalog_visibility="private")
 
 
 # ── D11 硬断言 ──────────────────────────────────────────────

--- a/tools/gen_docs.py
+++ b/tools/gen_docs.py
@@ -56,6 +56,7 @@ def render(*, include_plugins: bool = False) -> str:
 
     try:
         from souwen.registry import all_adapters, all_domains, external_plugins
+        from souwen.registry.catalog import public_source_catalog, source_categories
         from souwen.registry.meta import (
             AUTH_REQUIREMENT_LABELS,
             DISTRIBUTION_LABELS,
@@ -72,27 +73,30 @@ def render(*, include_plugins: bool = False) -> str:
 
     loaded_adapters = all_adapters()
     external_names = set(external_plugins())
+    public_catalog = public_source_catalog()
     adapters = {
         name: adapter
         for name, adapter in loaded_adapters.items()
-        if include_plugins or name not in external_names
+        if name in public_catalog and (include_plugins or name not in external_names)
     }
     visible_external_count = len(external_names) if include_plugins else 0
+    hidden_or_internal_count = len(loaded_adapters) - len(public_catalog)
+    category_labels = {category.key: category.label for category in source_categories()}
 
     lines: list[str] = []
     lines.append("# SouWen 数据源指南与清单")
     lines.append("")
     lines.append(
-        f"**总计**：**{len(adapters)}** 个数据源（从 registry 自动生成；"
-        f"其中外部插件 **{visible_external_count}** 个）。"
+        f"**总计**：**{len(adapters)}** 个公开数据源（从正式 Source Catalog 自动生成；"
+        f"其中外部插件 **{visible_external_count}** 个，隐藏/内部源 **{hidden_or_internal_count}** 个）。"
     )
     lines.append("")
     lines.append("## 事实来源")
     lines.append("")
     lines.append(
         "本页不是手工维护的静态表，而是由 `src/souwen/registry/sources/` 中的 "
-        "`SourceAdapter` 声明经 `tools/gen_docs.py` 生成。`SourceAdapter` 同时驱动 "
-        "CLI、REST API、doctor、Panel 和插件视图。"
+        "`SourceAdapter` 声明投影为正式 Source Catalog 后，经 `tools/gen_docs.py` 生成。"
+        "`SourceAdapter` 同时驱动 CLI、REST API、doctor、Panel 和插件视图。"
     )
     lines.append("")
     lines.append(
@@ -108,8 +112,13 @@ def render(*, include_plugins: bool = False) -> str:
         "`video` / `knowledge` / `developer` / `cn_tech` / `office` / `archive` / `fetch`。"
     )
     lines.append(
-        "- `/api/v1/sources` 和 Panel 使用兼容分类：`general` / `professional` 会拆分 "
-        "`web` 源，`knowledge` 显示为 `wiki`，`archive` 与跨域抓取能力归入 `fetch`。"
+        "- 正式 Source Catalog 使用展示分类："
+        + " / ".join(f"`{key}`（{label}）" for key, label in category_labels.items())
+        + "。"
+    )
+    lines.append(
+        "- `/api/v1/sources` 和 Panel 在过渡期仍使用兼容分类：`general` / `professional` "
+        "会拆分 `web` 源，`knowledge` 显示为 `wiki`，`archive` 与跨域抓取能力归入 `fetch`。"
     )
     lines.append(
         "- `Capabilities` 是门面层可派发能力；`fetch` 既可以是主 domain，也可以是 "


### PR DESCRIPTION
## 概述

建立正式 Source Catalog 基础层，为后续 `/api/v1/sources` contract、CLI、Panel 和旧 `ALL_SOURCES` 收口提供稳定投影。本 PR 只新增 catalog 模型与查询 API，并保留现有 `/api/v1/sources` 和 Panel 兼容 shape，避免把前后端 contract 切换提前混入本阶段。

## 主要变更

- 在 `SourceAdapter` 增加 `category` 与 `catalog_visibility` 字段，并新增 `SOURCE_CATEGORIES` / `CATALOG_VISIBILITIES` 常量与注册期校验。
- 新增 `src/souwen/registry/catalog.py`，提供 `SourceCategory`、`SourceCatalogEntry`、`source_catalog()`、`public_source_catalog()`、`sources_by_category()`、`source_categories()`、`default_source_map()`、`available_source_catalog(config)`。
- 兼容读取历史 `v0_category:general` / `v0_category:professional` / `v0_all_sources:exclude` tags，分别投影为 `web_general`、`web_professional` 和 `hidden`。
- `registry.views` 继续支持旧 `ALL_SOURCES` 派生，但可读取新 `adapter.category` / `catalog_visibility`，为后续迁移留入口。
- `tools/gen_docs.py` 改为基于 public Source Catalog 生成 `docs/data-sources.md`，当前公开源为 91 个，隐藏源为 `unpaywall`、`patentsview`、`pqai`。
- 新增 `tests/registry/test_catalog.py`，覆盖 catalog 投影、分类元数据、hidden 过滤、默认源安全性、运行时可用性过滤与外部插件分类投影。

## 验证

- `PYTHONPATH=src SOUWEN_PLUGIN_AUTOLOAD=0 pytest tests/registry/test_catalog.py tests/registry/test_consistency.py -q`：51 passed
- `PYTHONPATH=src SOUWEN_PLUGIN_AUTOLOAD=0 python3 tools/gen_docs.py --check`：通过
- `ruff check src tests scripts tools`：通过
- `ruff format --check src tests scripts tools`：通过
- `PYTHONPATH=src SOUWEN_PLUGIN_AUTOLOAD=0 pytest -q`：1215 passed, 3 skipped
- `git diff --check`：通过
