### PR TITLE
ci(v2): 修复 PyInstaller 动态 Source Catalog 打包

### DIFF
--- a/.github/workflows/build-pyinstaller.yml
+++ b/.github/workflows/build-pyinstaller.yml
@@ -214,6 +214,7 @@ jobs:
             --hidden-import=souwen.server.routes \
             --hidden-import=souwen.integrations \
             --hidden-import=souwen.integrations.mcp_server \
+            --collect-submodules=souwen.registry.sources \
             --collect-submodules=rich._unicode_data \
             cli.py
 
@@ -228,6 +229,7 @@ jobs:
             --hidden-import=souwen.server.routes \
             --exclude-module=souwen.integrations \
             --exclude-module=mcp \
+            --collect-submodules=souwen.registry.sources \
             --collect-submodules=rich._unicode_data \
             cli.py
 
@@ -243,23 +245,24 @@ jobs:
             --exclude-module=mcp \
             --exclude-module=pkg_resources \
             --exclude-module=setuptools \
+            --collect-submodules=souwen.registry.sources \
             --collect-submodules=rich._unicode_data \
             cli.py
 
       - name: Build with PyInstaller (Windows - Full)
         if: runner.os == 'Windows' && matrix.build_type == 'full'
         run: |
-          pyinstaller --onefile --clean --name ${{ env.APP_NAME }} --paths src --add-data "src/souwen/server/panel.html;souwen/server" --hidden-import=souwen.server --hidden-import=souwen.server.app --hidden-import=souwen.server.routes --hidden-import=souwen.integrations --hidden-import=souwen.integrations.mcp_server --collect-submodules=rich._unicode_data cli.py
+          pyinstaller --onefile --clean --name ${{ env.APP_NAME }} --paths src --add-data "src/souwen/server/panel.html;souwen/server" --hidden-import=souwen.server --hidden-import=souwen.server.app --hidden-import=souwen.server.routes --hidden-import=souwen.integrations --hidden-import=souwen.integrations.mcp_server --collect-submodules=souwen.registry.sources --collect-submodules=rich._unicode_data cli.py
 
       - name: Build with PyInstaller (Windows - Server)
         if: runner.os == 'Windows' && matrix.build_type == 'server'
         run: |
-          pyinstaller --onefile --clean --name ${{ env.APP_NAME }} --paths src --add-data "src/souwen/server/panel.html;souwen/server" --hidden-import=souwen.server --hidden-import=souwen.server.app --hidden-import=souwen.server.routes --exclude-module=souwen.integrations --exclude-module=mcp --collect-submodules=rich._unicode_data cli.py
+          pyinstaller --onefile --clean --name ${{ env.APP_NAME }} --paths src --add-data "src/souwen/server/panel.html;souwen/server" --hidden-import=souwen.server --hidden-import=souwen.server.app --hidden-import=souwen.server.routes --exclude-module=souwen.integrations --exclude-module=mcp --collect-submodules=souwen.registry.sources --collect-submodules=rich._unicode_data cli.py
 
       - name: Build with PyInstaller (Windows - CLI)
         if: runner.os == 'Windows' && matrix.build_type == 'cli'
         run: |
-          pyinstaller --onefile --clean --name ${{ env.APP_NAME }} --paths src --exclude-module=souwen.server --exclude-module=souwen.integrations --exclude-module=fastapi --exclude-module=uvicorn --exclude-module=mcp --exclude-module=pkg_resources --exclude-module=setuptools --collect-submodules=rich._unicode_data cli.py
+          pyinstaller --onefile --clean --name ${{ env.APP_NAME }} --paths src --exclude-module=souwen.server --exclude-module=souwen.integrations --exclude-module=fastapi --exclude-module=uvicorn --exclude-module=mcp --exclude-module=pkg_resources --exclude-module=setuptools --collect-submodules=souwen.registry.sources --collect-submodules=rich._unicode_data cli.py
 
       - name: Verify bundled CLI (Unix)
         if: runner.os != 'Windows'

--- a/.github/workflows/deploy-hf-space.yml
+++ b/.github/workflows/deploy-hf-space.yml
@@ -190,6 +190,7 @@ jobs:
             --exclude-module=mcp \
             --exclude-module=pkg_resources \
             --exclude-module=setuptools \
+            --collect-submodules=souwen.registry.sources \
             --collect-submodules=rich._unicode_data \
             cli.py
 


### PR DESCRIPTION
## 概述

修复 RC smoke 在 `HF Space CD` 手动运行中暴露的 PyInstaller CLI 二进制启动失败问题。失败日志显示打包后的 CLI 在导入 Source Catalog 时缺少动态导入模块 `souwen.registry.sources.paper`，导致 `./dist/souwen-local --help` 直接崩溃。

## 变更内容

- 在 `HF Space CD` 的 `PyInstaller CLI smoke` 命令中加入 `--collect-submodules=souwen.registry.sources`。
- 在正式 `Build with PyInstaller` workflow 的 Unix / Windows、CLI / Server / Full 打包命令中同步加入 `--collect-submodules=souwen.registry.sources`。
- 保持现有 `rich._unicode_data` 收集、server/integrations 排除策略和 release 创建条件不变。

## 验证

- `yaml.safe_load` 解析 `.github/workflows/deploy-hf-space.yml` 与 `.github/workflows/build-pyinstaller.yml` 通过。
- `actionlint .github/workflows/deploy-hf-space.yml .github/workflows/build-pyinstaller.yml` 通过。

## 说明

本修复仅收敛 PyInstaller 对动态 Source Catalog segment 的模块发现问题，不改变运行时代码、不触发部署、不创建 tag 或 GitHub Release。