### PR TITLE
feat(v2): 移除旧 Source Catalog 事实源

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Ruff format check
         run: ruff format --check src tests scripts
 
+      - name: Source catalog legacy term gate
+        run: python scripts/ci/check_no_legacy_terms.py
+
       - name: Registry and docs tests
         run: |
           pytest tests/registry/test_consistency.py tests/test_gen_docs.py -q

--- a/docs/adding-a-source.md
+++ b/docs/adding-a-source.md
@@ -111,7 +111,7 @@ _reg(SourceAdapter(
         ),
     },
     default_for=frozenset(),                # 不进默认源；想进默认就写 {"paper:search"}
-    tags=frozenset({"v0_category:professional"}),
+    category="paper",                       # web 源可显式声明 web_general / web_professional
 ))
 ```
 
@@ -129,7 +129,9 @@ _reg(SourceAdapter(
 | `extra_domains` | — | 跨域能力，**目前仅允许 `frozenset({"fetch"})`**（如 Tavily 同时是 web 搜索引擎和 fetch provider） |
 | `default_enabled` | — | UI 默认是否勾选；高风险源（google/baidu/twitter）建议 `False` |
 | `default_for` | — | 形如 `{"paper:search"}`，声明此源是否进入 `(domain, capability)` 默认集 |
-| `tags` | — | `{"high_risk"}`；内置 web 源可用 `v0_category:*`，外部 web 插件用公开 `category:general/professional` |
+| `tags` | — | `{"high_risk"}`；外部 web 插件可用公开 `category:general/professional` 标签 |
+| `category` | 推荐 | 正式 source catalog 分类；web 源用 `web_general` / `web_professional` |
+| `catalog_visibility` | — | `public` / `internal` / `hidden`，控制 catalog 展示范围 |
 | `needs_config` | 推荐 | 显式声明是否"必须配置才能工作"（None 时按 integration 推断） |
 | `auth_requirement` | 推荐 | `none` / `optional` / `required` / `self_hosted`；新代码优先使用它 |
 | `credential_fields` | 推荐 | 完整凭据字段；多字段 OAuth 源列全，如 `("client_id", "client_secret")` |
@@ -208,7 +210,7 @@ pytest tests/registry/test_consistency.py -v
 7. capability 在标准集 `CAPABILITIES` 里或为 `xxx:yyy` 命名空间形式；
 8. `extra_domains` 仅允许 `{"fetch"}`；
 9. 注册表无重名；
-10. `ALL_SOURCES` 派生与 registry 对齐；
+10. `SourceMeta` 与正式 catalog 投影对齐；
 11. 高风险源未进入默认集；
 12. source catalog 的 auth/risk/distribution/stability 字段均在枚举范围内；
 13. `resolve_params` 能完整覆盖每个 adapter（不抛异常）。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -138,7 +138,7 @@ client_cls = adapter.client_loader()  # 此刻才 importlib.import_module
 | 成熟度 | `stability` | 区分 stable / beta / experimental / deprecated |
 | 用户提示 | `usage_note` | 描述源运行时的限制或注意事项(如 unpaywall "仅支持 DOI OA 查找"、`stability="deprecated"` 源的修复进度);doctor / API / Panel 会作为消息后缀展示,**不参与可用性判定** |
 
-兼容字段仍保留：`needs_config`、`config_field`、`tags={"high_risk"}` 与 `v0_all_sources:exclude` 会派生到新的 catalog 视图中。
+兼容字段仍保留：`needs_config`、`config_field` 与 `tags={"high_risk"}` 会派生到新的 catalog 视图中；展示范围和成熟度使用 `catalog_visibility` / `stability` 显式声明。
 
 ---
 
@@ -298,7 +298,7 @@ _FETCH_HANDLERS["jina_reader"]  = _handle_jina_reader
 - config_field / credential_fields 在 `SouWenConfig.model_fields` 里存在
 - default_for 的 key 能解析为 (domain, capability) 且都合法
 - 注册表无重名
-- `ALL_SOURCES` 与 `registry.as_all_sources_dict()` 派生一致
+- `SourceMeta` 与 `registry.catalog.source_catalog()` 派生一致
 - high_risk 源不在任何默认源集
 - `resolve_params` 对所有 adapter/method 不抛异常
 - SourceType 枚举 ⊆ registry.enum_values（通过规范化映射）

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -132,7 +132,7 @@ ruff format src/
 注册表是单一事实源，但提供多条等价的入口路径：
 
 - ✅ **顶层便捷入口**：`souwen.search.search / search_all / search_papers / search_patents / web_search`、`souwen.web.fetch.fetch_content`、`souwen.web.wayback.WaybackClient` 等；内部通过 `souwen.registry` 派发。
-- ✅ **`souwen.models.SourceType` 与 `ALL_SOURCES`**：由 `registry.views.enum_values()` / `as_all_sources_dict()` 派生。
+- ✅ **`souwen.models.SourceType` 与 source catalog**：由 `registry.views.enum_values()` / `registry.catalog.source_catalog()` 派生。
 - ✅ **配置字段**：`SouWenConfig` 的 flat key（如 `tavily_api_key`）与频道覆盖 `sources.<name>.api_key` 都支持；新增源若选用 flat key 需同时支持频道覆盖。
 - ✅ **平台层入口**：`souwen.core.scraper.base` / `souwen.core.http_client` / `souwen.core.fingerprint` 是唯一推荐路径，不再新增顶层 shim。
 - ❌ **不要新增 dispatcher dict**：搜索路由、`source_map`、`engine_map` 等都已下沉到 registry 派发，新源不要再去改 `search.py` / `web/search.py`。

--- a/docs/plugin-integration-spec.md
+++ b/docs/plugin-integration-spec.md
@@ -167,14 +167,14 @@ plugin = SourceAdapter(
 |---|---|
 | `"external_plugin"` | **强烈建议所有外部插件加上**，便于审计与故障排查 |
 | `"high_risk"` | 高风控源，会被 `high_risk_sources()` 视图收录 |
-| `"category:professional"` | 仅适用于 `domain="web"` 的插件；进入专业搜索分类 |
-| `"category:general"` | 仅适用于 `domain="web"` 的插件；显式进入通用搜索分类（默认也是 general） |
+| `"category:professional"` | 仅适用于 `domain="web"` 的插件；进入 `web_professional` 专业网页搜索分类 |
+| `"category:general"` | 仅适用于 `domain="web"` 的插件；显式进入 `web_general` 通用网页搜索分类（默认也是 `web_general`） |
 
-`domain="web"` 的外部插件如果不声明 `category:*`，会按公开 domain 语义归入 `general`。
-只有 AI/聚合搜索、商业 SERP API 等更接近内置 `professional` 分类的插件，才建议声明 `category:professional`。
+`domain="web"` 的外部插件如果不声明 `category:*`，会按公开 domain 语义归入 `web_general`。
+只有 AI/聚合搜索、商业 SERP API 等更接近内置 `web_professional` 分类的插件，才建议声明 `category:professional`。
 
-> ⚠️ 不要使用 `v0_category:*` / `v0_all_sources:exclude` 等内置兼容标签——这些仅用于
-> 内置源对旧版 `ALL_SOURCES` 的向下兼容。
+> ⚠️ 外部插件不要使用内部迁移期标签；需要控制 catalog 分类时，优先使用
+> `SourceAdapter.category` 或公开 `category:general/professional` 标签。
 
 ### 校验时机
 

--- a/panel/src/core/hooks/useSearchPage.ts
+++ b/panel/src/core/hooks/useSearchPage.ts
@@ -61,7 +61,7 @@ const DOMAIN_CAPABILITIES: Record<string, Capability[]> = {
   archive: ['archive_lookup'],
 }
 
-/** Domain ↔ ALL_SOURCES category 映射（前端过滤 /sources 响应时用） */
+/** Domain ↔ /sources category 映射（前端过滤响应时用） */
 const DOMAIN_TO_CATEGORY: Record<string, string> = {
   paper: 'paper',
   patent: 'patent',

--- a/panel/src/core/types/api.ts
+++ b/panel/src/core/types/api.ts
@@ -28,7 +28,7 @@ export interface HealthResponse {
 }
 
 /**
- * 后端 source catalog 的固定分类，与 souwen.models.ALL_SOURCES 保持一致。
+ * 后端 /sources 当前响应的固定分类。
  */
 export type SourceCategory =
   | 'paper'

--- a/scripts/ci/check_no_legacy_terms.py
+++ b/scripts/ci/check_no_legacy_terms.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Fail when retired source-catalog terms re-enter active files."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+DENIED_TERMS = (
+    "ALL_SOURCES",
+    "as_all_sources_dict",
+    "_v0_category_for",
+    "v0_category",
+    "v0_all_sources",
+)
+
+ALLOWED_PATHS = {
+    "CHANGELOG.md",
+    "scripts/ci/check_no_legacy_terms.py",
+    "tests/test_import_surface.py",
+}
+
+ALLOWED_PREFIXES = ("docs/internal/",)
+
+TEXT_SUFFIXES = {
+    ".cfg",
+    ".css",
+    ".html",
+    ".ini",
+    ".js",
+    ".json",
+    ".md",
+    ".py",
+    ".rst",
+    ".toml",
+    ".ts",
+    ".tsx",
+    ".txt",
+    ".yaml",
+    ".yml",
+}
+
+
+def _repo_root() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    return Path(result.stdout.strip())
+
+
+def _tracked_files(root: Path) -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files"],
+        cwd=root,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    return [root / line for line in result.stdout.splitlines() if line]
+
+
+def _is_allowed(relative_path: str) -> bool:
+    if relative_path in ALLOWED_PATHS:
+        return True
+    return any(relative_path.startswith(prefix) for prefix in ALLOWED_PREFIXES)
+
+
+def main() -> int:
+    root = _repo_root()
+    findings: list[str] = []
+    for path in _tracked_files(root):
+        relative_path = path.relative_to(root).as_posix()
+        if _is_allowed(relative_path) or path.suffix not in TEXT_SUFFIXES:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            for term in DENIED_TERMS:
+                if term in line:
+                    findings.append(f"{relative_path}:{line_number}: {term}")
+
+    if findings:
+        print("Retired source-catalog terms found:")
+        for finding in findings:
+            print(f"  {finding}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/souwen/cli/sources.py
+++ b/src/souwen/cli/sources.py
@@ -15,8 +15,8 @@ def list_sources() -> None:
         AUTH_REQUIREMENT_LABELS,
         DISTRIBUTION_LABELS,
         RISK_LEVEL_LABELS,
-        get_all_sources,
     )
+    from souwen.registry.catalog import source_catalog
 
     _INTEGRATION_SHORT = {
         "open_api": "公开",
@@ -34,8 +34,8 @@ def list_sources() -> None:
     table.add_column("Dist", justify="center")
     table.add_column("Description", style="dim")
 
-    for name, meta in get_all_sources().items():
-        key_indicator = AUTH_REQUIREMENT_LABELS.get(meta.key_requirement, meta.key_requirement)
+    for name, meta in source_catalog().items():
+        key_indicator = AUTH_REQUIREMENT_LABELS.get(meta.auth_requirement, meta.auth_requirement)
         integration = _INTEGRATION_SHORT.get(meta.integration_type, meta.integration_type)
         risk = RISK_LEVEL_LABELS.get(meta.risk_level, meta.risk_level)
         dist = DISTRIBUTION_LABELS.get(meta.distribution, meta.distribution)

--- a/src/souwen/doctor.py
+++ b/src/souwen/doctor.py
@@ -40,12 +40,12 @@ from __future__ import annotations
 from typing import Any
 
 from souwen.config import get_config
+from souwen.registry.catalog import source_catalog
 from souwen.registry.meta import (
     AUTH_REQUIREMENT_LABELS,
     INTEGRATION_TYPE_LABELS,
     OPTIONAL_CREDENTIAL_EFFECT_LABELS,
     credential_fields_label,
-    get_all_sources,
     missing_credential_fields,
 )
 
@@ -146,7 +146,7 @@ def _stability_status(meta: Any) -> tuple[str, str] | None:
     note = getattr(meta, "usage_note", None)
     if stability == "deprecated":
         return "unavailable", note or f"{meta.name} 当前接入待修复"
-    if stability == "experimental" and meta.is_scraper:
+    if stability == "experimental" and getattr(meta, "integration_type", "") == "scraper":
         return "warning", note or "实验性爬虫，可能受反爬或 HTML 变更影响"
     return None
 
@@ -159,7 +159,7 @@ def check_all() -> list[dict]:
     Returns:
         每个数据源一条字典，包含：
         - name: 源名称
-        - category: 分类（paper|patent|general|professional|social|developer|wiki|video|fetch）
+        - category: 正式 catalog 分类
         - status: 状态（ok|warning|limited|unavailable|missing_key|disabled）
         - integration_type: 集成类型（open_api|scraper|official_api|self_hosted）
         - required_key: 必需的配置字段名（或 None）
@@ -171,7 +171,7 @@ def check_all() -> list[dict]:
     """
     cfg = get_config()
     results: list[dict] = []
-    all_sources = get_all_sources()
+    catalog = source_catalog()
 
     # 检测 curl_cffi（TLS 指纹伪装）可用性，影响所有爬虫引擎
     # 爬虫类源需要 curl_cffi 来实现 JA3 TLS 指纹伪装，避免被反爬拦截
@@ -182,7 +182,7 @@ def check_all() -> list[dict]:
     except ImportError:
         _has_tls_impersonation = False
 
-    for name, meta in all_sources.items():
+    for name, meta in catalog.items():
         enabled = cfg.is_source_enabled(name)
         field = meta.config_field
         missing_fields = missing_credential_fields(cfg, name, meta)
@@ -229,7 +229,7 @@ def check_all() -> list[dict]:
         if (
             enabled
             and status in {"ok", "limited"}
-            and meta.is_scraper
+            and meta.integration_type == "scraper"
             and not _has_tls_impersonation
         ):
             if status == "ok":
@@ -255,7 +255,7 @@ def check_all() -> list[dict]:
                 "status": status,
                 "integration_type": meta.integration_type,
                 "required_key": field,
-                "key_requirement": meta.key_requirement,
+                "key_requirement": meta.auth_requirement,
                 "auth_requirement": meta.auth_requirement,
                 "credential_fields": list(meta.credential_fields),
                 "optional_credential_effect": meta.optional_credential_effect,

--- a/src/souwen/models.py
+++ b/src/souwen/models.py
@@ -444,26 +444,3 @@ class WaybackSaveResult(BaseModel):
     snapshot_url: str | None = None  # 存档后的快照 URL
     timestamp: str | None = None  # 快照时间戳（YYYYMMDDHHMMSS）
     error: str | None = None
-
-
-ALL_SOURCES: dict[str, list[tuple[str, bool, str]]]
-
-
-# ALL_SOURCES 从注册表派生：
-#   - 字典 shape：`{category: [(name, needs_config, description), ...]}`
-#   - category 取值：paper / patent / general / professional / social / office /
-#     developer / wiki / cn_tech / video / fetch
-#   - "general" 下的源（SERP 爬虫 + self_hosted + 部分 SERP API）通过 adapter
-#     `tags={"v0_category:general"}` 显式标记
-#   - "professional" 同理（`v0_category:professional`）
-#   - 实验性/"待修复" 源（unpaywall / patentsview / pqai）通过
-#     `tags={"v0_all_sources:exclude"}` 排除（保持 `len(ALL_SOURCES["paper"]) == 16`
-#     与 `len(ALL_SOURCES["patent"]) == 6`）
-# 详见 `souwen.registry.views.as_all_sources_dict()`。
-def _load_all_sources() -> dict[str, list[tuple[str, bool, str]]]:
-    from souwen.registry import as_all_sources_dict
-
-    return as_all_sources_dict()
-
-
-ALL_SOURCES = _load_all_sources()

--- a/src/souwen/registry/__init__.py
+++ b/src/souwen/registry/__init__.py
@@ -15,7 +15,7 @@
     - lazy —— 客户端类的字符串懒加载（loader.py）
     - get / all_adapters / by_domain / by_capability / by_domain_and_capability /
       defaults_for / all_domains / all_capabilities / fetch_providers / high_risk_sources /
-      enum_values / as_all_sources_dict
+      enum_values
       —— 查询视图（views.py）
 
 设计参见 `local/v1-初步定义.md §5` 与 `local/重构计划.md §1.3`。
@@ -54,7 +54,6 @@ from souwen.registry.views import (
     all_adapters,
     all_capabilities,
     all_domains,
-    as_all_sources_dict,
     by_capability,
     by_domain,
     by_domain_and_capability,
@@ -112,7 +111,6 @@ __all__ = [
     "fetch_providers",
     "high_risk_sources",
     "enum_values",
-    "as_all_sources_dict",
     "external_plugins",
     # catalog
     "SourceCatalogEntry",

--- a/src/souwen/registry/adapter.py
+++ b/src/souwen/registry/adapter.py
@@ -195,13 +195,12 @@ class SourceAdapter:
         optional_credential_effect: 可选凭据的收益，如提高 rate limit 或解锁个性化能力。
         risk_level / risk_reasons: 风险等级与原因，兼容旧 tag high_risk。
         distribution / package_extra: 推荐分发范围与 optional dependency 组。
-        stability: 源的成熟度。v0_all_sources:exclude 会被视为 experimental。
+        stability: 源的成熟度。
         usage_note: 用户级提示，给 doctor / API / Panel 展示该源的运行时限制
             或注意事项（如 unpaywall 的 "仅支持 DOI OA 查找"）。**不参与可用性
             判定**——状态推断走 stability/auth_requirement 维度。
         category: 正式 source catalog 分类；None 表示由 catalog 兼容层从 domain/tags 派生。
-        catalog_visibility: 正式 source catalog 可见性；旧 `v0_all_sources:exclude`
-            tag 会在 catalog 兼容层投影为 hidden。
+        catalog_visibility: 正式 source catalog 可见性。
     """
 
     name: str
@@ -331,9 +330,7 @@ class SourceAdapter:
 
     @property
     def resolved_stability(self) -> str:
-        """兼容 v0 排除标签的成熟度。"""
-        if "v0_all_sources:exclude" in self.tags and self.stability == "stable":
-            return "experimental"
+        """返回最终成熟度。"""
         return self.stability
 
     def resolve_params(

--- a/src/souwen/registry/catalog.py
+++ b/src/souwen/registry/catalog.py
@@ -1,8 +1,7 @@
 """正式 source catalog 投影层。
 
 本模块从底层 ``SourceAdapter`` registry 派生面向展示、治理和后续 API
-contract 的 catalog 视图。旧 ``ALL_SOURCES`` / ``SourceMeta`` 兼容视图暂时保留；
-新代码需要目录语义时应优先从这里读取。
+contract 的 catalog 视图。新代码需要目录语义时应从这里读取。
 """
 
 from __future__ import annotations
@@ -38,6 +37,9 @@ class SourceCatalogEntry:
     category: str
     capabilities: tuple[str, ...]
     description: str
+    integration_type: str
+    config_field: str | None
+    needs_config: bool
     auth_requirement: str
     credential_fields: tuple[str, ...]
     optional_credential_effect: str | None
@@ -162,21 +164,13 @@ def _catalog_category_for(adapter: SourceAdapter) -> str:
 
     if adapter.category is not None:
         return adapter.category
-    if "category:general" in adapter.tags or "v0_category:general" in adapter.tags:
+    if "category:general" in adapter.tags:
         return "web_general"
-    if "category:professional" in adapter.tags or "v0_category:professional" in adapter.tags:
+    if "category:professional" in adapter.tags:
         return "web_professional"
     if adapter.domain == "web":
         return "web_general"
     return _DOMAIN_TO_CATALOG_CATEGORY[adapter.domain]
-
-
-def _catalog_visibility_for(adapter: SourceAdapter) -> str:
-    """兼容旧 ``v0_all_sources:exclude`` tag 的 catalog visibility。"""
-
-    if "v0_all_sources:exclude" in adapter.tags:
-        return "hidden"
-    return adapter.catalog_visibility
 
 
 def _is_available_by_default(adapter: SourceAdapter, visibility: str) -> bool:
@@ -195,7 +189,7 @@ def _is_available_by_default(adapter: SourceAdapter, visibility: str) -> bool:
 
 def _entry_from_adapter(adapter: SourceAdapter, *, external: bool = False) -> SourceCatalogEntry:
     category = _catalog_category_for(adapter)
-    visibility = _catalog_visibility_for(adapter)
+    visibility = adapter.catalog_visibility
     distribution = "plugin" if external else adapter.resolved_distribution
     return SourceCatalogEntry(
         name=adapter.name,
@@ -203,6 +197,9 @@ def _entry_from_adapter(adapter: SourceAdapter, *, external: bool = False) -> So
         category=category,
         capabilities=tuple(sorted(adapter.capabilities)),
         description=adapter.description,
+        integration_type=adapter.integration,
+        config_field=adapter.config_field,
+        needs_config=adapter.resolved_needs_config,
         auth_requirement=adapter.resolved_auth_requirement,
         credential_fields=adapter.resolved_credential_fields,
         optional_credential_effect=adapter.optional_credential_effect,
@@ -268,16 +265,13 @@ def available_source_catalog(config: Any) -> dict[str, SourceCatalogEntry]:
     self_hosted 凭据已满足。
     """
 
-    from souwen.registry.meta import get_source, has_required_credentials
+    from souwen.registry.meta import has_required_credentials
 
     result: dict[str, SourceCatalogEntry] = {}
     for name, entry in public_source_catalog().items():
-        meta = get_source(name)
-        if meta is None:
-            continue
         if not config.is_source_enabled(name):
             continue
-        if not has_required_credentials(config, name, meta):
+        if not has_required_credentials(config, name, entry):
             continue
         result[name] = entry
     return result

--- a/src/souwen/registry/meta.py
+++ b/src/souwen/registry/meta.py
@@ -1,7 +1,7 @@
 """SouWen 数据源元数据视图
 
 `souwen.registry` 是单一事实源（含执行适配 MethodSpec）。本模块对外提供基于
-分类（category）的便捷视图与查询函数，从 `souwen.registry.views` 派生。
+分类（category）的便捷视图与查询函数，从正式 source catalog 派生。
 
 公开 API：
     SourceMeta              —— 数据类（只读字段，视图）
@@ -17,14 +17,9 @@
     get_sources_by_distribution(distribution)     —— list[SourceMeta]
     ALL_SOURCE_NAMES        —— frozenset[str]
 
-domain → category 映射：
-    10 个 domain 中有 8 个直接对应 category：paper / patent / social / video /
-    knowledge / developer / cn_tech / office。另外：
-      - `web` 下的 scraper / self_hosted + 部分 SERP API → `general`
-      - `web` 下的 AI/语义 API → `professional`
-      - `knowledge` → `wiki`
-      - `archive` → `fetch`（Wayback 在 fetch 列表）
-    映射规则实现在 `souwen.registry.views._v0_category_for`。
+category 使用正式 catalog key：
+    paper / patent / web_general / web_professional / social / office /
+    developer / knowledge / cn_tech / video / archive / fetch。
 """
 
 from __future__ import annotations
@@ -33,8 +28,8 @@ from dataclasses import dataclass
 from threading import RLock
 from typing import Any
 
-from souwen.registry import views as _views
 from souwen.registry.adapter import AUTH_REQUIREMENTS, DISTRIBUTIONS, INTEGRATIONS
+from souwen.registry.catalog import source_catalog
 
 INTEGRATION_TYPES: frozenset[str] = INTEGRATIONS
 AUTH_REQUIREMENT_TYPES: frozenset[str] = AUTH_REQUIREMENTS
@@ -94,18 +89,13 @@ class SourceMeta:
         auth/risk/distribution/stability 等 source catalog 元数据。
 
     category 取值：
-        paper | patent | general | professional | social | office |
-        cn_tech | developer | wiki | video | fetch
-    （由 `_v0_category_for()` 把 adapter 的 domain 映射到对应 category）
+        paper | patent | web_general | web_professional | social | office |
+        developer | knowledge | cn_tech | video | archive | fetch
 
     字段语义注解：
         - ``credential_fields`` / ``risk_level`` / ``risk_reasons`` /
-          ``distribution`` / ``package_extra`` / ``stability`` 均存储
-          ``SourceAdapter`` 上的 ``resolved_*`` 投影（即已根据兼容字段如
-          ``high_risk`` tag、``v0_all_sources:exclude`` tag、scraper 默认 extra
-          推断出的最终值），消费者无需再访问 adapter 本体。
-        - ``distribution`` 在外部插件场景会被 ``_build_source_meta_view`` 强制改写
-          为 ``"plugin"``，与 adapter 上的声明可能不同。
+          ``distribution`` / ``package_extra`` / ``stability`` 均存储正式 catalog
+          投影中的最终值，消费者无需再访问 adapter 本体。
         - ``key_requirement`` 是 ``auth_requirement`` 的别名 property，保持
           doctor / API / Panel 的历史字段名兼容。
 
@@ -155,31 +145,25 @@ def _build_source_meta_view() -> dict[str, SourceMeta]:
     （如 Tavily domain=web + extra_domains={fetch}）只在主 category 下出现。
     """
     result: dict[str, SourceMeta] = {}
-    external_names = set(_views.external_plugins())
-    for adapter in _views.all_adapters().values():
-        # ALL_SOURCES 排除集合外的源（experimental/待修复）也会保留到本视图。
-        category = _views._v0_category_for(adapter)
-        if category is None:
-            continue
-        distribution = "plugin" if adapter.name in external_names else adapter.resolved_distribution
-        result[adapter.name] = SourceMeta(
-            name=adapter.name,
-            category=category,
-            integration_type=adapter.integration,
-            config_field=adapter.config_field,
-            description=adapter.description,
-            needs_config=adapter.resolved_needs_config,
-            auth_requirement=adapter.resolved_auth_requirement,
-            credential_fields=adapter.resolved_credential_fields,
-            optional_credential_effect=adapter.optional_credential_effect,
-            risk_level=adapter.resolved_risk_level,
-            risk_reasons=adapter.resolved_risk_reasons,
-            distribution=distribution,
-            package_extra=adapter.resolved_package_extra,
-            stability=adapter.resolved_stability,
-            usage_note=adapter.usage_note,
-            default_enabled=adapter.default_enabled,
-            default_for=adapter.default_for,
+    for entry in source_catalog().values():
+        result[entry.name] = SourceMeta(
+            name=entry.name,
+            category=entry.category,
+            integration_type=entry.integration_type,
+            config_field=entry.config_field,
+            description=entry.description,
+            needs_config=entry.needs_config,
+            auth_requirement=entry.auth_requirement,
+            credential_fields=entry.credential_fields,
+            optional_credential_effect=entry.optional_credential_effect,
+            risk_level=entry.risk_level,
+            risk_reasons=frozenset(entry.risk_reasons),
+            distribution=entry.distribution,
+            package_extra=entry.package_extra,
+            stability=entry.stability,
+            usage_note=entry.usage_note,
+            default_enabled=entry.default_enabled,
+            default_for=frozenset(entry.default_for),
         )
     return result
 
@@ -264,8 +248,9 @@ def get_sources_by_category(category: str) -> list[SourceMeta]:
     """按内容分类筛选数据源
 
     Args:
-        category: 分类标签（paper / patent / general / professional / social /
-            office / cn_tech / developer / wiki / video / fetch）
+        category: 正式 catalog 分类标签（paper / patent / web_general /
+            web_professional / social / office / developer / knowledge /
+            cn_tech / video / archive / fetch）
 
     Returns:
         该分类下的 SourceMeta 对象列表

--- a/src/souwen/registry/sources/__init__.py
+++ b/src/souwen/registry/sources/__init__.py
@@ -22,8 +22,7 @@
     **不会**把 80+ 个 Client 全部 import 进来。
   - `param_map` 把统一入参（limit/query）翻译为源原生参数名（per_page/rows/retmax/size/...）。
   - `default_for` 声明 (domain, capability) 下的默认源。
-  - `tags={"v0_category:general"}` / `{"v0_category:professional"}` 用于 ALL_SOURCES 分类映射
-    （让 `as_all_sources_dict()` 能正确派生 general / professional 划分）。
+  - `category` 声明正式 source catalog 分类；web 源用 `web_general` / `web_professional`。
 
 本文件的变更会被 `tests/registry/test_consistency.py` 验证：
   - 所有 client_loader 的目标类真实存在
@@ -39,11 +38,8 @@ from souwen.registry.adapter import MethodSpec, SourceAdapter
 from souwen.registry.loader import lazy
 from souwen.registry.views import _reg  # 模块内使用的注册函数
 
-# ALL_SOURCES 分类标签速记
-_T_GENERAL: frozenset[str] = frozenset({"v0_category:general"})
-_T_PROFESSIONAL: frozenset[str] = frozenset({"v0_category:professional"})
-_T_HIGH_RISK_GENERAL: frozenset[str] = frozenset({"v0_category:general", "high_risk"})
-_T_HIGH_RISK_SOCIAL: frozenset[str] = frozenset({"high_risk"})
+# 标签速记
+_T_HIGH_RISK: frozenset[str] = frozenset({"high_risk"})
 
 # 通用 param_map 速记
 _P_PER_PAGE: dict[str, str] = {"limit": "per_page"}
@@ -310,8 +306,8 @@ _reg(
         client_loader=lazy("souwen.paper.unpaywall:UnpaywallClient"),
         # unpaywall 没有 search 方法，只有 find_oa(doi)；用命名空间声明（D8）
         methods={"unpaywall:find_oa": MethodSpec("find_oa")},
-        # 不参与 search 调度，ALL_SOURCES["paper"] 也不收录
-        tags=frozenset({"v0_all_sources:exclude"}),
+        # 不参与 search 调度，默认 public catalog 不展示
+        catalog_visibility="hidden",
         usage_note="仅支持 DOI OA 查找",
     )
 )
@@ -345,8 +341,8 @@ _reg(
                 pre_call=_patentsview_pre_call,
             ),
         },
-        # "待修复"状态，ALL_SOURCES["patent"] 也不收录
-        tags=frozenset({"v0_all_sources:exclude"}),
+        # "待修复"状态，默认 public catalog 不展示
+        catalog_visibility="hidden",
         stability="deprecated",
         usage_note="公开搜索端点已变更，当前接入待修复",
     )
@@ -361,7 +357,7 @@ _reg(
         config_field=None,
         client_loader=lazy("souwen.patent.pqai:PqaiClient"),
         methods={"search": MethodSpec("search", _P_N_RESULTS)},
-        tags=frozenset({"v0_all_sources:exclude"}),
+        catalog_visibility="hidden",
         stability="deprecated",
         usage_note="匿名 API 当前返回 401，暂不建议默认使用",
     )
@@ -464,7 +460,7 @@ _reg(
         client_loader=lazy("souwen.web.duckduckgo:DuckDuckGoClient"),
         methods={"search": MethodSpec("search", _P_MAX_RESULTS)},
         default_for=frozenset({"web:search"}),
-        tags=_T_GENERAL,
+        category="web_general",
     )
 )
 
@@ -478,7 +474,7 @@ _reg(
         client_loader=lazy("souwen.web.ddg_news:DuckDuckGoNewsClient"),
         methods={"search_news": MethodSpec("search", _P_MAX_RESULTS)},
         default_for=frozenset({"web:search_news"}),
-        tags=_T_GENERAL,
+        category="web_general",
     )
 )
 
@@ -491,7 +487,7 @@ _reg(
         config_field=None,
         client_loader=lazy("souwen.web.ddg_images:DuckDuckGoImagesClient"),
         methods={"search_images": MethodSpec("search", _P_MAX_RESULTS)},
-        tags=_T_GENERAL,
+        category="web_general",
     )
 )
 
@@ -504,7 +500,7 @@ _reg(
         config_field=None,
         client_loader=lazy("souwen.web.ddg_videos:DuckDuckGoVideosClient"),
         methods={"search_videos": MethodSpec("search", _P_MAX_RESULTS)},
-        tags=_T_GENERAL,
+        category="web_general",
     )
 )
 
@@ -517,7 +513,7 @@ _reg(
         config_field=None,
         client_loader=lazy("souwen.web.yahoo:YahooClient"),
         methods={"search": MethodSpec("search", _P_MAX_RESULTS)},
-        tags=_T_GENERAL,
+        category="web_general",
     )
 )
 
@@ -530,7 +526,7 @@ _reg(
         config_field=None,
         client_loader=lazy("souwen.web.brave:BraveClient"),
         methods={"search": MethodSpec("search", _P_MAX_RESULTS)},
-        tags=_T_GENERAL,
+        category="web_general",
     )
 )
 
@@ -544,7 +540,8 @@ _reg(
         client_loader=lazy("souwen.web.google:GoogleClient"),
         methods={"search": MethodSpec("search", _P_MAX_RESULTS)},
         default_enabled=False,  # D10：高风险
-        tags=_T_HIGH_RISK_GENERAL,
+        tags=_T_HIGH_RISK,
+        category="web_general",
         risk_reasons=frozenset({"anti_scraping", "captcha", "ip_block"}),
     )
 )
@@ -559,7 +556,7 @@ _reg(
         client_loader=lazy("souwen.web.bing:BingClient"),
         methods={"search": MethodSpec("search", _P_MAX_RESULTS)},
         default_for=frozenset({"web:search"}),
-        tags=_T_GENERAL,
+        category="web_general",
     )
 )
 
@@ -572,7 +569,7 @@ _reg(
         config_field=None,
         client_loader=lazy("souwen.web.bing_cn:BingCnClient"),
         methods={"search": MethodSpec("search", _P_MAX_RESULTS)},
-        tags=_T_GENERAL,
+        category="web_general",
     )
 )
 
@@ -585,7 +582,7 @@ _reg(
         config_field=None,
         client_loader=lazy("souwen.web.startpage:StartpageClient"),
         methods={"search": MethodSpec("search", _P_MAX_RESULTS)},
-        tags=_T_GENERAL,
+        category="web_general",
     )
 )
 
@@ -599,7 +596,8 @@ _reg(
         client_loader=lazy("souwen.web.baidu:BaiduClient"),
         methods={"search": MethodSpec("search", _P_MAX_RESULTS)},
         default_enabled=False,
-        tags=_T_HIGH_RISK_GENERAL,
+        tags=_T_HIGH_RISK,
+        category="web_general",
         risk_reasons=frozenset({"anti_scraping", "captcha", "ip_block"}),
     )
 )
@@ -613,7 +611,7 @@ _reg(
         config_field=None,
         client_loader=lazy("souwen.web.mojeek:MojeekClient"),
         methods={"search": MethodSpec("search", _P_MAX_RESULTS)},
-        tags=_T_GENERAL,
+        category="web_general",
     )
 )
 
@@ -626,7 +624,7 @@ _reg(
         config_field=None,
         client_loader=lazy("souwen.web.yandex:YandexClient"),
         methods={"search": MethodSpec("search", _P_MAX_RESULTS)},
-        tags=_T_GENERAL,
+        category="web_general",
     )
 )
 
@@ -634,8 +632,8 @@ _reg(
 # ═════════════════════════════════════════════════════════════
 #  4. web.api（授权 API）
 # ═════════════════════════════════════════════════════════════
-# 按 ALL_SOURCES 的划分：SERP 类（serpapi/brave_api/serper/scrapingdog/metaso）进 general，
-# AI/语义类（tavily/exa/perplexity/firecrawl/linkup/xcrawl/zhipuai/aliyun_iqs）进 professional。
+# 按正式 catalog 划分：SERP 类（serpapi/brave_api/serper/scrapingdog/metaso）进 web_general，
+# AI/语义类（tavily/exa/perplexity/firecrawl/linkup/xcrawl/zhipuai/aliyun_iqs）进 web_professional。
 
 _reg(
     SourceAdapter(
@@ -646,7 +644,7 @@ _reg(
         config_field="serpapi_api_key",
         client_loader=lazy("souwen.web.serpapi:SerpApiClient"),
         methods={"search": MethodSpec("search", _P_MAX_RESULTS)},
-        tags=_T_GENERAL,
+        category="web_general",
     )
 )
 
@@ -659,7 +657,7 @@ _reg(
         config_field="brave_api_key",
         client_loader=lazy("souwen.web.brave_api:BraveApiClient"),
         methods={"search": MethodSpec("search", _P_MAX_RESULTS)},
-        tags=_T_GENERAL,
+        category="web_general",
     )
 )
 
@@ -672,7 +670,7 @@ _reg(
         config_field="serper_api_key",
         client_loader=lazy("souwen.web.serper:SerperClient"),
         methods={"search": MethodSpec("search", _P_MAX_RESULTS)},
-        tags=_T_GENERAL,
+        category="web_general",
     )
 )
 
@@ -685,7 +683,7 @@ _reg(
         config_field="scrapingdog_api_key",
         client_loader=lazy("souwen.web.scrapingdog:ScrapingDogClient"),
         methods={"search": MethodSpec("search", _P_MAX_RESULTS)},
-        tags=_T_GENERAL,
+        category="web_general",
     )
 )
 
@@ -698,7 +696,7 @@ _reg(
         config_field="metaso_api_key",
         client_loader=lazy("souwen.web.metaso:MetasoClient"),
         methods={"search": MethodSpec("search", _P_MAX_RESULTS)},
-        tags=_T_GENERAL,
+        category="web_general",
     )
 )
 
@@ -715,7 +713,7 @@ _reg(
             "search": MethodSpec("search", _P_MAX_RESULTS),
             "fetch": MethodSpec("extract"),
         },
-        tags=_T_PROFESSIONAL,
+        category="web_professional",
     )
 )
 
@@ -733,7 +731,7 @@ _reg(
             "fetch": MethodSpec("contents"),
             "exa:find_similar": MethodSpec("find_similar", _P_MAX_RESULTS),  # D8 命名空间
         },
-        tags=_T_PROFESSIONAL,
+        category="web_professional",
     )
 )
 
@@ -746,7 +744,7 @@ _reg(
         config_field="perplexity_api_key",
         client_loader=lazy("souwen.web.perplexity:PerplexityClient"),
         methods={"search": MethodSpec("search", _P_MAX_RESULTS)},
-        tags=_T_PROFESSIONAL,
+        category="web_professional",
     )
 )
 
@@ -763,7 +761,7 @@ _reg(
             "search": MethodSpec("search", _P_MAX_RESULTS),
             "fetch": MethodSpec("scrape"),
         },
-        tags=_T_PROFESSIONAL,
+        category="web_professional",
     )
 )
 
@@ -776,7 +774,7 @@ _reg(
         config_field="linkup_api_key",
         client_loader=lazy("souwen.web.linkup:LinkupClient"),
         methods={"search": MethodSpec("search", _P_MAX_RESULTS)},
-        tags=_T_PROFESSIONAL,
+        category="web_professional",
     )
 )
 
@@ -793,7 +791,7 @@ _reg(
             "search": MethodSpec("search", _P_MAX_RESULTS),
             "fetch": MethodSpec("scrape"),
         },
-        tags=_T_PROFESSIONAL,
+        category="web_professional",
     )
 )
 
@@ -806,7 +804,7 @@ _reg(
         config_field="zhipuai_api_key",
         client_loader=lazy("souwen.web.zhipuai_search:ZhipuAISearchClient"),
         methods={"search": MethodSpec("search", _P_MAX_RESULTS)},
-        tags=_T_PROFESSIONAL,
+        category="web_professional",
     )
 )
 
@@ -819,7 +817,7 @@ _reg(
         config_field="aliyun_iqs_api_key",
         client_loader=lazy("souwen.web.aliyun_iqs:AliyunIQSClient"),
         methods={"search": MethodSpec("search", _P_MAX_RESULTS)},
-        tags=_T_PROFESSIONAL,
+        category="web_professional",
     )
 )
 
@@ -837,7 +835,7 @@ _reg(
         config_field="searxng_url",
         client_loader=lazy("souwen.web.searxng:SearXNGClient"),
         methods={"search": MethodSpec("search", _P_MAX_RESULTS)},
-        tags=_T_GENERAL,
+        category="web_general",
     )
 )
 
@@ -850,7 +848,7 @@ _reg(
         config_field="whoogle_url",
         client_loader=lazy("souwen.web.whoogle:WhoogleClient"),
         methods={"search": MethodSpec("search", _P_MAX_RESULTS)},
-        tags=_T_GENERAL,
+        category="web_general",
     )
 )
 
@@ -863,7 +861,7 @@ _reg(
         config_field="websurfx_url",
         client_loader=lazy("souwen.web.websurfx:WebsurfxClient"),
         methods={"search": MethodSpec("search", _P_MAX_RESULTS)},
-        tags=_T_GENERAL,
+        category="web_general",
     )
 )
 
@@ -894,7 +892,7 @@ _reg(
         client_loader=lazy("souwen.web.twitter:TwitterClient"),
         methods={"search": MethodSpec("search", _P_MAX_RESULTS)},
         default_enabled=False,
-        tags=_T_HIGH_RISK_SOCIAL,
+        tags=_T_HIGH_RISK,
         risk_reasons=frozenset({"account_ban", "quota_cost", "geo_sensitive"}),
     )
 )

--- a/src/souwen/registry/views.py
+++ b/src/souwen/registry/views.py
@@ -6,7 +6,6 @@
   - souwen.search（门面）
   - souwen.web.search（门面）
   - souwen.registry.meta（SourceMeta 视图）
-  - souwen.models.ALL_SOURCES（派生）
   - server/routes 的 /sources 端点
   - CLI 的 sources 子命令
   - docs 自动生成脚本
@@ -180,107 +179,6 @@ def enum_values() -> list[str]:
     return sorted(_REGISTRY.keys())
 
 
-# ── ALL_SOURCES 兼容视图 ────────────────────────────────────
-
-#: domain → ALL_SOURCES 分类的映射（ALL_SOURCES 包含的 9 个分类）。
-#: 注意：`general` 混了 engines + self_hosted + 部分 SERP API，
-#:      `professional` 是另一批 SERP/AI 类 API。
-_DOMAIN_TO_CATEGORY: dict[str, str] = {
-    "paper": "paper",
-    "patent": "patent",
-    "social": "social",
-    "video": "video",
-    "knowledge": "wiki",  # 历史命名 "wiki"
-    "developer": "developer",
-    "cn_tech": "cn_tech",
-    "office": "office",
-    "archive": "fetch",  # wayback 归在 fetch
-    FETCH_DOMAIN: "fetch",
-}
-
-_CATALOG_TO_V0_CATEGORY: dict[str, str] = {
-    "paper": "paper",
-    "patent": "patent",
-    "web_general": "general",
-    "web_professional": "professional",
-    "social": "social",
-    "office": "office",
-    "developer": "developer",
-    "knowledge": "wiki",
-    "cn_tech": "cn_tech",
-    "video": "video",
-    "archive": "fetch",
-    FETCH_DOMAIN: "fetch",
-}
-
-
-def _v0_category_for(adapter: SourceAdapter) -> str | None:
-    """把 adapter 映射到 ALL_SOURCES key。web 分两类：general / professional。
-
-    对 domain=web 的源：
-      - integration ∈ {scraper, self_hosted, 部分 official_api 型 SERP 引擎} → general
-      - integration=official_api 且以 AI/搜索聚合为主 → professional
-
-    判定优先走 tags（"category:*" / "v0_category:*"）显式标记；
-    未显式标记的 web 插件按公开 domain 语义保底归入 general。
-    """
-    if adapter.category is not None:
-        return _CATALOG_TO_V0_CATEGORY.get(adapter.category)
-    if "category:general" in adapter.tags or "v0_category:general" in adapter.tags:
-        return "general"
-    if "category:professional" in adapter.tags or "v0_category:professional" in adapter.tags:
-        return "professional"
-    if adapter.domain == "web":
-        return "general"
-    return _DOMAIN_TO_CATEGORY.get(adapter.domain)
-
-
-def as_all_sources_dict() -> dict[str, list[tuple[str, bool, str]]]:
-    """派生 `ALL_SOURCES` 字典结构（用于 `models.ALL_SOURCES`）。
-
-    返回格式：`{category: [(name, needs_config, description), ...]}`
-    category 仅包含 adapter 实际覆盖到的（空分类不会出现）。
-
-    fetch 特殊处理：主 domain=fetch 以及 extra_domains 含 fetch 的 adapter
-    都会出现在 fetch 列表里。
-
-    排除规则：adapter.tags 含 `v0_all_sources:exclude` 的源**不出现**在返回值中。
-    用于历史上未列入 ALL_SOURCES 的实验性/"待修复"源（unpaywall / patentsview / pqai），
-    这些源仍然保留在注册表里供未来启用。
-    """
-    result: dict[str, list[tuple[str, bool, str]]] = {}
-    for adapter in _REGISTRY.values():
-        if "v0_all_sources:exclude" in adapter.tags or adapter.catalog_visibility == "hidden":
-            continue
-        category = _v0_category_for(adapter)
-        if category is not None:
-            result.setdefault(category, []).append(
-                (adapter.name, adapter.resolved_needs_config, adapter.description)
-            )
-        # 跨域 fetch
-        if FETCH_DOMAIN in adapter.extra_domains and adapter.domain != FETCH_DOMAIN:
-            fetch_list = result.setdefault("fetch", [])
-            if not any(t[0] == adapter.name for t in fetch_list):
-                fetch_list.append(
-                    (adapter.name, adapter.resolved_needs_config, adapter.description)
-                )
-    # 稳定的 category 顺序
-    order = [
-        "paper",
-        "patent",
-        "general",
-        "professional",
-        "social",
-        "office",
-        "developer",
-        "wiki",
-        "cn_tech",
-        "video",
-        "fetch",
-    ]
-    return {k: result[k] for k in order if k in result}
-
-
 # ── 便于测试 / 脚本使用 ────────────────────────────────────
 
 
@@ -323,7 +221,6 @@ __all__ = [
     "fetch_providers",
     "high_risk_sources",
     "enum_values",
-    "as_all_sources_dict",
     "external_plugins",
 ]
 

--- a/src/souwen/server/routes/sources.py
+++ b/src/souwen/server/routes/sources.py
@@ -18,17 +18,33 @@ async def list_sources():
     确保前端搜索页只展示真正可用的通道。
     """
     from souwen.config import get_config
-    from souwen.registry import as_all_sources_dict
-    from souwen.registry.meta import get_source, has_required_credentials
+    from souwen.registry import all_adapters, public_source_catalog
+    from souwen.registry.adapter import FETCH_DOMAIN
+    from souwen.registry.meta import has_required_credentials
 
     cfg = get_config()
-    all_sources = as_all_sources_dict()
+
+    # TODO(PR6): /sources 公开 contract 切到正式 catalog key 后删除这层临时适配。
+    category_map = {
+        "paper": "paper",
+        "patent": "patent",
+        "web_general": "general",
+        "web_professional": "professional",
+        "social": "social",
+        "office": "office",
+        "developer": "developer",
+        "knowledge": "wiki",
+        "cn_tech": "cn_tech",
+        "video": "video",
+        "archive": "fetch",
+        "fetch": "fetch",
+    }
 
     def _source_item(name: str, meta) -> dict:
         return {
             "name": name,
             "needs_key": meta.needs_config,
-            "key_requirement": meta.key_requirement,
+            "key_requirement": meta.auth_requirement,
             "auth_requirement": meta.auth_requirement,
             "credential_fields": list(meta.credential_fields),
             "optional_credential_effect": meta.optional_credential_effect,
@@ -43,17 +59,23 @@ async def list_sources():
             "description": meta.description,
         }
 
+    def _append_visible_source(
+        result: dict[str, list[dict]], category: str, name: str, meta
+    ) -> None:
+        item = _source_item(name, meta)
+        if not any(existing["name"] == name for existing in result[category]):
+            result[category].append(item)
+
     result: dict[str, list[dict]] = {category: [] for category in SOURCE_CATEGORY_ORDER}
-    for category, entries in all_sources.items():
-        result.setdefault(category, [])
-        for name, _needs_key, _desc in entries:
-            # 单次查询 meta，避免 _is_usable 与 _source_item 的重复 dict 查找
-            meta = get_source(name)
-            if meta is None:
-                continue
-            if not cfg.is_source_enabled(name):
-                continue
-            if not has_required_credentials(cfg, name, meta):
-                continue
-            result[category].append(_source_item(name, meta))
+    adapters = all_adapters()
+    for name, meta in public_source_catalog().items():
+        if not cfg.is_source_enabled(name):
+            continue
+        if not has_required_credentials(cfg, name, meta):
+            continue
+        category = category_map[meta.category]
+        _append_visible_source(result, category, name, meta)
+        adapter = adapters.get(name)
+        if adapter is not None and FETCH_DOMAIN in adapter.extra_domains:
+            _append_visible_source(result, "fetch", name, meta)
     return result

--- a/src/souwen/server/schemas/common.py
+++ b/src/souwen/server/schemas/common.py
@@ -59,7 +59,7 @@ class SourceInfo(BaseModel):
 class SourcesResponse(BaseModel):
     """数据源列表响应 — 按类别分组
 
-    与 registry live 兼容视图的 11 个分类一一对应，/sources 端点
+    与当前 /sources 兼容响应的 11 个分类一一对应，/sources 端点
     会按类别返回当前可用（凭据满足）的数据源列表。
     """
 

--- a/tests/registry/test_catalog.py
+++ b/tests/registry/test_catalog.py
@@ -59,7 +59,7 @@ def test_every_adapter_projects_to_catalog_entry() -> None:
         assert entry.default_for == tuple(sorted(entry.default_for))
 
 
-def test_legacy_tags_project_to_formal_catalog_categories_and_visibility() -> None:
+def test_formal_fields_project_to_catalog_categories_and_visibility() -> None:
     catalog = source_catalog()
     assert catalog["duckduckgo"].category == "web_general"
     assert catalog["tavily"].category == "web_professional"

--- a/tests/registry/test_consistency.py
+++ b/tests/registry/test_consistency.py
@@ -11,7 +11,7 @@
   5. adapter.config_field 在 SouWenConfig.model_fields 里存在
   6. default_for 的每个 key 能解析为 (domain, capability) 且都合法
   7. 注册表没有重名
-  8. ALL_SOURCES 与 registry 的 v0 投影对齐（派生一致性）
+  8. SourceMeta 与正式 catalog 投影对齐
 
 补充断言（门面与数据流健壮性）：
   9. 默认源名在 registry 的同 domain 下可查
@@ -35,6 +35,7 @@ from souwen.registry import (
     enum_values,
     fetch_providers,
     high_risk_sources,
+    source_catalog,
 )
 from souwen.registry import external_plugins
 from souwen.registry.adapter import (
@@ -329,19 +330,21 @@ class TestD11HardAsserts:
                     f"adapter.domains={adapter.domains}"
                 )
 
-    def test_all_sources_matches_registry(self):
-        """D11-8：models.ALL_SOURCES 与 registry 视图派生一致。"""
-        from souwen.models import ALL_SOURCES
-        from souwen.registry import as_all_sources_dict
+    def test_source_meta_matches_catalog_projection(self):
+        """D11-8：SourceMeta 与正式 catalog 投影一致。"""
+        from souwen.registry import meta as source_meta
 
-        derived = as_all_sources_dict()
-        assert set(ALL_SOURCES.keys()) == set(derived.keys()), (
-            f"ALL_SOURCES 键集 {set(ALL_SOURCES.keys())} != 派生 {set(derived.keys())}"
-        )
-        for cat in derived:
-            got = sorted(ALL_SOURCES[cat])
-            expected = sorted(derived[cat])
-            assert got == expected, f"category={cat!r} 条目不一致"
+        catalog = source_catalog()
+        metadata = source_meta.get_all_sources()
+        assert set(metadata.keys()) == set(catalog.keys())
+        for name, entry in catalog.items():
+            meta = metadata[name]
+            assert meta.category == entry.category
+            assert meta.auth_requirement == entry.auth_requirement
+            assert meta.credential_fields == entry.credential_fields
+            assert meta.risk_level == entry.risk_level
+            assert meta.distribution == entry.distribution
+            assert meta.stability == entry.stability
 
 
 # ── 补充一致性检查 ─────────────────────────────────────────
@@ -593,8 +596,8 @@ class TestExternalPlugins:
         assert source_meta.is_known_source("ext_cache_probe") is False
         assert "ext_cache_probe" not in source_meta.ALL_SOURCE_NAMES
 
-    def test_external_web_plugin_without_internal_v0_tag_is_visible(self, clean_registry):
-        """外部 web 插件不应依赖内部 v0_category:* tag 才进入兼容视图。"""
+    def test_external_web_plugin_without_explicit_category_is_visible(self, clean_registry):
+        """外部 web 插件不声明 category 时仍进入 catalog。"""
         from souwen.registry import meta as source_meta
 
         adapter = SourceAdapter(
@@ -611,13 +614,13 @@ class TestExternalPlugins:
         assert _reg_external(adapter) is True
         meta = source_meta.get_source("ext_web_probe")
         assert meta is not None
-        assert meta.category == "general"
+        assert meta.category == "web_general"
         assert meta.distribution == "plugin"
         assert source_meta.is_known_source("ext_web_probe") is True
         assert "ext_web_probe" in source_meta.ALL_SOURCE_NAMES
 
     def test_external_web_plugin_can_use_public_professional_category_tag(self, clean_registry):
-        """外部 web 插件可用公开 category:* tag 选择 professional 分类。"""
+        """外部 web 插件可用公开 category:* tag 选择专业网页分类。"""
         from souwen.registry import meta as source_meta
 
         adapter = SourceAdapter(
@@ -636,4 +639,4 @@ class TestExternalPlugins:
         assert _reg_external(adapter) is True
         meta = source_meta.get_source("ext_professional_web_probe")
         assert meta is not None
-        assert meta.category == "professional"
+        assert meta.category == "web_professional"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -16,13 +16,13 @@ from typing import cast
 from souwen.doctor import check_all, format_report, summarize_statuses
 from souwen.core.exceptions import ConfigError
 from souwen.registry.adapter import MethodSpec, SourceAdapter
+from souwen.registry.catalog import source_catalog
 from souwen.registry.loader import lazy
 from souwen.registry.views import _reg_external
-from souwen.registry.meta import get_all_sources
 
 
 def register_runtime_web_doctor_probe() -> str:
-    """注册一个不带内部 v0_category:* tag 的外部 web 插件。"""
+    """注册一个不声明 category 的外部 web 插件。"""
     name = "doctor_web_probe"
     adapter = SourceAdapter(
         name=name,
@@ -74,20 +74,21 @@ class TestCheckAll:
         assert crossref["status"] == "ok"
 
     def test_categories_are_valid(self):
-        """所有 category 值在 8 类中"""
+        """所有 category 值在正式 catalog 分类中"""
         results = check_all()
         valid_cats = {
             "paper",
             "patent",
-            "general",
-            "professional",
+            "web_general",
+            "web_professional",
             "social",
+            "office",
             "developer",
-            "wiki",
+            "knowledge",
             "video",
+            "archive",
             "fetch",
             "cn_tech",
-            "office",
         }
         for r in results:
             assert r["category"] in valid_cats
@@ -129,7 +130,7 @@ class TestCheckAll:
 
     def test_source_config_matches_37(self):
         """source registry 有 92+ 个数据源（内置 + 外部插件）"""
-        assert len(get_all_sources()) >= 92
+        assert len(source_catalog()) >= 94
 
     def test_semantic_scholar_without_key_is_limited(self, monkeypatch):
         """Semantic Scholar 无 Key 时标记为 limited。"""
@@ -298,13 +299,13 @@ class TestCheckAll:
         assert status_counts["degraded"] == 1
         assert counts["failed"] == 2
 
-    def test_runtime_web_plugin_without_internal_v0_tag_is_visible(self, clean_registry):
-        """外部 web 插件应出现在 doctor 路径，不依赖内部 v0_category:* tag。"""
+    def test_runtime_web_plugin_without_explicit_category_is_visible(self, clean_registry):
+        """外部 web 插件应出现在 doctor 路径。"""
         name = register_runtime_web_doctor_probe()
 
         results = check_all()
         source = next(r for r in results if r["name"] == name)
-        assert source["category"] == "general"
+        assert source["category"] == "web_general"
         assert source["distribution"] == "plugin"
         assert source["status"] in {"ok", "warning"}
 

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -528,27 +528,32 @@ class TestCLI:
         assert "已配置" in short_masked
         assert "ab" not in short_masked
 
-    def test_cli_all_sources_data(self):
-        """数据源清单完整性（v1 从 registry 派生）
+    def test_cli_source_catalog_data(self):
+        """数据源清单完整性。"""
+        from souwen.registry.catalog import public_source_catalog
 
-        注意：v0 的 `ALL_SOURCES` 与 `source_meta` 之间存在漂移
-        （bing_cn / ddg_news / ddg_images / ddg_videos / metaso / twitter / facebook
-        在 source_meta 登记但 ALL_SOURCES 漏列）。
-        v1 统一由 registry 派生，修复漂移；因此 general/social 数字比 v0 更高。
-        """
-        from souwen.models import ALL_SOURCES
+        catalog = public_source_catalog()
+        counts: dict[str, int] = {}
+        for entry in catalog.values():
+            counts[entry.category] = counts.get(entry.category, 0) + 1
 
-        assert len(ALL_SOURCES["paper"]) == 18
-        assert len(ALL_SOURCES["patent"]) == 6
+        assert counts["paper"] == 18
+        assert counts["patent"] == 6
         total_web = sum(
-            len(ALL_SOURCES[c])
-            for c in ("general", "professional", "social", "developer", "wiki", "video")
+            counts[c]
+            for c in (
+                "web_general",
+                "web_professional",
+                "social",
+                "developer",
+                "knowledge",
+                "video",
+            )
         )
-        # v0 期望 31；v1 修复漂移后为 39
         assert total_web == 39
-        assert len(ALL_SOURCES["fetch"]) >= 21  # 21 内置 + 可能有外部插件
-        # cn_tech 拆分后独立源
-        assert len(ALL_SOURCES["cn_tech"]) == 9
+        assert counts["fetch"] == 17
+        assert counts["archive"] == 1
+        assert counts["cn_tech"] == 9
 
 
 class TestServer:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,11 +1,11 @@
 """SouWen 数据模型边界测试。
 
 覆盖 ``souwen.models`` 中数据模型的完整性、字段约束、枚举值。
-验证 ALL_SOURCES 元数据、SourceType 枚举完整性、extra='forbid' 验证、
+验证 source catalog 元数据、SourceType 枚举完整性、extra='forbid' 验证、
 WebSearchResult 必要字段等不变量。
 
 测试清单：
-- ``TestAllSources``：ALL_SOURCES 字典结构、计数、论文/专利/Web 源统计
+- ``TestSourceCatalog``：catalog 字典结构、计数、论文/专利/Web 源统计
 - ``TestSourceTypeEnum``：SourceType 枚举值完整性、各源名称
 - ``TestExtraForbid``：拒绝未知字段
 - ``TestWebSearchResult``：必要字段校验、snippet 默认值
@@ -15,70 +15,76 @@ import pytest
 from pydantic import ValidationError
 
 from souwen.models import (
-    ALL_SOURCES,
     PaperResult,
     PatentResult,
     SearchResponse,
     SourceType,
     WebSearchResult,
 )
+from souwen.registry.catalog import public_source_catalog
 
 
-class TestAllSources:
-    """ALL_SOURCES 元信息测试"""
+class TestSourceCatalog:
+    """source catalog 元信息测试"""
 
     def test_paper_count(self):
         """paper 暴露 18 个搜索数据源"""
-        assert len(ALL_SOURCES["paper"]) == 18
+        catalog = public_source_catalog()
+        assert sum(1 for entry in catalog.values() if entry.category == "paper") == 18
 
     def test_patent_count(self):
         """patent 暴露 6 个搜索数据源"""
-        assert len(ALL_SOURCES["patent"]) == 6
+        catalog = public_source_catalog()
+        assert sum(1 for entry in catalog.values() if entry.category == "patent") == 6
 
     def test_web_count(self):
-        """web-derived categories have correct source counts（v1 从 registry 派生）
-
-        v0 的 ALL_SOURCES 漏列了 source_meta 已登记的 bing_cn / ddg_news /
-        ddg_images / ddg_videos / metaso / twitter / facebook。v1 统一从 registry
-        派生，修复漂移；因此 general/social 数字比 v0 更高。
-        """
-        assert len(ALL_SOURCES["general"]) == 21  # v0: 16
-        assert len(ALL_SOURCES["professional"]) == 8
-        assert len(ALL_SOURCES["social"]) == 5  # v0: 3
-        assert len(ALL_SOURCES["developer"]) == 2
-        assert len(ALL_SOURCES["wiki"]) == 1
-        assert len(ALL_SOURCES["video"]) == 2
+        """web-derived categories have correct source counts."""
+        catalog = public_source_catalog()
+        counts: dict[str, int] = {}
+        for entry in catalog.values():
+            counts[entry.category] = counts.get(entry.category, 0) + 1
+        assert counts["web_general"] == 21
+        assert counts["web_professional"] == 8
+        assert counts["social"] == 5
+        assert counts["developer"] == 2
+        assert counts["knowledge"] == 1
+        assert counts["video"] == 2
         # cn_tech 拆分后独立源
-        assert len(ALL_SOURCES["cn_tech"]) == 9
+        assert counts["cn_tech"] == 9
 
     def test_total_count(self):
         """总计暴露的数据源数量（含可能的外部插件）。"""
-        total = sum(len(v) for v in ALL_SOURCES.values())
-        assert total >= 91  # v0: 73, v1 内置: 91, 外部插件可增加
+        assert len(public_source_catalog()) >= 91
 
-    def test_each_entry_is_tuple_of_three(self):
-        """每条目是 (name, requires_key, desc) 三元组"""
-        for category, sources in ALL_SOURCES.items():
-            for entry in sources:
-                assert len(entry) == 3, f"{category}: {entry}"
-                assert isinstance(entry[0], str)
-                assert isinstance(entry[1], bool)
-                assert isinstance(entry[2], str)
+    def test_each_entry_has_display_fields(self):
+        """每条目包含展示所需字段。"""
+        for name, entry in public_source_catalog().items():
+            assert entry.name == name
+            assert isinstance(entry.needs_config, bool)
+            assert entry.description
 
     def test_search_only_exposes_supported_paper_sources(self):
         """paper 搜索列表不再暴露 unpaywall。"""
-        names = {name for name, _, _ in ALL_SOURCES["paper"]}
+        names = {
+            name for name, entry in public_source_catalog().items() if entry.category == "paper"
+        }
         assert "unpaywall" not in names
 
     def test_patent_search_hides_known_broken_free_defaults(self):
         """patent 搜索列表不再默认暴露已失效免费源。"""
-        names = {name for name, _, _ in ALL_SOURCES["patent"]}
+        names = {
+            name for name, entry in public_source_catalog().items() if entry.category == "patent"
+        }
         assert "patentsview" not in names
         assert "pqai" not in names
 
     def test_self_hosted_web_sources_require_setup(self):
         """自建 Web 引擎在清单中标记为需要配置。"""
-        needs_key = {name: required for name, required, _ in ALL_SOURCES["general"]}
+        needs_key = {
+            name: entry.needs_config
+            for name, entry in public_source_catalog().items()
+            if entry.category == "web_general"
+        }
         assert needs_key["searxng"] is True
         assert needs_key["whoogle"] is True
         assert needs_key["websurfx"] is True

--- a/tests/test_server/test_app.py
+++ b/tests/test_server/test_app.py
@@ -195,12 +195,12 @@ class TestAdminAuth:
         assert data["failed"] == 2
         assert data["status_counts"]["limited"] == 1
 
-    def test_admin_doctor_keeps_runtime_web_plugin_without_internal_v0_tag(
+    def test_admin_doctor_keeps_runtime_web_plugin_without_explicit_category(
         self,
         authed_client,
         clean_registry,
     ):
-        """admin doctor 应返回不带内部 v0_category:* tag 的外部 web 插件。"""
+        """admin doctor 应返回不声明 category 的外部 web 插件。"""
         from tests.test_doctor import register_runtime_web_doctor_probe
 
         name = register_runtime_web_doctor_probe()
@@ -210,7 +210,7 @@ class TestAdminAuth:
         )
         assert resp.status_code == 200
         sources = {item["name"]: item for item in resp.json()["sources"]}
-        assert sources[name]["category"] == "general"
+        assert sources[name]["category"] == "web_general"
         assert sources[name]["distribution"] == "plugin"
 
     def test_admin_sources_config_includes_catalog_fields(self, authed_client):
@@ -507,8 +507,10 @@ class TestSearchAuth:
             item["name"] for entries in data.values() for item in entries
         }
 
-    def test_sources_keeps_runtime_web_plugin_without_internal_v0_tag(self, client, clean_registry):
-        """外部 web 插件不应因缺少内部 v0_category:* tag 从 /sources 消失。"""
+    def test_sources_keeps_runtime_web_plugin_without_explicit_category(
+        self, client, clean_registry
+    ):
+        """外部 web 插件不应因缺少 category 声明从 /sources 消失。"""
         from souwen.registry.adapter import MethodSpec, SourceAdapter
         from souwen.registry.loader import lazy
         from souwen.registry.views import _reg_external


### PR DESCRIPTION
## 背景

PR 1 已建立正式 `Source Catalog` 投影，但运行时代码里仍保留旧清单派生和内部 `v0_*` 标签兼容路径。本 PR 按 revised plan 的 PR 2 边界推进：把正式代码路径切到 catalog，不改变 `/api/v1/sources` 当前公开响应 shape。

## 变更

- 移除 `models.ALL_SOURCES`、`registry.views.as_all_sources_dict()` 和旧分类投影函数。
- 将内置源声明里的旧分类/隐藏标签改为 `category` 与 `catalog_visibility` 正式字段。
- 扩展 `SourceCatalogEntry` 的运行时展示字段，让 doctor、CLI、SourceMeta 与 `/sources` 可以从 catalog 投影读取。
- `/api/v1/sources` 保留现有 `general/professional/wiki/fetch` 兼容响应结构，但改由 catalog 临时适配生成，并保留 PR 6 TODO。
- 新增 `scripts/ci/check_no_legacy_terms.py`，并接入 V2 CI bootstrap，防止旧 catalog 术语回流正式文件。
- 更新 registry、doctor、server、infra/model 测试，以及相关文档和 Panel 注释，避免继续把旧清单当事实源。

## 验证

- `python3 scripts/ci/check_no_legacy_terms.py`
- `PYTHONPATH=src SOUWEN_PLUGIN_AUTOLOAD=0 pytest tests/registry/test_catalog.py tests/registry/test_consistency.py tests/test_models.py tests/test_doctor.py tests/test_server/test_app.py tests/test_infra.py -q`
- `PYTHONPATH=src SOUWEN_PLUGIN_AUTOLOAD=0 python3 tools/gen_docs.py --check`
- `ruff check src tests scripts tools`
- `ruff format --check src tests scripts tools`
- `PYTHONPATH=src SOUWEN_PLUGIN_AUTOLOAD=0 pytest -q`
- `npm run --prefix panel test`
- `npm run --prefix panel build`
- `git diff --check`
