### PR TITLE
docs(v2): 对齐 Gate 7 文档 walk-through 认证示例

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -123,7 +123,7 @@ asyncio.run(main())
 ### API Server
 
 ```bash
-souwen serve --host 0.0.0.0 --port 8000
+SOUWEN_ADMIN_PASSWORD=adminpass souwen serve --host 0.0.0.0 --port 8000
 ```
 
 Main endpoints:
@@ -131,10 +131,15 @@ Main endpoints:
 ```bash
 curl "http://localhost:8000/api/v1/search/paper?q=transformer&per_page=5"
 curl "http://localhost:8000/api/v1/search/web?q=python"
-curl "http://localhost:8000/api/v1/fetch" -X POST -d '{"urls":["https://example.com"]}'
+curl "http://localhost:8000/api/v1/fetch" \
+  -H "Authorization: Bearer adminpass" \
+  -H "Content-Type: application/json" \
+  -d '{"urls":["https://example.com"]}'
 curl "http://localhost:8000/api/v1/wayback/cdx?url=https://example.com"
 curl "http://localhost:8000/api/v1/sources"
 ```
+
+`/api/v1/fetch`, `/api/v1/links`, and `/api/v1/sitemap` are admin-protected fetch capabilities and require an Admin Bearer token. Search endpoints and `/api/v1/sources` can be protected separately with `SOUWEN_USER_PASSWORD`.
 
 Visit `/docs` for the full OpenAPI documentation; visit `/panel#/` to enter the Web UI (default: souwen-google skin). `/` redirects to `/docs` with the default configuration.
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ asyncio.run(main())
 ### API Server
 
 ```bash
-souwen serve --host 0.0.0.0 --port 8000
+SOUWEN_ADMIN_PASSWORD=adminpass souwen serve --host 0.0.0.0 --port 8000
 ```
 
 主要端点：
@@ -132,10 +132,15 @@ souwen serve --host 0.0.0.0 --port 8000
 ```bash
 curl "http://localhost:8000/api/v1/search/paper?q=transformer&per_page=5"
 curl "http://localhost:8000/api/v1/search/web?q=python"
-curl "http://localhost:8000/api/v1/fetch" -X POST -d '{"urls":["https://example.com"]}'
+curl "http://localhost:8000/api/v1/fetch" \
+  -H "Authorization: Bearer adminpass" \
+  -H "Content-Type: application/json" \
+  -d '{"urls":["https://example.com"]}'
 curl "http://localhost:8000/api/v1/wayback/cdx?url=https://example.com"
 curl "http://localhost:8000/api/v1/sources"
 ```
+
+`/api/v1/fetch`、`/api/v1/links` 和 `/api/v1/sitemap` 属于管理端抓取能力，需要 Admin Bearer Token；搜索和 `/api/v1/sources` 可再通过 `SOUWEN_USER_PASSWORD` 单独保护。
 
 访问 `/docs` 查看完整 OpenAPI 文档；访问 `/panel#/` 进入 Web UI（默认 souwen-google 皮肤）。`/` 在默认配置下重定向到 `/docs`。
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -114,7 +114,7 @@ _reg(SourceAdapter(
 
 ### 懒加载
 
-注册表模块导入时**不**加载 93 个内置源对应的 Client：
+注册表模块导入时**不**加载 94 个内置源对应的 Client：
 
 ```python
 client_loader=lazy("souwen.paper.openalex:OpenAlexClient")

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -58,7 +58,7 @@ asyncio.run(main())
 ## API Server
 
 ```bash
-souwen serve --host 0.0.0.0 --port 8000
+SOUWEN_ADMIN_PASSWORD=adminpass souwen serve --host 0.0.0.0 --port 8000
 ```
 
 常用端点：
@@ -68,9 +68,12 @@ curl "http://localhost:8000/api/v1/search/paper?q=transformer&per_page=5"
 curl "http://localhost:8000/api/v1/search/web?q=python&per_page=5"
 curl "http://localhost:8000/api/v1/sources"
 curl "http://localhost:8000/api/v1/fetch" \
+  -H "Authorization: Bearer adminpass" \
   -H "Content-Type: application/json" \
   -d '{"urls":["https://example.com"],"providers":["builtin"]}'
 ```
+
+`/api/v1/fetch`、`/api/v1/links` 和 `/api/v1/sitemap` 属于管理端抓取能力，需要 Admin Bearer Token。需要同时保护搜索和 `/api/v1/sources` 时，再设置 `SOUWEN_USER_PASSWORD`。
 
 启动后访问 `/docs` 查看 OpenAPI，访问 `/panel#/` 使用 Web Panel。
 


### PR DESCRIPTION
## 概述

本 PR 修复 Gate 7 docs walk-through 中发现的文档口径问题，使快速开始里的 API 示例与当前服务端认证边界一致。

## 变更内容

- `README.md` / `README.en.md`
  - API Server 示例改为显式设置 `SOUWEN_ADMIN_PASSWORD=adminpass`。
  - `/api/v1/fetch` curl 示例补充 `Authorization: Bearer adminpass` 与 `Content-Type: application/json`。
  - 补充说明 `/api/v1/fetch`、`/api/v1/links`、`/api/v1/sitemap` 属于 Admin-protected fetch capabilities；搜索和 `/api/v1/sources` 可用 `SOUWEN_USER_PASSWORD` 单独保护。
- `docs/getting-started.md`
  - 同步 API Server 启动命令与 fetch 示例认证头。
  - 补充 fetch/links/sitemap 的 Admin token 边界说明。
- `docs/architecture.md`
  - 将 lazy client 数量从 `93` 修正为当前 registry 的 `94` 个内置源。

## 验证

- `git diff --check`
- `PYTHONPATH=src SOUWEN_PLUGIN_AUTOLOAD=0 python3 tools/gen_docs.py --check`
- `PYTHONPATH=src SOUWEN_PLUGIN_AUTOLOAD=0 python3 scripts/ci/check_no_legacy_terms.py`
- 临时 HOME / cache / server 验证：
  - 无 token 请求 `/api/v1/fetch` 返回 `401`
  - `Authorization: Bearer adminpass` 请求 `/api/v1/fetch` 返回 `200` 并进入 fetch 逻辑

## 边界

- 仅修改文档，不修改 runtime 行为。
- 不涉及 PyPI、tag、release、deploy 或 mergeback。
