### PR TITLE
feat(v2): Fetch fallback 策略 + fanout 多 provider 返回

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -62,14 +62,15 @@ from souwen import search, search_papers, search_patents, web_search
 from souwen.web.fetch import fetch_content, validate_fetch_url
 ```
 
-#### `fetch_content(urls, providers=None, timeout=30.0, skip_ssrf_check=False, selector=None, start_index=0, max_length=None, respect_robots_txt=False)` → `FetchResponse`
+#### `fetch_content(urls, providers=None, strategy="fallback", timeout=30.0, skip_ssrf_check=False, selector=None, start_index=0, max_length=None, respect_robots_txt=False)` → `FetchResponse`
 
-并发内容抓取，支持 22 个提供者。
+多提供者内容抓取，支持 22 个提供者。默认 `fallback` 按 URL 补抓失败项；`fanout` 会并发执行所有 provider，并返回全部 provider 结果，适合质量对比和调试。
 
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `urls` | `list[str]` | — | 目标 URL 列表 |
 | `providers` | `list[str] \| None` | `["builtin"]` | 提供者: builtin / jina_reader / arxiv_fulltext / tavily / firecrawl / xcrawl / exa / crawl4ai / scrapling / scrapfly / diffbot / scrapingbee / zenrows / scraperapi / apify / cloudflare / wayback / newspaper / readability / mcp / site_crawler / deepwiki |
+| `strategy` | `"fallback" \| "fanout"` | `"fallback"` | 多 provider 策略：`fallback` 按 URL 顺序补失败项；`fanout` 返回所有 provider 结果 |
 | `timeout` | `float` | `30.0` | 每个 URL 超时秒数 |
 | `skip_ssrf_check` | `bool` | `False` | 跳过 SSRF 校验（仅内部使用） |
 | `selector` | `str \| None` | `None` | CSS 选择器，仅提取匹配元素（builtin / scrapling 支持） |
@@ -195,7 +196,9 @@ class FetchResponse(BaseModel):
     total: int = 0                              # 总数
     total_ok: int = 0                           # 成功数
     total_failed: int = 0                       # 失败数
-    provider: str = ""                          # 使用的提供者
+    providers: list[str] = []                   # 请求的提供者列表
+    strategy: str = "fallback"                  # 使用的抓取策略
+    provider: str | None = None                 # 兼容旧版单 provider 字段
     meta: dict = {}                             # 元数据
 ```
 
@@ -266,11 +269,13 @@ souwen doctor         # 检查所有数据源可用性
 
 ```bash
 # 抓取网页内容（默认 builtin，零配置）
-souwen fetch <urls...> [--provider/-p builtin] [--timeout/-t 30] [--json/-j]
+souwen fetch <urls...> [--provider/-p builtin] [--strategy fallback] [--timeout/-t 30] [--json/-j]
 
 # 示例
 souwen fetch https://example.com                      # 内置抓取
 souwen fetch https://a.com https://b.com -p jina_reader  # Jina Reader
+souwen fetch https://example.com -p builtin -p jina_reader --strategy fallback  # 逐 URL 补抓
+souwen fetch https://example.com -p builtin -p jina_reader --strategy fanout    # 多 provider 对比
 souwen fetch https://example.com --json               # JSON 输出
 ```
 
@@ -865,14 +870,16 @@ Cache-Control: public, max-age=3600
 
 #### `POST /api/v1/fetch`
 
-抓取网页内容，支持 22 个提供者。
+抓取网页内容，支持 22 个提供者。默认 `fallback` 按 URL 补抓失败项；`fanout` 会并发返回所有 provider 结果。
 
 **请求体 (JSON)：**
 
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `urls` | `list[str]` (1-20) | *(必填)* | 目标 URL 列表 |
-| `provider` | `string` | `"builtin"` | 提供者: `builtin` / `jina_reader` / `arxiv_fulltext` / `tavily` / `firecrawl` / `xcrawl` / `exa` / `crawl4ai` / `scrapling` / `scrapfly` / `diffbot` / `scrapingbee` / `zenrows` / `scraperapi` / `apify` / `cloudflare` / `wayback` / `newspaper` / `readability` / `mcp` / `site_crawler` / `deepwiki` |
+| `provider` | `string` | `"builtin"` | 兼容旧版单 provider 字段 |
+| `providers` | `list[str] \| null` | `null` | 多 provider 列表；提供时优先于 `provider`。可选：`builtin` / `jina_reader` / `arxiv_fulltext` / `tavily` / `firecrawl` / `xcrawl` / `exa` / `crawl4ai` / `scrapling` / `scrapfly` / `diffbot` / `scrapingbee` / `zenrows` / `scraperapi` / `apify` / `cloudflare` / `wayback` / `newspaper` / `readability` / `mcp` / `site_crawler` / `deepwiki` |
+| `strategy` | `"fallback" \| "fanout"` | `"fallback"` | 多 provider 策略：`fallback` 按 URL 顺序补失败项；`fanout` 返回所有 provider 结果 |
 | `timeout` | `float` (1-120) | `30` | 每 URL 超时秒数 |
 | `selector` | `string \| null` | `null` | CSS 选择器，仅提取匹配元素（builtin / scrapling 支持） |
 | `start_index` | `integer` (≥0) | `0` | 内容起始切片位置 |
@@ -883,7 +890,8 @@ Cache-Control: public, max-age=3600
 ```json
 {
   "urls": ["https://example.com/article"],
-  "provider": "builtin",
+  "providers": ["builtin", "jina_reader"],
+  "strategy": "fallback",
   "timeout": 30
 }
 ```
@@ -910,8 +918,20 @@ Cache-Control: public, max-age=3600
   "total": 1,
   "total_ok": 1,
   "total_failed": 0,
-  "provider": "builtin",
-  "meta": {}
+  "provider": null,
+  "providers": ["builtin", "jina_reader"],
+  "strategy": "fallback",
+  "meta": {
+    "strategy": "fallback",
+    "requested_providers": ["builtin", "jina_reader"],
+    "attempted": {
+      "https://example.com/article": ["builtin"]
+    },
+    "selected_provider": {
+      "https://example.com/article": "builtin"
+    },
+    "ssrf_blocked": 0
+  }
 }
 ```
 

--- a/src/souwen/cli/fetch.py
+++ b/src/souwen/cli/fetch.py
@@ -22,15 +22,37 @@ def _validate_fetch_provider(value: str) -> str:
     return value
 
 
+def _validate_fetch_providers(value: list[str] | None) -> list[str] | None:
+    """校验 CLI fetch provider 列表。"""
+    if value is None:
+        return None
+    for provider in value:
+        _validate_fetch_provider(provider)
+    return value
+
+
+def _validate_fetch_strategy(value: str) -> str:
+    """校验 CLI fetch strategy 选项。"""
+    if value not in {"fallback", "fanout"}:
+        raise typer.BadParameter(f"无效策略: {value}，可选: fallback, fanout")
+    return value
+
+
 @app.command("fetch")
 def fetch_cmd(
     urls: list[str] = typer.Argument(..., help="目标 URL（支持多个）"),
-    provider: str = typer.Option(
-        "builtin",
+    providers: list[str] | None = typer.Option(
+        None,
         "--provider",
         "-p",
-        callback=_validate_fetch_provider,
-        help=_FETCH_PROVIDER_HELP,
+        callback=_validate_fetch_providers,
+        help=_FETCH_PROVIDER_HELP + "；可重复传入，默认 builtin",
+    ),
+    strategy: str = typer.Option(
+        "fallback",
+        "--strategy",
+        callback=_validate_fetch_strategy,
+        help="多 provider 策略: fallback / fanout",
     ),
     selector: str = typer.Option(
         None, "--selector", "-s", help="CSS 选择器（builtin / scrapling 支持）"
@@ -47,7 +69,8 @@ def fetch_cmd(
     async def _do():
         return await fetch_content(
             urls=urls,
-            providers=[provider],
+            providers=providers or ["builtin"],
+            strategy=strategy,
             timeout=float(timeout),
             selector=selector,
             start_index=start_index,

--- a/src/souwen/models.py
+++ b/src/souwen/models.py
@@ -282,7 +282,9 @@ class FetchResponse(BaseModel):
     total: int = 0
     total_ok: int = 0
     total_failed: int = 0
-    provider: str = ""
+    providers: list[str] = Field(default_factory=list)
+    strategy: str = "fallback"
+    provider: str | None = None
     meta: dict = Field(default_factory=dict)
 
 

--- a/src/souwen/server/routes/fetch.py
+++ b/src/souwen/server/routes/fetch.py
@@ -19,11 +19,20 @@ def _valid_fetch_provider_names() -> frozenset[str]:
     return frozenset(adapter.name for adapter in fetch_providers())
 
 
-def _fetch_route_timeout(provider: str, url_count: int, timeout: float) -> float:
+def _fetch_route_timeout(
+    providers: str | list[str],
+    url_count: int,
+    timeout: float,
+    strategy: str = "fallback",
+) -> float:
     """HTTP route 外层超时应跟随 fetch 层 provider 级预算。"""
     from souwen.web.fetch import _get_provider_global_timeout
 
-    return _get_provider_global_timeout(provider, url_count, timeout) + 5
+    selected = [providers] if isinstance(providers, str) else providers
+    budgets = [_get_provider_global_timeout(provider, url_count, timeout) for provider in selected]
+    if strategy == "fanout":
+        return max(budgets, default=timeout + 10) + 5
+    return sum(budgets) + 5
 
 
 @router.post(
@@ -35,18 +44,31 @@ async def fetch_content_endpoint(body: FetchRequest):
     from souwen.web.fetch import fetch_content
 
     valid_fetch_providers = _valid_fetch_provider_names()
-    if body.provider not in valid_fetch_providers:
+    selected_providers = body.providers or [body.provider]
+    invalid_providers = [
+        provider for provider in selected_providers if provider not in valid_fetch_providers
+    ]
+    if invalid_providers:
         raise HTTPException(
             status_code=400,
-            detail=f"无效提供者: {body.provider}，可选: {', '.join(sorted(valid_fetch_providers))}",
+            detail=(
+                f"无效提供者: {', '.join(invalid_providers)}，"
+                f"可选: {', '.join(sorted(valid_fetch_providers))}"
+            ),
         )
 
-    route_timeout = _fetch_route_timeout(body.provider, len(body.urls), body.timeout)
+    route_timeout = _fetch_route_timeout(
+        selected_providers,
+        len(body.urls),
+        body.timeout,
+        body.strategy,
+    )
     try:
         resp = await asyncio.wait_for(
             fetch_content(
                 urls=body.urls,
-                providers=[body.provider],
+                providers=selected_providers,
+                strategy=body.strategy,
                 timeout=body.timeout,
                 selector=body.selector,
                 start_index=body.start_index,
@@ -62,13 +84,25 @@ async def fetch_content_endpoint(body: FetchRequest):
             "total_ok": resp.total_ok,
             "total_failed": resp.total_failed,
             "provider": resp.provider,
+            "providers": resp.providers,
+            "strategy": resp.strategy,
             "meta": resp.meta,
         }
     except asyncio.TimeoutError:
-        logger.warning("内容抓取超时: provider=%s urls=%d", body.provider, len(body.urls))
+        logger.warning(
+            "内容抓取超时: providers=%s strategy=%s urls=%d",
+            selected_providers,
+            body.strategy,
+            len(body.urls),
+        )
         raise HTTPException(status_code=504, detail=f"抓取超时（总预算 {route_timeout:g}s）")
     except Exception:
-        logger.warning("内容抓取内部错误: provider=%s", body.provider, exc_info=True)
+        logger.warning(
+            "内容抓取内部错误: providers=%s strategy=%s",
+            selected_providers,
+            body.strategy,
+            exc_info=True,
+        )
         raise
 
 

--- a/src/souwen/server/schemas/fetch.py
+++ b/src/souwen/server/schemas/fetch.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel, Field
 
 from souwen.registry import fetch_providers
@@ -14,14 +16,26 @@ class FetchRequest(BaseModel):
 
     Attributes:
         urls: 目标 URL 列表（1-20 条）
-        provider: 提供者名称（默认 builtin）
+        provider: 兼容旧版单 provider 字段（默认 builtin）
+        providers: 多 provider 列表；提供时优先于 provider
+        strategy: 多 provider 策略，fallback 或 fanout
         timeout: 每个 URL 超时秒数
     """
 
     urls: list[str] = Field(..., min_length=1, max_length=20)
     provider: str = Field(
         default="builtin",
-        description=f"抓取提供者，可选: {', '.join(_FETCH_PROVIDER_NAMES)}",
+        description=f"兼容单抓取提供者，可选: {', '.join(_FETCH_PROVIDER_NAMES)}",
+    )
+    providers: list[str] | None = Field(
+        default=None,
+        min_length=1,
+        max_length=20,
+        description=f"抓取提供者列表；提供时优先于 provider，可选: {', '.join(_FETCH_PROVIDER_NAMES)}",
+    )
+    strategy: Literal["fallback", "fanout"] = Field(
+        default="fallback",
+        description="多提供者策略：fallback 按 URL 补失败项，fanout 并发返回全部 provider 结果",
     )
     timeout: float = Field(default=30.0, ge=1.0, le=120.0)
     selector: str | None = Field(

--- a/src/souwen/web/fetch.py
+++ b/src/souwen/web/fetch.py
@@ -23,13 +23,15 @@
                     crawl4ai / scrapfly / diffbot / scrapingbee / zenrows /
                     scraperapi / apify / cloudflare / wayback / newspaper / readability
 
-    fetch_content(urls, providers=None, timeout=30.0, skip_ssrf_check=False) -> FetchResponse
-        - 功能：并发多提供者聚合抓取入口（用户显式选择提供者，不自动级联）
+    fetch_content(
+        urls, providers=None, strategy="fallback", timeout=30.0, skip_ssrf_check=False
+    ) -> FetchResponse
+        - 功能：多提供者抓取入口，支持 per-URL fallback 与 fanout 质量对比
         - 输入：urls 目标 URL 列表, providers 提供者列表(默认 ["builtin"]),
-                timeout 每 URL 超时, skip_ssrf_check 是否跳过 SSRF 校验
+                strategy 抓取策略, timeout 每 URL 超时, skip_ssrf_check 是否跳过 SSRF 校验
         - 输出：FetchResponse 聚合结果（含 SSRF 拦截记录）
         - 关键变量：selected 选用的提供者列表, valid_urls SSRF 通过的 URL,
-                ssrf_failures SSRF 拦截的失败结果
+                ssrf_failures SSRF 拦截的失败结果, attempted 每 URL 尝试 provider
 
 模块依赖：
     - asyncio: 异步并发与超时控制
@@ -47,6 +49,7 @@
     - SSRF 防护：解析 DNS 后逐个 IP 校验，拒绝私有/回环/链路本地/保留段
     - 提供者懒加载：在分支内 import，避免循环依赖与不必要的依赖加载
     - 用户显式选择提供者：默认 builtin（内置，零配置），可选 jina_reader 等付费提供者
+    - fallback 策略按 URL 逐项补失败项，fanout 策略并发返回全部 provider 结果
     - 全局超时 = per-URL timeout + 10 秒宽限期
 """
 
@@ -57,9 +60,10 @@ import contextvars
 import ipaddress
 import logging
 import socket
+from collections import defaultdict, deque
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import urlparse
 
 from souwen.config import get_config
@@ -70,6 +74,7 @@ logger = logging.getLogger("souwen.web.fetch")
 
 FetchHandler = Callable[..., Awaitable[FetchResponse]]
 """Fetch handler signature: ``async (urls: list[str], timeout: float, **kwargs) -> FetchResponse``."""
+FetchStrategy = Literal["fallback", "fanout"]
 
 # ── 插件上下文：由 plugin.py 加载器在 ep.load() 周围设置 ──
 _current_plugin_owner: contextvars.ContextVar[str | None] = contextvars.ContextVar(
@@ -558,75 +563,63 @@ async def _fetch_with_provider(
         total_ok=0,
         total_failed=len(urls),
         provider=provider,
+        providers=[provider],
     )
 
 
-async def fetch_content(
+def _provider_compat_value(providers: list[str]) -> str | None:
+    """兼容旧版单 provider 字段；多 provider 响应不再伪装成单一 provider。"""
+    return providers[0] if len(providers) == 1 else None
+
+
+def _align_results_to_urls(
+    *,
+    provider: str,
     urls: list[str],
-    providers: list[str] | None = None,
-    timeout: float = 30.0,
-    skip_ssrf_check: bool = False,
+    results: list[FetchResult],
+) -> list[FetchResult]:
+    """按请求 URL 顺序取回 provider 结果，缺失项补 provider 级失败。"""
+    by_url: dict[str, deque[FetchResult]] = defaultdict(deque)
+    for result in results:
+        by_url[result.url].append(result)
+
+    aligned: list[FetchResult] = []
+    requested_urls = set(urls)
+    for index, url in enumerate(urls):
+        if by_url[url]:
+            aligned.append(by_url[url].popleft())
+            continue
+        if index < len(results) and results[index].url not in requested_urls:
+            aligned.append(results[index])
+            continue
+        aligned.append(
+            FetchResult(
+                url=url,
+                final_url=url,
+                source=provider,
+                error=f"{provider} 未返回该 URL 的抓取结果",
+            )
+        )
+    return aligned
+
+
+async def _run_provider_fetch(
+    provider: str,
+    urls: list[str],
+    timeout: float,
+    *,
     selector: str | None = None,
     start_index: int = 0,
     max_length: int | None = None,
     respect_robots_txt: bool = False,
 ) -> FetchResponse:
-    """并发多提供者聚合内容抓取
-
-    用户显式选择提供者（不自动级联），默认使用 builtin（内置，零配置）。
-    每个提供者独立抓取全部 URL 列表中有效的 URL。
-
-    Args:
-        urls: 目标 URL 列表
-        providers: 提供者列表，默认 ["builtin"]
-        timeout: 每个 URL 超时秒数
-        skip_ssrf_check: 跳过 SSRF 校验（仅内部使用）
-
-    Returns:
-        FetchResponse 聚合结果
-    """
-    selected = providers or ["builtin"]
-
-    # SSRF 校验
-    valid_urls: list[str] = []
-    ssrf_failures: list[FetchResult] = []
-    if not skip_ssrf_check:
-        for url in urls:
-            ok, reason = validate_fetch_url(url)
-            if ok:
-                valid_urls.append(url)
-            else:
-                ssrf_failures.append(
-                    FetchResult(
-                        url=url,
-                        final_url=url,
-                        source=selected[0],
-                        error=f"SSRF 校验失败: {reason}",
-                    )
-                )
-    else:
-        valid_urls = list(urls)
-
-    if not valid_urls:
-        return FetchResponse(
-            urls=urls,
-            results=ssrf_failures,
-            total=len(ssrf_failures),
-            total_ok=0,
-            total_failed=len(ssrf_failures),
-            provider=",".join(selected),
-            meta={"requested_providers": selected, "ssrf_blocked": len(ssrf_failures)},
-        )
-
-    # 用户显式选择单提供者（不做多提供者扇出）
-    provider = selected[0]
-    global_timeout = _get_provider_global_timeout(provider, len(valid_urls), timeout)
-
+    """执行单个 provider，并把超时/异常折算成 FetchResponse。"""
+    global_timeout = _get_provider_global_timeout(provider, len(urls), timeout)
     try:
         resp = await asyncio.wait_for(
             _fetch_with_provider(
                 provider,
-                valid_urls,
+                urls,
                 timeout=timeout,
                 selector=selector,
                 start_index=start_index,
@@ -635,35 +628,199 @@ async def fetch_content(
             ),
             timeout=global_timeout,
         )
+        return resp.model_copy(
+            update={
+                "provider": resp.provider or provider,
+                "providers": resp.providers or [provider],
+            }
+        )
     except asyncio.TimeoutError:
-        logger.warning("Fetch 全局超时: provider=%s urls=%d", provider, len(valid_urls))
-        resp = FetchResponse(
-            urls=valid_urls,
+        logger.warning("Fetch 全局超时: provider=%s urls=%d", provider, len(urls))
+        return FetchResponse(
+            urls=urls,
             results=[
-                FetchResult(url=u, final_url=u, source=provider, error="全局超时")
-                for u in valid_urls
+                FetchResult(url=u, final_url=u, source=provider, error="全局超时") for u in urls
             ],
-            total=len(valid_urls),
+            total=len(urls),
             total_ok=0,
-            total_failed=len(valid_urls),
+            total_failed=len(urls),
             provider=provider,
+            providers=[provider],
         )
     except Exception as exc:
         logger.warning("Fetch 提供者异常: provider=%s err=%s", provider, exc)
-        resp = FetchResponse(
-            urls=valid_urls,
+        return FetchResponse(
+            urls=urls,
             results=[
-                FetchResult(url=u, final_url=u, source=provider, error=str(exc)) for u in valid_urls
+                FetchResult(url=u, final_url=u, source=provider, error=str(exc)) for u in urls
             ],
-            total=len(valid_urls),
+            total=len(urls),
             total_ok=0,
-            total_failed=len(valid_urls),
+            total_failed=len(urls),
             provider=provider,
+            providers=[provider],
         )
 
-    # 合并 SSRF 拦截结果
-    all_results = ssrf_failures + list(resp.results)
-    ok_count = sum(1 for r in all_results if r.error is None)
+
+async def fetch_content(
+    urls: list[str],
+    providers: list[str] | None = None,
+    strategy: FetchStrategy = "fallback",
+    timeout: float = 30.0,
+    skip_ssrf_check: bool = False,
+    selector: str | None = None,
+    start_index: int = 0,
+    max_length: int | None = None,
+    respect_robots_txt: bool = False,
+) -> FetchResponse:
+    """多提供者内容抓取
+
+    默认使用 ``fallback``：按 provider 顺序逐 URL 补抓失败项。
+    ``fanout`` 会并发执行所有 provider，并返回全部 provider 结果。
+
+    Args:
+        urls: 目标 URL 列表
+        providers: 提供者列表，默认 ["builtin"]
+        strategy: 抓取策略，``fallback`` 或 ``fanout``
+        timeout: 每个 URL 超时秒数
+        skip_ssrf_check: 跳过 SSRF 校验（仅内部使用）
+
+    Returns:
+        FetchResponse 聚合结果
+    """
+    if strategy not in ("fallback", "fanout"):
+        raise ValueError(f"无效 fetch strategy: {strategy}")
+
+    selected = providers or ["builtin"]
+    provider_compat = _provider_compat_value(selected)
+    attempted: dict[str, list[str]] = {url: [] for url in urls}
+    selected_provider: dict[str, str] = {}
+
+    # SSRF 校验
+    valid_entries: list[tuple[int, str]] = []
+    final_by_index: dict[int, FetchResult] = {}
+    if not skip_ssrf_check:
+        for index, url in enumerate(urls):
+            ok, reason = validate_fetch_url(url)
+            if ok:
+                valid_entries.append((index, url))
+            else:
+                final_by_index[index] = FetchResult(
+                    url=url,
+                    final_url=url,
+                    source="ssrf",
+                    error=f"SSRF 校验失败: {reason}",
+                )
+    else:
+        valid_entries = list(enumerate(urls))
+
+    ssrf_blocked = len(final_by_index)
+    meta = {
+        "strategy": strategy,
+        "requested_providers": selected,
+        "attempted": attempted,
+        "selected_provider": selected_provider,
+        "ssrf_blocked": ssrf_blocked,
+    }
+
+    if not valid_entries:
+        all_results = [final_by_index[index] for index in sorted(final_by_index)]
+        return FetchResponse(
+            urls=urls,
+            results=all_results,
+            total=len(all_results),
+            total_ok=0,
+            total_failed=len(all_results),
+            provider=provider_compat,
+            providers=selected,
+            strategy=strategy,
+            meta=meta,
+        )
+
+    if strategy == "fanout":
+        valid_urls = [url for _, url in valid_entries]
+        for _, url in valid_entries:
+            attempted[url].extend(selected)
+
+        responses = await asyncio.gather(
+            *[
+                _run_provider_fetch(
+                    provider,
+                    valid_urls,
+                    timeout=timeout,
+                    selector=selector,
+                    start_index=start_index,
+                    max_length=max_length,
+                    respect_robots_txt=respect_robots_txt,
+                )
+                for provider in selected
+            ]
+        )
+        provider_results = [result for response in responses for result in response.results]
+        all_results = [final_by_index[index] for index in sorted(final_by_index)] + provider_results
+        ok_count = sum(1 for result in all_results if result.error is None)
+        return FetchResponse(
+            urls=urls,
+            results=all_results,
+            total=len(all_results),
+            total_ok=ok_count,
+            total_failed=len(all_results) - ok_count,
+            provider=provider_compat,
+            providers=selected,
+            strategy=strategy,
+            meta=meta,
+        )
+
+    pending_entries = list(valid_entries)
+    last_failure_by_index: dict[int, FetchResult] = {}
+
+    for provider in selected:
+        if not pending_entries:
+            break
+
+        batch_indices = [index for index, _ in pending_entries]
+        batch_urls = [url for _, url in pending_entries]
+        for url in batch_urls:
+            attempted[url].append(provider)
+
+        response = await _run_provider_fetch(
+            provider,
+            batch_urls,
+            timeout=timeout,
+            selector=selector,
+            start_index=start_index,
+            max_length=max_length,
+            respect_robots_txt=respect_robots_txt,
+        )
+        aligned_results = _align_results_to_urls(
+            provider=provider,
+            urls=batch_urls,
+            results=list(response.results),
+        )
+
+        next_pending: list[tuple[int, str]] = []
+        for index, url, result in zip(batch_indices, batch_urls, aligned_results, strict=False):
+            if result.error is None:
+                final_by_index[index] = result
+                selected_provider[url] = provider
+            else:
+                last_failure_by_index[index] = result
+                next_pending.append((index, url))
+        pending_entries = next_pending
+
+    for index, url in pending_entries:
+        final_by_index[index] = last_failure_by_index.get(
+            index,
+            FetchResult(
+                url=url,
+                final_url=url,
+                source=selected[-1],
+                error="所有提供者均未返回该 URL 的抓取结果",
+            ),
+        )
+
+    all_results = [final_by_index[index] for index in range(len(urls)) if index in final_by_index]
+    ok_count = sum(1 for result in all_results if result.error is None)
 
     return FetchResponse(
         urls=urls,
@@ -671,6 +828,8 @@ async def fetch_content(
         total=len(all_results),
         total_ok=ok_count,
         total_failed=len(all_results) - ok_count,
-        provider=provider,
-        meta={"requested_providers": selected, "ssrf_blocked": len(ssrf_failures)},
+        provider=provider_compat,
+        providers=selected,
+        strategy=strategy,
+        meta=meta,
     )

--- a/tests/registry/test_catalog.py
+++ b/tests/registry/test_catalog.py
@@ -19,7 +19,9 @@ from souwen.registry.catalog import (
     sources_by_category,
 )
 from souwen.registry.loader import lazy
+from souwen.registry import external_plugins, fetch_providers
 from souwen.registry.views import _reg_external
+from souwen.web.fetch import get_fetch_handlers
 
 
 def test_source_categories_have_stable_metadata() -> None:
@@ -130,6 +132,16 @@ def test_available_source_catalog_matches_runtime_credentials_and_enabled_state(
         SouWenConfig(sources={"searxng": {"base_url": "https://search.example"}})
     )
     assert "searxng" in configured
+
+
+def test_catalog_fetch_providers_have_runtime_handlers() -> None:
+    """Source catalog 中的 fetch provider 必须能派发到 fetch handler。"""
+    external_plugin_names = set(external_plugins())
+    registry_fetch_provider_names = {
+        adapter.name for adapter in fetch_providers() if adapter.name not in external_plugin_names
+    }
+    handler_names = set(get_fetch_handlers())
+    assert registry_fetch_provider_names <= handler_names
 
 
 def test_runtime_plugin_uses_public_category_tag_and_plugin_distribution(

--- a/tests/test_server/test_fetch_route.py
+++ b/tests/test_server/test_fetch_route.py
@@ -37,6 +37,7 @@ def stub_fetch(monkeypatch):
     async def _fake_fetch(
         urls,
         providers=None,
+        strategy="fallback",
         timeout=30.0,
         selector=None,
         start_index=0,
@@ -47,6 +48,7 @@ def stub_fetch(monkeypatch):
             {
                 "urls": list(urls),
                 "providers": list(providers) if providers else providers,
+                "strategy": strategy,
                 "timeout": timeout,
                 "selector": selector,
                 "start_index": start_index,
@@ -70,7 +72,15 @@ def stub_fetch(monkeypatch):
             total=len(results),
             total_ok=len(results),
             total_failed=0,
-            provider=(providers[0] if providers else "builtin"),
+            provider=(
+                providers[0]
+                if providers and len(providers) == 1
+                else None
+                if providers
+                else "builtin"
+            ),
+            providers=list(providers) if providers else ["builtin"],
+            strategy=strategy,
         )
 
     import souwen.web.fetch as web_fetch_mod
@@ -97,6 +107,8 @@ class TestFetchEndpoint:
         assert body["total"] == 1
         assert body["total_ok"] == 1
         assert body["provider"] == "builtin"
+        assert body["providers"] == ["builtin"]
+        assert body["strategy"] == "fallback"
         assert body["results"][0]["url"] == "https://example.com/a"
         assert stub_fetch and stub_fetch[0]["timeout"] == 10
 
@@ -112,6 +124,25 @@ class TestFetchEndpoint:
         assert resp.status_code == 200, resp.text
         assert resp.json()["provider"] == "arxiv_fulltext"
         assert stub_fetch and stub_fetch[0]["providers"] == ["arxiv_fulltext"]
+
+    def test_multiple_providers_fanout_are_accepted(self, client, stub_fetch):
+        """providers + fanout 应优先于旧版 provider 字段透传到底层 fetch。"""
+        resp = client.post(
+            "/api/v1/fetch",
+            json={
+                "urls": ["https://example.com/a"],
+                "provider": "builtin",
+                "providers": ["builtin", "jina_reader"],
+                "strategy": "fanout",
+            },
+        )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["providers"] == ["builtin", "jina_reader"]
+        assert body["strategy"] == "fanout"
+        assert stub_fetch and stub_fetch[0]["providers"] == ["builtin", "jina_reader"]
+        assert stub_fetch[0]["strategy"] == "fanout"
 
     def test_missing_urls_returns_422(self, client, stub_fetch):
         """缺少必填字段 ``urls`` 应被 Pydantic 拒绝（422）。"""
@@ -141,6 +172,30 @@ class TestFetchEndpoint:
         assert resp.status_code == 400
         assert "无效提供者" in resp.json().get("detail", "")
 
+    def test_invalid_provider_in_providers_returns_400(self, client, stub_fetch):
+        """providers 中任一非法 provider 都应返回 400。"""
+        resp = client.post(
+            "/api/v1/fetch",
+            json={
+                "urls": ["https://example.com"],
+                "providers": ["builtin", "totally-not-a-provider"],
+            },
+        )
+        assert resp.status_code == 400
+        assert "totally-not-a-provider" in resp.json().get("detail", "")
+
+    def test_invalid_strategy_returns_422(self, client, stub_fetch):
+        """strategy 只允许 fallback / fanout。"""
+        resp = client.post(
+            "/api/v1/fetch",
+            json={
+                "urls": ["https://example.com"],
+                "providers": ["builtin", "jina_reader"],
+                "strategy": "race",
+            },
+        )
+        assert resp.status_code == 422
+
     def test_late_registered_provider_is_accepted(self, client, stub_fetch, monkeypatch):
         """路由应在请求时动态读取 provider，支持 reload 后新增插件。"""
         import souwen.server.routes.fetch as fetch_route
@@ -168,6 +223,8 @@ class TestFetchEndpoint:
 
         assert _fetch_route_timeout("builtin", 5, 10) == 25
         assert _fetch_route_timeout("scrapling", 5, 10) == 65
+        assert _fetch_route_timeout(["builtin", "scrapling"], 5, 10, "fallback") == 85
+        assert _fetch_route_timeout(["builtin", "scrapling"], 5, 10, "fanout") == 65
 
     def test_timeout_below_min_returns_422(self, client, stub_fetch):
         """timeout < 1 应被 Pydantic 校验拒绝（422）。"""

--- a/tests/test_web/test_fetch.py
+++ b/tests/test_web/test_fetch.py
@@ -17,8 +17,8 @@ import asyncio
 
 import pytest
 
-from souwen.models import FetchResult
-from souwen.web.fetch import validate_fetch_url, fetch_content
+from souwen.models import FetchResponse, FetchResult
+from souwen.web.fetch import fetch_content, register_fetch_handler, validate_fetch_url
 
 
 class TestSSRFValidation:
@@ -66,6 +66,31 @@ class TestSSRFValidation:
 class TestFetchContent:
     """fetch_content 聚合测试"""
 
+    @staticmethod
+    def _response(provider: str, urls: list[str], failed: set[str] | None = None) -> FetchResponse:
+        failed = failed or set()
+        results = [
+            FetchResult(
+                url=url,
+                final_url=url,
+                source=provider,
+                title=f"{provider} title",
+                content=f"{provider} content",
+                error="boom" if url in failed else None,
+            )
+            for url in urls
+        ]
+        ok_count = sum(1 for result in results if result.error is None)
+        return FetchResponse(
+            urls=list(urls),
+            results=results,
+            total=len(results),
+            total_ok=ok_count,
+            total_failed=len(results) - ok_count,
+            provider=provider,
+            providers=[provider],
+        )
+
     @pytest.mark.asyncio
     async def test_unknown_provider(self):
         """未知提供者返回全部失败"""
@@ -76,7 +101,124 @@ class TestFetchContent:
         )
         assert resp.total_failed == 1
         assert resp.total_ok == 0
+        assert resp.providers == ["nonexistent"]
+        assert resp.strategy == "fallback"
         assert "未知提供者" in resp.results[0].error
+
+    @pytest.mark.asyncio
+    async def test_fallback_retries_only_failed_urls(self, clean_fetch_handlers):
+        """fallback 应只把失败 URL 交给后续 provider 补抓。"""
+        calls: list[tuple[str, list[str]]] = []
+        urls = [
+            "https://example.com/a",
+            "https://example.com/b",
+            "https://example.com/c",
+        ]
+
+        async def primary(urls, timeout, **_kwargs):
+            calls.append(("primary", list(urls)))
+            return self._response("primary", list(urls), failed={"https://example.com/c"})
+
+        async def backup(urls, timeout, **_kwargs):
+            calls.append(("backup", list(urls)))
+            return self._response("backup", list(urls))
+
+        register_fetch_handler("primary", primary)
+        register_fetch_handler("backup", backup)
+
+        resp = await fetch_content(
+            urls=urls,
+            providers=["primary", "backup"],
+            strategy="fallback",
+            skip_ssrf_check=True,
+        )
+
+        assert calls == [
+            ("primary", urls),
+            ("backup", ["https://example.com/c"]),
+        ]
+        assert resp.total == 3
+        assert resp.total_ok == 3
+        assert resp.provider is None
+        assert resp.providers == ["primary", "backup"]
+        assert resp.strategy == "fallback"
+        assert [result.source for result in resp.results] == ["primary", "primary", "backup"]
+        assert resp.meta["attempted"] == {
+            "https://example.com/a": ["primary"],
+            "https://example.com/b": ["primary"],
+            "https://example.com/c": ["primary", "backup"],
+        }
+        assert resp.meta["selected_provider"] == {
+            "https://example.com/a": "primary",
+            "https://example.com/b": "primary",
+            "https://example.com/c": "backup",
+        }
+
+    @pytest.mark.asyncio
+    async def test_fanout_returns_all_provider_results(self, clean_fetch_handlers):
+        """fanout 应并发执行所有 provider，并返回所有 provider 结果。"""
+        calls: list[tuple[str, list[str]]] = []
+        urls = ["https://example.com/a", "https://example.com/b"]
+
+        async def left(urls, timeout, **_kwargs):
+            calls.append(("left", list(urls)))
+            return self._response("left", list(urls))
+
+        async def right(urls, timeout, **_kwargs):
+            calls.append(("right", list(urls)))
+            return self._response("right", list(urls))
+
+        register_fetch_handler("left", left)
+        register_fetch_handler("right", right)
+
+        resp = await fetch_content(
+            urls=urls,
+            providers=["left", "right"],
+            strategy="fanout",
+            skip_ssrf_check=True,
+        )
+
+        assert sorted(calls) == [("left", urls), ("right", urls)]
+        assert resp.total == 4
+        assert resp.total_ok == 4
+        assert resp.provider is None
+        assert resp.providers == ["left", "right"]
+        assert resp.strategy == "fanout"
+        assert [result.source for result in resp.results] == ["left", "left", "right", "right"]
+        assert resp.meta["attempted"] == {
+            "https://example.com/a": ["left", "right"],
+            "https://example.com/b": ["left", "right"],
+        }
+
+    @pytest.mark.asyncio
+    async def test_fanout_does_not_duplicate_ssrf_failures(self, clean_fetch_handlers):
+        """fanout 不应按 provider 数量放大 SSRF 拦截失败。"""
+        calls: list[tuple[str, list[str]]] = []
+
+        async def first(urls, timeout, **_kwargs):
+            calls.append(("first", list(urls)))
+            return self._response("first", list(urls))
+
+        async def second(urls, timeout, **_kwargs):
+            calls.append(("second", list(urls)))
+            return self._response("second", list(urls))
+
+        register_fetch_handler("first", first)
+        register_fetch_handler("second", second)
+
+        resp = await fetch_content(
+            urls=["http://127.0.0.1/admin", "https://1.1.1.1/"],
+            providers=["first", "second"],
+            strategy="fanout",
+        )
+
+        ssrf_failures = [result for result in resp.results if "SSRF" in (result.error or "")]
+        assert len(ssrf_failures) == 1
+        assert resp.meta["ssrf_blocked"] == 1
+        assert sorted(calls) == [
+            ("first", ["https://1.1.1.1/"]),
+            ("second", ["https://1.1.1.1/"]),
+        ]
 
     @pytest.mark.asyncio
     async def test_ssrf_block_mixed(self):
@@ -107,6 +249,8 @@ class TestFetchContent:
         )
         # 全部被 SSRF 拦截，但 provider 应为 builtin
         assert resp.provider == "builtin"
+        assert resp.providers == ["builtin"]
+        assert resp.strategy == "fallback"
 
     @pytest.mark.asyncio
     async def test_arxiv_fulltext_provider_dispatches(self, monkeypatch):


### PR DESCRIPTION
## 概述

本 PR 落地 v2 分步计划 PR5，修正 `fetch_content(providers=...)` 只执行首个 provider 的语义缺口，新增 `fallback` / `fanout` 两种抓取策略，并同步 Python API、REST API、CLI、文档与测试。

## 新增能力

- `fetch_content()` 新增 `strategy="fallback" | "fanout"` 参数，默认保持低成本的 `fallback`。
- `fallback` 改为按 URL 逐项补抓：首个 provider 已成功的 URL 不再交给后续 provider，失败 URL 才进入下一 provider。
- `fanout` 并发执行所有请求的 provider，并返回全部 provider 结果，便于质量对比和调试。
- `FetchResponse` 新增 `providers`、`strategy` 字段，并保留 `provider` 作为单 provider 兼容字段。

## API 与 CLI

- `/api/v1/fetch` 新增 `providers` 和 `strategy` 请求字段；`providers` 存在时优先于旧版 `provider`。
- route timeout 改为策略感知：`fallback` 使用 provider 预算求和，`fanout` 使用最大 provider 预算。
- `souwen fetch` 支持重复传入 `--provider/-p`，并新增 `--strategy fallback|fanout`。
- `docs/api-reference.md` 更新 Python API、CLI 和 REST API 说明与响应示例。

## 兼容性

- `providers=None` 仍默认使用 `builtin`。
- 单 provider 请求继续返回兼容字段 `provider=<name>`。
- 多 provider 请求的 `provider` 返回 `null`，以避免把多 provider 响应伪装成单一 provider。
- SSRF 校验仍只执行一次，fanout 不会按 provider 数量重复生成 SSRF failure。

## 测试

- `PYTHONPATH=src SOUWEN_PLUGIN_AUTOLOAD=0 pytest tests/test_web/test_fetch.py tests/test_server/test_fetch_route.py tests/test_plugin.py tests/registry/test_catalog.py -q`
- `PYTHONPATH=src SOUWEN_PLUGIN_AUTOLOAD=0 pytest -q`
- `ruff format --check src tests scripts tools`
- `ruff check src tests scripts tools`
- `git diff --check`
- `PYTHONPATH=src SOUWEN_PLUGIN_AUTOLOAD=0 python3 tools/gen_docs.py --check`
- `PYTHONPATH=src SOUWEN_PLUGIN_AUTOLOAD=0 python3 scripts/ci/run_profile.py --profile minimal --profile server --profile full --profile plugin`
- `npm ci --prefix panel`
- `npm run --prefix panel test`
- `npm run --prefix panel build`

## 文件清单

- `src/souwen/web/fetch.py`
- `src/souwen/models.py`
- `src/souwen/server/schemas/fetch.py`
- `src/souwen/server/routes/fetch.py`
- `src/souwen/cli/fetch.py`
- `tests/test_web/test_fetch.py`
- `tests/test_server/test_fetch_route.py`
- `tests/registry/test_catalog.py`
- `docs/api-reference.md`
