### PR TITLE
docs(v2): 对齐 config init 生成路径

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -142,7 +142,7 @@ Visit `/docs` for the full OpenAPI documentation; visit `/panel#/` to enter the 
 
 Config priority: env > `./souwen.yaml` > `~/.config/souwen/config.yaml` > `.env` > defaults.
 
-Run `souwen config init` to generate a template at `~/.config/souwen/config.yaml`.
+Run `souwen config init` to generate a `./souwen.yaml` template in the current directory. Copy it to `~/.config/souwen/config.yaml` if you want a user-level config.
 
 ## 🏗 Architecture
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ curl "http://localhost:8000/api/v1/sources"
 
 配置优先级：env > `./souwen.yaml` > `~/.config/souwen/config.yaml` > `.env` > 默认值。
 
-首次运行 `souwen config init` 会在 `~/.config/souwen/config.yaml` 生成模板。
+运行 `souwen config init` 会在当前目录生成 `./souwen.yaml` 模板；需要全局配置时，可将模板复制到 `~/.config/souwen/config.yaml`。
 
 ## 🏗 架构
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,12 +17,14 @@
 ## 快速开始
 
 ```bash
-# 生成配置模板
+# 在当前目录生成 ./souwen.yaml 配置模板
 souwen config init
 
 # 查看当前配置（API Key 脱敏显示）
 souwen config show
 ```
+
+需要用户级配置时，可将生成的 `./souwen.yaml` 复制到 `~/.config/souwen/config.yaml`。
 
 也可以复制 `.env.example` 为 `.env` 后按需填写：
 


### PR DESCRIPTION
## 背景

Gate 2 隔离 clean install smoke 中，按 README / CLI 路径验证 `souwen config init` 时确认：当前 CLI 实际会在当前目录生成 `./souwen.yaml`，而 README 中英文版写成了 `~/.config/souwen/config.yaml`。这属于真实用户路径文档口径错误，应该在 RC smoke 阶段收口。

## 变更

- 更新 `README.md`：说明 `souwen config init` 生成当前目录 `./souwen.yaml`，需要用户级配置时可复制到 `~/.config/souwen/config.yaml`。
- 更新 `README.en.md`：同步英文说明。
- 更新 `docs/configuration.md`：在快速开始中明确 `config init` 生成路径，并补充用户级配置复制方式。

## 验证

- `git diff --check`
- 复扫 `README.md` / `README.en.md` / `docs/configuration.md` / `docs/api-reference.md` 中 `config init`、`souwen.yaml`、`~/.config/souwen/config.yaml` 的表述。
- Gate 2 隔离 clean install 已确认 `souwen config init` 在临时 cwd 生成 `souwen.yaml`，未写入临时 HOME 下的 `~/.config/souwen/config.yaml`。

## 边界

- PR base 是 `v2-dev`，不合并到 `main`。
- 本 PR 只修复 smoke 暴露的文档路径口径，不改变 CLI 行为。
