### PR TITLE
feat(v2): 显式化插件加载 bootstrap

### DIFF
--- a/docs/adding-a-source.md
+++ b/docs/adding-a-source.md
@@ -259,7 +259,8 @@ curl 'http://localhost:8000/api/v1/search/paper?q=transformer&sources=my_source&
 ## 7. 替代方案：作为外部插件发布
 
 如果数据源不打算合入主仓（私有、实验性或商业插件），可以作为独立 Python 包发布。
-SouWen 通过 setuptools entry_points 或配置文件自动发现外部插件。
+SouWen CLI / server 启动时通过 `ensure_plugins_loaded(get_config())` 显式加载
+setuptools entry_points 或配置文件声明的外部插件。
 
 完整对接规范见 [plugin-integration-spec.md](./plugin-integration-spec.md)。
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -224,21 +224,22 @@ client_cls = adapter.client_loader()  # 此刻才 importlib.import_module
 
 Docker 镜像示例：`pip install ".[server,tls,web2pdf]"`。
 两种模式都依赖同一个 `[project.entry-points."souwen.plugins"]` 声明，
-SouWen 启动时统一通过 `importlib.metadata` 扫描发现。
+CLI / server 启动时通过 `ensure_plugins_loaded(get_config())` 显式扫描发现。
+单纯 `import souwen.registry` 只注册内置源，不执行第三方 entry point。
 
 ### 加载流程
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│  registry/__init__.py 导入                                       │
+│  CLI / server bootstrap                                          │
 │      ↓                                                           │
-│  1. import sources       —— 触发 94 个内置 _reg()，填满 _REGISTRY │
+│  1. import souwen.registry —— 触发 94 个内置 _reg()，填满 _REGISTRY │
 │      ↓                                                           │
-│  2. plugin.load_plugins()                                        │
+│  2. plugin.ensure_plugins_loaded(get_config())                    │
 │       ├─ discover_entrypoint_plugins()                           │
 │       │     扫描 importlib.metadata entry_points(group=          │
-│       │     "souwen.plugins")，逐个 ep.load() → _coerce_to_     │
-│       │     adapters() → _reg_external()                         │
+│       │     "souwen.plugins")，逐个 ep.load() → _coerce_to_       │
+│       │     plugin() → _reg_external()                            │
 │       └─ load_config_plugins(config.plugins)                     │
 │             解析 "module:attr" 字符串列表，同上                  │
 │      ↓                                                           │

--- a/docs/plugin-integration-spec.md
+++ b/docs/plugin-integration-spec.md
@@ -59,8 +59,11 @@ my-source = "my_plugin:plugin"
 web2pdf = ["superweb2pdf[capture]>=0.2.0"]
 ```
 
-无论哪种模式，启动时 SouWen 都通过 `importlib.metadata.entry_points(group="souwen.plugins")`
-扫描发现。**插件作者通常只需声明 entry_points**，是否打包嵌入由宿主决定。
+无论哪种模式，SouWen 的 CLI / server bootstrap 都会调用
+`ensure_plugins_loaded(get_config())`，再通过
+`importlib.metadata.entry_points(group="souwen.plugins")` 扫描发现。
+**插件作者通常只需声明 entry_points**，是否打包嵌入由宿主决定。
+单纯 `import souwen.registry` 只注册内置源，不会执行第三方 entry point。
 
 ### Entry Point 目标可以是四种形态
 
@@ -74,11 +77,11 @@ web2pdf = ["superweb2pdf[capture]>=0.2.0"]
 ### 加载流程
 
 ```
-registry/__init__.py 导入
+CLI / server bootstrap
     ↓
-1. import sources       —— 触发内置 _reg()，填满 _REGISTRY
+1. import souwen.registry —— 触发内置 _reg()，填满 _REGISTRY
     ↓
-2. plugin.load_plugins(config)
+2. plugin.ensure_plugins_loaded(get_config())
     ├─ discover_entrypoint_plugins()
     │     扫描 importlib.metadata entry_points(group="souwen.plugins")
     └─ load_config_plugins(config.plugins + SOUWEN_PLUGINS)
@@ -448,10 +451,15 @@ export SOUWEN_PLUGINS='["my_plugin:plugin","other_pkg.mod:make_adapter"]'
 | `_reg_external` 字段类型不合法 | 抛 `TypeError`，被外层 catch 后记 warning |
 | Fetch handler 重名注册（`override=False`） | 记 warning，保留旧 handler |
 
-`load_plugins()` 返回值：
+`ensure_plugins_loaded()` 返回值：
 
 ```python
-{"loaded": ["my-source", "..."], "errors": [{"source": "...", "name": "...", "error": "..."}]}
+PluginLoadResult(
+    loaded_plugins=("my-plugin",),
+    loaded_adapters=("my-source",),
+    skipped=(),
+    errors=(PluginLoadError(source="...", name="...", error="..."),),
+)
 ```
 
 可在启动日志或 `/api/v1/plugins` 端点（如有）中暴露给运维。
@@ -641,7 +649,8 @@ def test_fetch_handler_registered():
 | `ENTRY_POINT_GROUP` | `"souwen.plugins"` | entry point 分组名 |
 | `discover_entrypoint_plugins(group=ENTRY_POINT_GROUP)` | `() -> (loaded, errors)` | 扫描 entry points 并注册 |
 | `load_config_plugins(plugin_paths)` | `(list[str]) -> (loaded, errors)` | 加载 `"module:attr"` 字符串列表 |
-| `load_plugins(config=None)` | `(SouWenConfig\|None) -> {"loaded": [...], "errors": [...]}` | 总入口（registry 启动时自动调用） |
+| `ensure_plugins_loaded(config=None)` | `(SouWenConfig\|None) -> PluginLoadResult` | CLI / server / library 显式插件 bootstrap，幂等 |
+| `load_plugins(config=None)` | `(SouWenConfig\|None) -> {"loaded": [...], "errors": [...]}` | 低层兼容入口，新代码优先用 `ensure_plugins_loaded()` |
 
 ### `souwen.config`
 

--- a/scripts/ci/run_profile.py
+++ b/scripts/ci/run_profile.py
@@ -45,7 +45,7 @@ FULL_IMPORT_CODE = "\n".join(
         "    JinaReaderClient, web_search, fetch_content,",
         ")",
         "from souwen.doctor import check_all",
-        "from souwen.plugin import discover_entrypoint_plugins, load_plugins",
+        "from souwen.plugin import discover_entrypoint_plugins, ensure_plugins_loaded",
         "from souwen.web.fetch import register_fetch_handler, get_fetch_handlers",
         "from souwen.registry.views import external_plugins",
         "print('all source, doctor, plugin and fetch handler imports OK')",
@@ -55,9 +55,9 @@ FULL_IMPORT_CODE = "\n".join(
 
 PLUGIN_DISCOVERY_CODE = "\n".join(
     [
-        "from souwen.plugin import load_plugins",
+        "from souwen.plugin import ensure_plugins_loaded",
         "from souwen.registry.views import external_plugins",
-        "load_plugins()",
+        "ensure_plugins_loaded()",
         "plugins = external_plugins()",
         "assert 'example_echo' in plugins, plugins",
         "print('example_echo plugin discovered')",

--- a/scripts/plugin_functional_check.py
+++ b/scripts/plugin_functional_check.py
@@ -65,9 +65,10 @@ def verify_example_distribution(*, require_installed: bool) -> tuple[str, dict[s
 
 
 def verify_example_contract() -> tuple[str, dict[str, object]]:
-    from souwen.plugin import get_loaded_plugins
+    from souwen.plugin import ensure_plugins_loaded, get_loaded_plugins
     from souwen.testing import assert_valid_plugin, validate_client_contract
 
+    ensure_plugins_loaded()
     plugin = get_loaded_plugins().get(EXAMPLE_PLUGIN)
     require(plugin is not None, f"{EXAMPLE_PLUGIN} plugin object not loaded")
 
@@ -89,11 +90,12 @@ def verify_example_contract() -> tuple[str, dict[str, object]]:
 
 
 def verify_entry_point_registry() -> tuple[str, dict[str, object]]:
-    from souwen.plugin import get_loaded_plugins
+    from souwen.plugin import ensure_plugins_loaded, get_loaded_plugins
     from souwen.plugin_manager import list_plugins
     from souwen.registry import all_adapters, external_plugins
     from souwen.web.fetch import get_fetch_handler_owners, get_fetch_handlers
 
+    ensure_plugins_loaded()
     external = set(external_plugins())
     adapters = all_adapters()
     handlers = get_fetch_handlers()
@@ -165,9 +167,10 @@ def verify_optional_web2pdf(*, require_installed: bool) -> tuple[str, dict[str, 
             details={"distribution": OPTIONAL_WEB2PDF_DISTRIBUTION},
         )
 
-    from souwen.plugin import get_loaded_plugins
+    from souwen.plugin import ensure_plugins_loaded, get_loaded_plugins
     from souwen.registry import external_plugins
 
+    ensure_plugins_loaded()
     external = set(external_plugins())
     loaded_plugins = get_loaded_plugins()
     require(

--- a/src/souwen/cli/__init__.py
+++ b/src/souwen/cli/__init__.py
@@ -41,6 +41,22 @@ app = typer.Typer(
 )
 
 
+def _bootstrap_plugins() -> None:
+    """Load runtime plugins for CLI command execution."""
+    try:
+        from souwen.config import get_config
+        from souwen.plugin import ensure_plugins_loaded
+
+        result = ensure_plugins_loaded(get_config())
+        if result.errors:
+            logging.getLogger("souwen.plugin").warning(
+                "CLI 插件加载完成，错误 %d 个",
+                len(result.errors),
+            )
+    except Exception as exc:  # noqa: BLE001
+        logging.getLogger("souwen.plugin").warning("CLI 插件 bootstrap 失败，已跳过: %s", exc)
+
+
 @app.callback()
 def main(
     version: bool = typer.Option(
@@ -79,6 +95,8 @@ def main(
     except Exception:
         logging.getLogger("souwen").setLevel(level)
 
+    _bootstrap_plugins()
+
 
 # ---------------------------------------------------------------------------
 # 子命令注册：导入各子模块（它们通过 `from souwen.cli import app` 使用主 app）
@@ -111,7 +129,15 @@ app.add_typer(plugins.plugins_app, name="plugins")
 # 兼容性导出：tests/test_infra.py 直接 `from souwen.cli import _mask_value`
 from souwen.cli.config_cmds import _mask_value  # noqa: E402, F401
 
-__all__ = ["app", "main", "console", "_run_async", "_version_callback", "_mask_value"]
+__all__ = [
+    "app",
+    "main",
+    "console",
+    "_run_async",
+    "_version_callback",
+    "_bootstrap_plugins",
+    "_mask_value",
+]
 
 
 if __name__ == "__main__":

--- a/src/souwen/cli/serve.py
+++ b/src/souwen/cli/serve.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import typer
 
-from souwen.cli import app
+from souwen.cli import _bootstrap_plugins, app
 from souwen.cli._common import console
 
 
@@ -29,6 +29,7 @@ def serve(
     from souwen.server.auth import is_admin_open_enabled
 
     cfg = get_config()
+    _bootstrap_plugins()
     console.print("[bold]━━━ SouWen 启动配置 ━━━[/bold]")
     # 访客密码状态
     v_pw = cfg.effective_visitor_password

--- a/src/souwen/plugin.py
+++ b/src/souwen/plugin.py
@@ -28,9 +28,9 @@ import importlib
 import inspect
 import logging
 import os
+import threading
 from collections.abc import Awaitable, Callable, Iterable
-from dataclasses import dataclass, field
-from dataclasses import asdict, is_dataclass
+from dataclasses import asdict, dataclass, field, is_dataclass
 from importlib import metadata
 from typing import TYPE_CHECKING, Any
 
@@ -87,6 +87,26 @@ class Plugin:
 
 #: 已加载的 Plugin 对象存储（plugin.name → Plugin）
 _PLUGINS: dict[str, Plugin] = {}
+_PLUGIN_LOAD_LOCK = threading.RLock()
+
+
+@dataclass(frozen=True, slots=True)
+class PluginLoadError:
+    """插件加载错误的稳定公共视图。"""
+
+    source: str
+    name: str
+    error: str
+
+
+@dataclass(frozen=True, slots=True)
+class PluginLoadResult:
+    """显式插件 bootstrap 的可观测结果。"""
+
+    loaded_plugins: tuple[str, ...]
+    loaded_adapters: tuple[str, ...]
+    skipped: tuple[str, ...]
+    errors: tuple[PluginLoadError, ...]
 
 
 def _coerce_to_adapters(obj: Any) -> list[SourceAdapter]:
@@ -245,8 +265,8 @@ def _inject_plugin_config(
 def _inject_config_into_loaded_plugins(config: SouWenConfig) -> list[str]:
     """Retroactively inject plugin_config into already-loaded entry-point plugins.
 
-    Called after config is available to bridge the gap between early plugin loading
-    (in ``registry/__init__``) and late config availability.
+    Called after config is available to bridge explicit plugin loading that may
+    have happened before the caller had a ``SouWenConfig`` object.
 
     Returns list of plugin names that received config.
     """
@@ -498,6 +518,56 @@ def get_loaded_plugins() -> dict[str, Plugin]:
     return dict(_PLUGINS)
 
 
+def _plugin_load_error_from_dict(raw: dict[str, str]) -> PluginLoadError:
+    return PluginLoadError(
+        source=str(raw.get("source", "")),
+        name=str(raw.get("name", "")),
+        error=str(raw.get("error", "")),
+    )
+
+
+def _collect_plugin_skip_names(*, include_loaded: bool) -> tuple[set[str], list[str]]:
+    """Collect disabled/denylisted plugin names for one load attempt.
+
+    ``include_loaded`` is used by the explicit bootstrap path so repeated calls
+    can skip already loaded entry points before ``ep.load()`` runs.
+    """
+    skip_names: set[str] = set()
+    skipped: list[str] = []
+
+    if include_loaded and _PLUGINS:
+        loaded_plugin_names = sorted(_PLUGINS)
+        skip_names.update(loaded_plugin_names)
+        skipped.extend(loaded_plugin_names)
+
+    try:
+        from souwen.plugin_manager import _load_state
+
+        disabled = {
+            name
+            for name in _load_state().get("disabled_plugins", [])
+            if isinstance(name, str) and name.strip()
+        }
+        if disabled:
+            skip_names.update(disabled)
+            skipped.extend(sorted(disabled))
+            logger.info("插件禁用列表: %s", ", ".join(sorted(disabled)))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("读取插件禁用列表失败，将加载所有未显式跳过的插件: %s", exc)
+
+    denylist = {
+        name.strip()
+        for name in os.environ.get("SOUWEN_PLUGIN_DENYLIST", "").split(",")
+        if name.strip()
+    }
+    if denylist:
+        skip_names.update(denylist)
+        skipped.extend(sorted(denylist))
+        logger.info("插件环境拒绝列表: %s", ", ".join(sorted(denylist)))
+
+    return skip_names, sorted(set(skipped))
+
+
 def _resolve_dotted_path(path: str) -> Any:
     """解析 `"module.path:attribute"` 字符串为 Python 对象。"""
     if ":" not in path:
@@ -541,6 +611,7 @@ def discover_entrypoint_plugins(
         candidates = list(eps.select(group=group))
     else:  # pragma: no cover — 兼容老接口
         candidates = list(eps.get(group, []))  # type: ignore[union-attr]
+    candidates.sort(key=lambda ep: getattr(ep, "name", ""))
 
     for ep in candidates:
         ep_name = getattr(ep, "name", "<unknown>")
@@ -704,42 +775,14 @@ def load_config_plugins(
     return loaded, errors
 
 
-def load_plugins(config: SouWenConfig | None = None) -> dict[str, Any]:
-    """加载所有插件（entry points + 配置文件指定）。
-
-    这是面向 `souwen.registry` 的统一入口，应该在内置源注册完成后调用。
-    自动读取插件禁用列表，跳过已禁用的插件。
-
-    Args:
-        config: 可选的 `SouWenConfig`。提供则会读取其 `plugins` 字段。
-            为 None 时只做 entry points 发现，避免在 registry 初始化期间
-            循环导入 config 模块。
-
-    Returns:
-        ``{"loaded": [...名称], "errors": [...]}``。即使全部失败也不抛异常。
-    """
+def _load_plugins_with_skip(
+    config: SouWenConfig | None,
+    *,
+    skip_names: set[str],
+) -> dict[str, Any]:
+    """Load plugins using caller-provided skip names."""
     all_loaded: list[str] = []
     all_errors: list[dict[str, str]] = []
-
-    # 读取插件禁用列表（函数级 import 避免循环依赖）
-    skip_names: set[str] = set()
-    try:
-        from souwen.plugin_manager import _load_state
-
-        skip_names = set(_load_state().get("disabled_plugins", []))
-        if skip_names:
-            logger.info("插件禁用列表: %s", ", ".join(sorted(skip_names)))
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("读取插件禁用列表失败，将加载所有插件: %s", exc)
-
-    denylist = {
-        name.strip()
-        for name in os.environ.get("SOUWEN_PLUGIN_DENYLIST", "").split(",")
-        if name.strip()
-    }
-    if denylist:
-        skip_names.update(denylist)
-        logger.info("插件环境拒绝列表: %s", ", ".join(sorted(denylist)))
 
     autoload = os.environ.get("SOUWEN_PLUGIN_AUTOLOAD", "1").lower()
     if autoload in {"0", "false"}:
@@ -778,12 +821,57 @@ def load_plugins(config: SouWenConfig | None = None) -> dict[str, Any]:
     return {"loaded": all_loaded, "errors": all_errors}
 
 
+def load_plugins(config: SouWenConfig | None = None) -> dict[str, Any]:
+    """加载所有插件（entry points + 配置文件指定）。
+
+    这是保留的低层兼容入口。新启动路径应优先使用
+    :func:`ensure_plugins_loaded`，以获得幂等保护和结构化结果。
+
+    Args:
+        config: 可选的 `SouWenConfig`。提供则会读取其 `plugins` 字段。
+
+    Returns:
+        ``{"loaded": [...名称], "errors": [...]}``。即使全部失败也不抛异常。
+    """
+    skip_names, _skipped = _collect_plugin_skip_names(include_loaded=False)
+    return _load_plugins_with_skip(config, skip_names=skip_names)
+
+
+def ensure_plugins_loaded(config: SouWenConfig | None = None) -> PluginLoadResult:
+    """显式加载运行时插件，并保证重复调用不会重复执行已加载插件入口。
+
+    该函数是 CLI、server 和需要插件能力的 library 用户的公共 bootstrap
+    入口。它尊重 ``SOUWEN_PLUGIN_AUTOLOAD=0``，此时不会扫描 entry points，
+    但仍允许 ``config.plugins`` 中显式列出的配置插件加载。
+    """
+    with _PLUGIN_LOAD_LOCK:
+        before_plugins = set(_PLUGINS)
+        skip_names, skipped = _collect_plugin_skip_names(include_loaded=True)
+        raw_result = _load_plugins_with_skip(config, skip_names=skip_names)
+        loaded_plugins = tuple(name for name in sorted(_PLUGINS) if name not in before_plugins)
+        loaded_adapters = tuple(str(name) for name in raw_result.get("loaded", []))
+        errors = tuple(
+            _plugin_load_error_from_dict(error)
+            for error in raw_result.get("errors", [])
+            if isinstance(error, dict)
+        )
+        return PluginLoadResult(
+            loaded_plugins=loaded_plugins,
+            loaded_adapters=loaded_adapters,
+            skipped=tuple(skipped),
+            errors=errors,
+        )
+
+
 __all__ = [
     "ENTRY_POINT_GROUP",
     "HealthCheck",
     "LifecycleHook",
     "Plugin",
+    "PluginLoadError",
+    "PluginLoadResult",
     "discover_entrypoint_plugins",
+    "ensure_plugins_loaded",
     "get_loaded_plugins",
     "load_config_plugins",
     "load_plugins",

--- a/src/souwen/plugin_manager.py
+++ b/src/souwen/plugin_manager.py
@@ -27,7 +27,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from souwen.plugin import (
-    discover_entrypoint_plugins,
+    ensure_plugins_loaded,
     get_loaded_plugins,
     unload_plugin,
     unload_plugin_async,
@@ -875,10 +875,17 @@ def reload_plugins() -> dict[str, Any]:
         importlib.invalidate_caches()
         state = _load_state()
         skip_names = set(state.get("disabled_plugins", []))
-        loaded, errors = discover_entrypoint_plugins(skip_names=skip_names)
+        result = ensure_plugins_loaded()
+        loaded = list(result.loaded_adapters)
+        errors = [
+            {"source": error.source, "name": error.name, "error": error.error}
+            for error in result.errors
+        ]
         message = f"插件重新扫描完成，新增加载 {len(loaded)} 个，错误 {len(errors)} 个。"
         if skip_names:
             message += f" 已跳过禁用插件: {', '.join(sorted(skip_names))}。"
+        if result.skipped:
+            message += f" 本次跳过: {', '.join(result.skipped)}。"
         return {"loaded": loaded, "errors": errors, "message": message}
     except Exception as exc:  # noqa: BLE001
         logger.warning("重新扫描插件失败: %s", exc)

--- a/src/souwen/registry/__init__.py
+++ b/src/souwen/registry/__init__.py
@@ -69,18 +69,6 @@ from souwen.registry.views import (
 # 这一步**必须**在所有视图符号 import 之后，因为 sources package 里会调用 views._reg。
 from souwen.registry import sources as _sources  # noqa: F401,E402
 
-# 内置源注册完毕后加载外部插件（entry points + 配置文件指定）。
-# 注意：此处不传 config，避免在 registry 初始化期间触发 config 模块导入循环；
-# 配置文件里 plugins: 字段由 souwen.config 在加载完成后通过 load_plugins(config) 触发。
-try:
-    from souwen.plugin import load_plugins as _load_plugins  # noqa: E402
-
-    _load_plugins()
-except Exception as _exc:  # noqa: BLE001
-    import logging as _logging
-
-    _logging.getLogger("souwen.plugin").warning("插件系统初始化失败,已跳过: %s", _exc)
-
 __all__ = [
     # 常量与数据类
     "SourceAdapter",

--- a/src/souwen/server/app.py
+++ b/src/souwen/server/app.py
@@ -83,7 +83,7 @@ from starlette.middleware.gzip import GZipMiddleware
 from souwen import __version__
 from souwen.config import ensure_config_file, get_config
 from souwen.logging_config import setup_logging
-from souwen.plugin import get_loaded_plugins
+from souwen.plugin import ensure_plugins_loaded, get_loaded_plugins
 from souwen.server.auth import is_admin_open_enabled
 from souwen.server.middleware import RequestIDMiddleware, get_request_id
 from souwen.server.routes import router, admin_router
@@ -129,6 +129,13 @@ async def _call_plugin_lifecycle_hooks(hook_name: str) -> None:
             _current_plugin_owner.reset(token)
 
 
+def _bootstrap_plugins(cfg) -> None:
+    """Load runtime plugins before server lifecycle hooks run."""
+    result = ensure_plugins_loaded(cfg)
+    if result.errors:
+        logger.warning("Server 插件加载完成，错误 %d 个", len(result.errors))
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """FastAPI 应用生命周期管理（启动和关闭 hooks）
@@ -150,6 +157,7 @@ async def lifespan(app: FastAPI):
     if path:
         logger.info("配置文件: %s", path)
     cfg = get_config()
+    _bootstrap_plugins(cfg)
     admin_pw = cfg.effective_admin_password
     user_pw = cfg.effective_user_password
     auth_parts = []

--- a/tests/test_import_surface.py
+++ b/tests/test_import_surface.py
@@ -1,6 +1,10 @@
 """v2 public import surface tests."""
 
 import importlib
+import os
+import subprocess
+import sys
+from pathlib import Path
 
 import pytest
 
@@ -23,6 +27,82 @@ def test_new_public_import_surface():
     assert SouWenHttpClient.__name__ == "SouWenHttpClient"
     assert BaseScraper.__name__ == "BaseScraper"
     assert WaybackClient.__name__ == "WaybackClient"
+
+
+def test_import_registry_does_not_scan_plugin_entry_points():
+    """`import souwen.registry` must not execute third-party plugin discovery."""
+    repo_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo_root / "src")
+    env["SOUWEN_PLUGIN_AUTOLOAD"] = "1"
+    code = """
+import importlib.metadata as metadata
+
+calls = 0
+
+def fake_entry_points():
+    global calls
+    calls += 1
+    raise AssertionError("entry_points should not be called")
+
+metadata.entry_points = fake_entry_points
+import souwen.registry
+assert calls == 0, calls
+print("registry import ok")
+"""
+
+    completed = subprocess.run(
+        [sys.executable, "-c", code],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_cli_bootstrap_calls_explicit_plugin_loader(monkeypatch):
+    from souwen.plugin import PluginLoadResult
+
+    import souwen.cli as cli_mod
+
+    cfg = object()
+    calls = []
+    monkeypatch.setattr("souwen.config.get_config", lambda: cfg)
+    monkeypatch.setattr(
+        "souwen.plugin.ensure_plugins_loaded",
+        lambda config: (
+            calls.append(config)
+            or PluginLoadResult(loaded_plugins=(), loaded_adapters=(), skipped=(), errors=())
+        ),
+    )
+
+    cli_mod._bootstrap_plugins()
+
+    assert calls == [cfg]
+
+
+def test_server_bootstrap_calls_explicit_plugin_loader(monkeypatch):
+    pytest.importorskip("fastapi")
+    from souwen.plugin import PluginLoadResult
+
+    from souwen.server import app as app_mod
+
+    cfg = object()
+    calls = []
+    monkeypatch.setattr(
+        app_mod,
+        "ensure_plugins_loaded",
+        lambda config: (
+            calls.append(config)
+            or PluginLoadResult(loaded_plugins=(), loaded_adapters=(), skipped=(), errors=())
+        ),
+    )
+
+    app_mod._bootstrap_plugins(cfg)
+
+    assert calls == [cfg]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -20,12 +20,15 @@ from pydantic import BaseModel
 
 from souwen.plugin import (
     Plugin,
+    PluginLoadError,
+    PluginLoadResult,
     _PLUGINS,
     _coerce_to_adapters,
     _coerce_to_plugin,
     _register_plugin,
     _resolve_dotted_path,
     discover_entrypoint_plugins,
+    ensure_plugins_loaded,
     get_loaded_plugins,
     load_config_plugins,
     load_plugins,
@@ -445,6 +448,114 @@ class TestLoadPlugins:
 
         assert result == {"loaded": [], "errors": []}
         assert captured == [{"ops_blocked", "adapter_blocked", "state_blocked"}]
+
+
+class TestEnsurePluginsLoaded:
+    def test_entry_point_returns_structured_result(
+        self, clean_registry, clean_plugins, monkeypatch
+    ):
+        monkeypatch.delenv("SOUWEN_PLUGIN_AUTOLOAD", raising=False)
+        monkeypatch.setattr(
+            "souwen.plugin_manager._load_state",
+            lambda: {"disabled_plugins": [], "installed_via_api": []},
+        )
+        eps = _FakeEntryPoints(
+            [_FakeEntryPoint("structured_ep", lambda: make_test_adapter("structured_adapter"))]
+        )
+        monkeypatch.setattr("souwen.plugin.metadata.entry_points", lambda: eps)
+
+        result = ensure_plugins_loaded()
+
+        assert isinstance(result, PluginLoadResult)
+        assert result.loaded_plugins == ("structured_ep",)
+        assert result.loaded_adapters == ("structured_adapter",)
+        assert result.skipped == ()
+        assert result.errors == ()
+
+    def test_idempotent_call_skips_loaded_entry_point_before_load(
+        self, clean_registry, clean_plugins, clean_fetch_handlers, monkeypatch
+    ):
+        monkeypatch.delenv("SOUWEN_PLUGIN_AUTOLOAD", raising=False)
+        monkeypatch.setattr(
+            "souwen.plugin_manager._load_state",
+            lambda: {"disabled_plugins": [], "installed_via_api": []},
+        )
+        load_count: list[str] = []
+
+        async def fake_handler(*_args, **_kwargs):
+            return None
+
+        def loader():
+            load_count.append("called")
+            register_fetch_handler("idempotent_adapter", fake_handler)
+            return make_test_adapter("idempotent_adapter")
+
+        monkeypatch.setattr(
+            "souwen.plugin.metadata.entry_points",
+            lambda: _FakeEntryPoints([_FakeEntryPoint("idempotent_ep", loader)]),
+        )
+
+        first = ensure_plugins_loaded()
+        second = ensure_plugins_loaded()
+
+        assert first.loaded_plugins == ("idempotent_ep",)
+        assert first.loaded_adapters == ("idempotent_adapter",)
+        assert second.loaded_plugins == ()
+        assert second.loaded_adapters == ()
+        assert "idempotent_ep" in second.skipped
+        assert load_count == ["called"]
+        assert get_fetch_handler_owners()["idempotent_adapter"] == "idempotent_ep"
+
+    def test_autoload_zero_never_scans_entry_points_but_allows_config_plugins(
+        self, clean_registry, clean_plugins, monkeypatch
+    ):
+        monkeypatch.setenv("SOUWEN_PLUGIN_AUTOLOAD", "0")
+        monkeypatch.setattr(
+            "souwen.plugin.metadata.entry_points",
+            lambda: pytest.fail("entry point scan should stay disabled"),
+        )
+        monkeypatch.setattr(
+            "souwen.plugin_manager._load_state",
+            lambda: {"disabled_plugins": [], "installed_via_api": []},
+        )
+        adapter = make_test_adapter("explicit_cfg_adapter")
+        import souwen.plugin as plugin_mod
+
+        monkeypatch.setattr(
+            plugin_mod, "_test_explicit_cfg_factory", lambda: adapter, raising=False
+        )
+
+        class FakeConfig:
+            plugins = ["souwen.plugin:_test_explicit_cfg_factory"]
+
+        result = ensure_plugins_loaded(FakeConfig())
+
+        assert result.loaded_plugins == ("souwen.plugin:_test_explicit_cfg_factory",)
+        assert result.loaded_adapters == ("explicit_cfg_adapter",)
+        assert result.errors == ()
+
+    def test_errors_are_returned_as_dataclasses(self, clean_registry, clean_plugins, monkeypatch):
+        monkeypatch.delenv("SOUWEN_PLUGIN_AUTOLOAD", raising=False)
+        monkeypatch.setattr(
+            "souwen.plugin_manager._load_state",
+            lambda: {"disabled_plugins": [], "installed_via_api": []},
+        )
+
+        def boom():
+            raise RuntimeError("broken plugin")
+
+        monkeypatch.setattr(
+            "souwen.plugin.metadata.entry_points",
+            lambda: _FakeEntryPoints([_FakeEntryPoint("broken_ep", boom)]),
+        )
+
+        result = ensure_plugins_loaded()
+
+        assert result.loaded_plugins == ()
+        assert len(result.errors) == 1
+        assert isinstance(result.errors[0], PluginLoadError)
+        assert result.errors[0].name == "broken_ep"
+        assert "broken plugin" in result.errors[0].error
 
 
 # ── 集成 / 状态清理 ────────────────────────────────────────

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -684,21 +684,28 @@ class TestInstallUninstall:
 
 
 class TestReloadPlugins:
-    def test_reload_plugins_calls_discover_entrypoint_plugins(
+    def test_reload_plugins_calls_explicit_loader(
         self,
         monkeypatch: pytest.MonkeyPatch,
         state_dir: Path,
     ) -> None:
+        from souwen.plugin import PluginLoadError, PluginLoadResult
+
         called = False
 
-        def fake_discover(
-            *, skip_names: set[str] | None = None
-        ) -> tuple[list[str], list[dict[str, str]]]:
+        def fake_ensure_plugins_loaded() -> PluginLoadResult:
             nonlocal called
             called = True
-            return ["alpha"], [{"source": "entry_points", "name": "broken", "error": "boom"}]
+            return PluginLoadResult(
+                loaded_plugins=("alpha_plugin",),
+                loaded_adapters=("alpha",),
+                skipped=(),
+                errors=(PluginLoadError("entry_points", "broken", "boom"),),
+            )
 
-        monkeypatch.setattr("souwen.plugin_manager.discover_entrypoint_plugins", fake_discover)
+        monkeypatch.setattr(
+            "souwen.plugin_manager.ensure_plugins_loaded", fake_ensure_plugins_loaded
+        )
 
         result = reload_plugins()
 
@@ -713,21 +720,26 @@ class TestReloadPlugins:
         monkeypatch: pytest.MonkeyPatch,
         state_dir: Path,
     ) -> None:
+        from souwen.plugin import PluginLoadResult
+
         _save_state({"disabled_plugins": ["beta"], "installed_via_api": []})
-        captured_skip: set[str] | None = None
 
-        def fake_discover(
-            *, skip_names: set[str] | None = None
-        ) -> tuple[list[str], list[dict[str, str]]]:
-            nonlocal captured_skip
-            captured_skip = skip_names
-            return [], []
+        def fake_ensure_plugins_loaded() -> PluginLoadResult:
+            return PluginLoadResult(
+                loaded_plugins=(),
+                loaded_adapters=(),
+                skipped=("beta",),
+                errors=(),
+            )
 
-        monkeypatch.setattr("souwen.plugin_manager.discover_entrypoint_plugins", fake_discover)
+        monkeypatch.setattr(
+            "souwen.plugin_manager.ensure_plugins_loaded", fake_ensure_plugins_loaded
+        )
 
-        reload_plugins()
+        result = reload_plugins()
 
-        assert captured_skip == {"beta"}
+        assert "已跳过禁用插件: beta" in result["message"]
+        assert "本次跳过: beta" in result["message"]
 
 
 class TestRuntimeDisable:
@@ -1230,9 +1242,16 @@ class TestAPIEndpoints:
         state_dir: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        from souwen.plugin import PluginLoadResult
+
         monkeypatch.setattr(
-            "souwen.plugin_manager.discover_entrypoint_plugins",
-            lambda *, skip_names=None: (["alpha"], []),
+            "souwen.plugin_manager.ensure_plugins_loaded",
+            lambda: PluginLoadResult(
+                loaded_plugins=("alpha_plugin",),
+                loaded_adapters=("alpha",),
+                skipped=(),
+                errors=(),
+            ),
         )
 
         response = client.post("/plugins/reload")


### PR DESCRIPTION
## 背景

PR4 对应 v2 分步实践计划中的“插件加载显式化”。此前 `import souwen.registry` 会在导入期顺带执行第三方插件 entry point 发现，这会让 library import、registry 测试和后续 fetch 行为重构受到外部插件副作用影响。

## 改动

- 从 `src/souwen/registry/__init__.py` 移除 import-time `load_plugins()`，registry import 现在只注册内置源。
- 在 `src/souwen/plugin.py` 新增显式公共 bootstrap：`ensure_plugins_loaded(config=None)`，返回结构化 `PluginLoadResult` / `PluginLoadError`。
- `ensure_plugins_loaded()` 保持幂等：重复调用会把已加载 plugin 加入 skip names，避免再次执行同一个 entry point loader 或重复注册 fetch handler。
- 保留 `load_plugins(config=None)` 作为低层兼容入口，新启动路径统一转向 `ensure_plugins_loaded()`。
- CLI、`serve` 命令、FastAPI lifespan、plugin reload、CI profile、plugin functional check 改为显式调用插件 bootstrap。
- 同步插件文档，明确 library import 与 CLI/server 启动的行为差异。

## 验证

- `PYTHONPATH=src SOUWEN_PLUGIN_AUTOLOAD=1 pytest tests/test_plugin.py tests/test_plugin_manager.py tests/test_ci_profile_runner.py -q`
- `PYTHONPATH=src SOUWEN_PLUGIN_AUTOLOAD=0 pytest tests/registry/test_catalog.py tests/test_import_surface.py -q`
- `PYTHONPATH=src SOUWEN_PLUGIN_AUTOLOAD=0 pytest -q`
- `ruff format --check src tests scripts tools`
- `ruff check src tests scripts tools`
- `git diff --check`
- `PYTHONPATH=src SOUWEN_PLUGIN_AUTOLOAD=0 python3 tools/gen_docs.py --check`
- `PYTHONPATH=src SOUWEN_PLUGIN_AUTOLOAD=0 python3 scripts/ci/run_profile.py --profile minimal --profile server --profile full --profile plugin`
- `npm ci --prefix panel`
- `npm run --prefix panel test`
- `npm run --prefix panel build`

## 边界

- 本 PR 不修改 fetch fallback / fanout 语义。
- 本 PR 不修改 `/api/v1/sources` 响应形态。
