### PR TITLE
ci(v2): 修复 External Smoke Gate 恢复收口上下文

### DIFF
--- a/.github/workflows/external-smoke-gate.yml
+++ b/.github/workflows/external-smoke-gate.yml
@@ -147,6 +147,7 @@ jobs:
       - name: Create or update nightly failure issue
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           MARKER: "<!-- external-smoke-nightly-failure -->"
         run: |
           set -euo pipefail
@@ -220,6 +221,7 @@ jobs:
       - name: Close recovered nightly failure issue
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           MARKER: "<!-- external-smoke-nightly-failure -->"
         run: |
           set -euo pipefail


### PR DESCRIPTION
## 背景

`v2-dev` 已进入 RC smoke / release validation 阶段。最近的 `External Smoke Gate (schedule)` 中，Scrapling 与 Crawl4AI 能力 gate 已成功，但 `Close recovered nightly issue` 在未 checkout 的 job 中运行 `gh` 命令时失败：`fatal: not a git repository (or any of the parent directories): .git`。这会把真实恢复场景误报为失败，影响后续 release smoke Go / No-Go 判断。

## 变更

- 为 `open-nightly-failure-issue` step 增加 `GH_REPO: ${{ github.repository }}`。
- 为 `close-nightly-failure-issue` step 增加 `GH_REPO: ${{ github.repository }}`。
- 不新增 checkout，不扩大权限，不改变 Scrapling / Crawl4AI gate 的执行逻辑。

## 验证

- `git diff --check`
- `actionlint .github/workflows/external-smoke-gate.yml`
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/external-smoke-gate.yml')); print('yaml.safe_load ok')"`
- 在 `/tmp` 非 git 目录验证 `GH_REPO=BlueSkyXN/SouWen gh issue list --state open --limit 1 --json number --jq 'length'` 可运行。
- 在 `/tmp` 非 git 目录验证 `GH_REPO=BlueSkyXN/SouWen gh run view 25518710567 --json jobs --jq '.jobs | length'` 可运行。

## 边界

- PR base 是 `v2-dev`，不合并到 `main`。
- 本 PR 只修复 External Smoke Gate 的 issue 收口假红，不引入新的 release/deploy/tag 行为。
- 合并后建议再用 `workflow_dispatch suite=release` 重跑 External Smoke Gate，作为 Gate 1 的云端验收证据。
