### PR TITLE
fix(v2): 统一默认搜索源与 registry 契约

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -43,7 +43,7 @@ from souwen import search, search_papers, search_patents, web_search
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `query` | `str` | — | 搜索关键词 |
-| `sources` | `list[str] \| None` | `["google_patents"]` | 数据源列表 |
+| `sources` | `list[str] \| None` | `null`（registry `patent:search` 当前为 `["google_patents"]`） | 数据源列表 |
 | `per_page` | `int` | `10` | 每个源返回结果数 |
 
 #### `web_search(query, engines=None, max_results_per_engine=10)` → `WebSearchResponse`
@@ -53,7 +53,7 @@ from souwen import search, search_papers, search_patents, web_search
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `query` | `str` | — | 搜索关键词 |
-| `engines` | `list[str] \| None` | `["duckduckgo", "bing"]` | 引擎列表 |
+| `engines` | `list[str] \| None` | `null`（registry `web:search` 当前为 `["duckduckgo", "bing"]`） | 引擎列表 |
 | `max_results_per_engine` | `int` | `10` | 每个引擎最大结果数 |
 
 ### 网页内容抓取
@@ -457,7 +457,7 @@ Cache-Control: public, max-age=3600
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `q` | string (1-500) | *(必填)* | 搜索关键词 |
-| `sources` | string | `"google_patents"` | 数据源列表，逗号分隔 |
+| `sources` | string \| null | `null`（registry `patent:search` 当前为 `google_patents`） | 数据源列表，逗号分隔 |
 | `per_page` | int (1-100) | `10` | 每个数据源返回结果数 |
 | `timeout` | float (1-300) \| null | `null` | 端点硬超时（秒），超时返回 504 |
 
@@ -468,7 +468,7 @@ Cache-Control: public, max-age=3600
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `q` | string (1-500) | *(必填)* | 搜索关键词 |
-| `engines` | string | `"duckduckgo,bing"` | 搜索引擎，逗号分隔 |
+| `engines` | string \| null | `null`（registry `web:search` 当前为 `duckduckgo,bing`） | 搜索引擎，逗号分隔 |
 | `per_page` | int (1-50) | `10` | 每引擎最大结果数（**主名称**） |
 | `max_results` | int (1-50) \| null | `null` | `per_page` 的别名；显式提供时**优先级高于 `per_page`** |
 | `timeout` | float (1-300) \| null | `null` | 端点硬超时（秒），超时返回 504 |
@@ -986,7 +986,7 @@ python -m souwen.integrations.mcp_server
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `query` | string | — | 搜索关键词 |
-| `sources` | array | `["google_patents"]` | 数据源 |
+| `sources` | array | `null`（registry `patent:search` 当前为 `["google_patents"]`） | 数据源 |
 | `limit` | int | `5` | 结果数 |
 
 返回：JSON `SearchResponse` 数组
@@ -996,7 +996,7 @@ python -m souwen.integrations.mcp_server
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `query` | string | — | 搜索关键词 |
-| `engines` | array | `null`（由后端默认 `["duckduckgo", "bing"]` 决定） | 引擎列表 |
+| `engines` | array | `null`（registry `web:search` 当前为 `["duckduckgo", "bing"]`） | 引擎列表 |
 | `limit` | int | `10` | 每引擎最大结果数 |
 
 返回：JSON `SearchResponse` 对象

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,9 @@ dependencies = [
 [project.urls]
 Homepage = "https://github.com/BlueSkyXN/SouWen"
 Repository = "https://github.com/BlueSkyXN/SouWen"
-Documentation = "https://github.com/BlueSkyXN/SouWen/tree/main/docs"
+Documentation = "https://github.com/BlueSkyXN/SouWen/tree/v2-dev/docs"
 Issues = "https://github.com/BlueSkyXN/SouWen/issues"
-Changelog = "https://github.com/BlueSkyXN/SouWen/blob/main/CHANGELOG.md"
+Changelog = "https://github.com/BlueSkyXN/SouWen/blob/v2-dev/CHANGELOG.md"
 
 [project.scripts]
 souwen = "souwen.cli:app"

--- a/src/souwen/cli/search.py
+++ b/src/souwen/cli/search.py
@@ -14,6 +14,10 @@ from souwen.registry import defaults_for
 search_app = typer.Typer(help="搜索论文/专利/网页")
 _DEFAULT_PAPER_SOURCES = defaults_for("paper", "search")
 _DEFAULT_PAPER_SOURCES_LABEL = ",".join(_DEFAULT_PAPER_SOURCES)
+_DEFAULT_PATENT_SOURCES = defaults_for("patent", "search")
+_DEFAULT_PATENT_SOURCES_LABEL = ",".join(_DEFAULT_PATENT_SOURCES)
+_DEFAULT_WEB_ENGINES = defaults_for("web", "search")
+_DEFAULT_WEB_ENGINES_LABEL = ",".join(_DEFAULT_WEB_ENGINES)
 
 
 @search_app.command("paper")
@@ -93,7 +97,12 @@ def search_paper(
 @search_app.command("patent")
 def search_patent(
     query: str = typer.Argument(..., help="搜索关键词"),
-    sources: str = typer.Option("google_patents", "--sources", "-s", help="数据源，逗号分隔"),
+    sources: str | None = typer.Option(
+        None,
+        "--sources",
+        "-s",
+        help=f"数据源，逗号分隔；默认 {_DEFAULT_PATENT_SOURCES_LABEL}",
+    ),
     limit: int = typer.Option(5, "--limit", "-n", help="每个源返回数量"),
     json_output: bool = typer.Option(False, "--json", "-j", help="JSON 格式输出"),
     timeout: int | None = typer.Option(None, "--timeout", "-t", help="总超时（秒），默认不限制"),
@@ -101,10 +110,15 @@ def search_patent(
     """搜索专利"""
     from souwen.search import search_patents
 
-    source_list = [s.strip() for s in sources.split(",") if s.strip()]
+    requested_sources = None
+    if sources is None:
+        source_list = list(_DEFAULT_PATENT_SOURCES)
+    else:
+        source_list = [s.strip() for s in sources.split(",") if s.strip()]
+        requested_sources = source_list
 
     async def _do():
-        coro = search_patents(query, sources=source_list, per_page=limit)
+        coro = search_patents(query, sources=requested_sources, per_page=limit)
         if timeout is not None:
             return await asyncio.wait_for(coro, timeout=timeout)
         return await coro
@@ -159,7 +173,12 @@ def search_patent(
 @search_app.command("web")
 def search_web_cmd(
     query: str = typer.Argument(..., help="搜索关键词"),
-    engines: str = typer.Option("duckduckgo,bing", "--engines", "-e", help="搜索引擎，逗号分隔"),
+    engines: str | None = typer.Option(
+        None,
+        "--engines",
+        "-e",
+        help=f"搜索引擎，逗号分隔；默认 {_DEFAULT_WEB_ENGINES_LABEL}",
+    ),
     limit: int = typer.Option(10, "--limit", "-n", help="每引擎最大结果数"),
     json_output: bool = typer.Option(False, "--json", "-j", help="JSON 格式输出"),
     timeout: int | None = typer.Option(None, "--timeout", "-t", help="总超时（秒），默认不限制"),
@@ -167,10 +186,15 @@ def search_web_cmd(
     """搜索网页"""
     from souwen.web.search import web_search
 
-    engine_list = [e.strip() for e in engines.split(",") if e.strip()]
+    requested_engines = None
+    if engines is None:
+        engine_list = list(_DEFAULT_WEB_ENGINES)
+    else:
+        engine_list = [e.strip() for e in engines.split(",") if e.strip()]
+        requested_engines = engine_list
 
     async def _do():
-        coro = web_search(query, engines=engine_list, max_results_per_engine=limit)
+        coro = web_search(query, engines=requested_engines, max_results_per_engine=limit)
         if timeout is not None:
             return await asyncio.wait_for(coro, timeout=timeout)
         return await coro

--- a/src/souwen/integrations/mcp/server.py
+++ b/src/souwen/integrations/mcp/server.py
@@ -86,6 +86,10 @@ from souwen.integrations.mcp.tools.bilibili import (
 
 _DEFAULT_PAPER_SOURCES = defaults_for("paper", "search")
 _DEFAULT_PAPER_SOURCES_LABEL = ",".join(_DEFAULT_PAPER_SOURCES)
+_DEFAULT_PATENT_SOURCES = defaults_for("patent", "search")
+_DEFAULT_PATENT_SOURCES_LABEL = ",".join(_DEFAULT_PATENT_SOURCES)
+_DEFAULT_WEB_ENGINES = defaults_for("web", "search")
+_DEFAULT_WEB_ENGINES_LABEL = ",".join(_DEFAULT_WEB_ENGINES)
 
 
 def create_server() -> "Server":
@@ -148,7 +152,7 @@ def create_server() -> "Server":
                         "sources": {
                             "type": "array",
                             "items": {"type": "string"},
-                            "description": "数据源列表，默认 google_patents",
+                            "description": f"数据源列表，默认 {_DEFAULT_PATENT_SOURCES_LABEL}",
                         },
                         "limit": {
                             "type": "integer",
@@ -161,7 +165,7 @@ def create_server() -> "Server":
             ),
             Tool(
                 name="web_search",
-                description="网页搜索。支持 21 个引擎，默认 DuckDuckGo + Bing。",
+                description=f"网页搜索。默认 {_DEFAULT_WEB_ENGINES_LABEL}。",
                 inputSchema={
                     "type": "object",
                     "properties": {
@@ -169,7 +173,7 @@ def create_server() -> "Server":
                         "engines": {
                             "type": "array",
                             "items": {"type": "string"},
-                            "description": "引擎列表",
+                            "description": f"引擎列表，默认 {_DEFAULT_WEB_ENGINES_LABEL}",
                         },
                         "limit": {
                             "type": "integer",
@@ -300,7 +304,7 @@ def create_server() -> "Server":
             elif name == "search_patents":
                 from souwen.search import search_patents
 
-                sources = arguments.get("sources", ["google_patents"])
+                sources = arguments.get("sources")
                 limit = arguments.get("limit", 5)
                 responses = await search_patents(
                     arguments["query"], sources=sources, per_page=limit

--- a/src/souwen/search.py
+++ b/src/souwen/search.py
@@ -253,7 +253,7 @@ async def search_patents(
 
     Args:
         query: 搜索关键词
-        sources: 数据源列表；None 表示使用 registry 的默认源（默认 ["google_patents"]）
+        sources: 数据源列表；None 表示使用 registry 的默认专利源
         per_page: 每个源返回的结果数
         **kwargs: 额外参数
 

--- a/src/souwen/server/routes/search.py
+++ b/src/souwen/server/routes/search.py
@@ -21,6 +21,10 @@ from souwen.server.schemas import (
 router = APIRouter()
 _DEFAULT_PAPER_SOURCES = defaults_for("paper", "search")
 _DEFAULT_PAPER_SOURCES_LABEL = ",".join(_DEFAULT_PAPER_SOURCES)
+_DEFAULT_PATENT_SOURCES = defaults_for("patent", "search")
+_DEFAULT_PATENT_SOURCES_LABEL = ",".join(_DEFAULT_PATENT_SOURCES)
+_DEFAULT_WEB_ENGINES = defaults_for("web", "search")
+_DEFAULT_WEB_ENGINES_LABEL = ",".join(_DEFAULT_WEB_ENGINES)
 
 
 @router.get(
@@ -83,7 +87,10 @@ async def api_search_paper(
 )
 async def api_search_patent(
     q: str = Query(..., description="搜索关键词", min_length=1, max_length=500),
-    sources: str = Query("google_patents", description="数据源，逗号分隔"),
+    sources: str | None = Query(
+        None,
+        description=f"数据源，逗号分隔；默认 {_DEFAULT_PATENT_SOURCES_LABEL}",
+    ),
     per_page: int = Query(10, ge=1, le=100, description="每页结果数"),
     timeout: float | None = Query(None, ge=1, le=300, description="端点硬超时（秒），超时返回 504"),
 ):
@@ -91,9 +98,14 @@ async def api_search_patent(
     from souwen.core.exceptions import SouWenError
     from souwen.search import search_patents
 
-    source_list = [s.strip() for s in sources.split(",") if s.strip()]
+    requested_sources = None
+    if sources is None:
+        source_list = list(_DEFAULT_PATENT_SOURCES)
+    else:
+        source_list = [s.strip() for s in sources.split(",") if s.strip()]
+        requested_sources = source_list
     try:
-        coro = search_patents(q, sources=source_list, per_page=per_page)
+        coro = search_patents(q, sources=requested_sources, per_page=per_page)
         if timeout is not None:
             results = await asyncio.wait_for(coro, timeout=timeout)
         else:
@@ -128,7 +140,10 @@ async def api_search_patent(
 )
 async def api_search_web(
     q: str = Query(..., description="搜索关键词", min_length=1, max_length=500),
-    engines: str = Query("duckduckgo,bing", description="搜索引擎，逗号分隔"),
+    engines: str | None = Query(
+        None,
+        description=f"搜索引擎，逗号分隔；默认 {_DEFAULT_WEB_ENGINES_LABEL}",
+    ),
     per_page: int = Query(
         10, ge=1, le=50, alias="per_page", description="每引擎最大结果数（别名: max_results）"
     ),
@@ -139,10 +154,15 @@ async def api_search_web(
     from souwen.core.exceptions import SouWenError
     from souwen.web.search import web_search
 
-    engine_list = [e.strip() for e in engines.split(",") if e.strip()]
+    requested_engines = None
+    if engines is None:
+        engine_list = list(_DEFAULT_WEB_ENGINES)
+    else:
+        engine_list = [e.strip() for e in engines.split(",") if e.strip()]
+        requested_engines = engine_list
     effective = max_results if max_results is not None else per_page
     try:
-        coro = web_search(q, engines=engine_list, max_results_per_engine=effective)
+        coro = web_search(q, engines=requested_engines, max_results_per_engine=effective)
         if timeout is not None:
             resp = await asyncio.wait_for(coro, timeout=timeout)
         else:

--- a/src/souwen/web/search.py
+++ b/src/souwen/web/search.py
@@ -22,7 +22,7 @@ from typing import Sequence
 from souwen.config import get_config
 from souwen.core.concurrency import get_semaphore
 from souwen.models import WebSearchResponse, WebSearchResult
-from souwen.registry import get as _registry_get
+from souwen.registry import defaults_for, get as _registry_get
 
 logger = logging.getLogger("souwen.web.search")
 _WEB_ENGINE_TIMEOUT_CAP_SECONDS = 15.0
@@ -89,6 +89,11 @@ def _deduplicate(results: Sequence[WebSearchResult]) -> list[WebSearchResult]:
     return deduped
 
 
+def _default_web_engines() -> list[str]:
+    """默认 Web 搜索引擎列表（从 registry 派生）。"""
+    return defaults_for("web", "search")
+
+
 async def web_search(
     query: str,
     engines: list[str] | None = None,
@@ -98,7 +103,7 @@ async def web_search(
 ) -> WebSearchResponse:
     """并发多引擎聚合搜索
 
-    同时查询多个搜索引擎（默认 ["duckduckgo", "bing"]），聚合结果并可选去重。
+    同时查询多个搜索引擎（默认来自 registry 的 ``web:search``），聚合结果并可选去重。
     Engine 通过 `souwen.registry` 懒加载，因此该函数调用时才会 import 对应客户端。
 
     备注：
@@ -108,7 +113,7 @@ async def web_search(
 
     Args:
         query: 搜索关键词
-        engines: 引擎名列表，默认 ["duckduckgo", "bing"]
+        engines: 引擎名列表；None 表示使用 registry 声明的默认 web 搜索源
         max_results_per_engine: 每个引擎最大返回数
         deduplicate: 是否按 URL 去重
         **kwargs: 传递给各引擎构造函数的参数（如 use_curl_cffi）
@@ -121,7 +126,7 @@ async def web_search(
         >>> for r in resp.results:
         ...     print(f"[{r.engine}] {r.title} → {r.url}")
     """
-    selected = engines or ["duckduckgo", "bing"]
+    selected = engines or _default_web_engines()
 
     tasks = []
     active_engines: list[str] = []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -217,6 +217,43 @@ def test_search_paper_uses_registry_defaults_when_sources_omitted(monkeypatch):
     assert captured == {"query": "test", "sources": None, "per_page": 5}
 
 
+def test_search_patent_uses_registry_defaults_when_sources_omitted(monkeypatch):
+    """专利搜索省略 ``--sources`` 时，也应透传 ``None`` 给 registry 默认源。"""
+    import sys
+
+    search_module = sys.modules["souwen.search"]
+    captured = {}
+
+    async def fake_search(query, sources=None, per_page=10, **kwargs):
+        captured["query"] = query
+        captured["sources"] = sources
+        captured["per_page"] = per_page
+        return []
+
+    monkeypatch.setattr(search_module, "search_patents", fake_search)
+    result = runner.invoke(app, ["search", "patent", "test", "--json"])
+    assert result.exit_code == 0
+    assert captured == {"query": "test", "sources": None, "per_page": 5}
+
+
+def test_search_web_uses_registry_defaults_when_engines_omitted(monkeypatch):
+    """网页搜索省略 ``--engines`` 时，应透传 ``None`` 给 registry 默认源。"""
+    from souwen.web import search as web_search_mod
+
+    captured = {}
+
+    async def fake_web_search(query, engines=None, max_results_per_engine=10, **kwargs):
+        captured["query"] = query
+        captured["engines"] = engines
+        captured["max_results_per_engine"] = max_results_per_engine
+        return web_search_mod.WebSearchResponse(query=query, source="duckduckgo", results=[])
+
+    monkeypatch.setattr(web_search_mod, "web_search", fake_web_search)
+    result = runner.invoke(app, ["search", "web", "test", "--json"])
+    assert result.exit_code == 0
+    assert captured == {"query": "test", "engines": None, "max_results_per_engine": 10}
+
+
 def test_plugins_new_scaffolds_project(monkeypatch, tmp_path: Path):
     """``plugins new`` creates a complete plugin project skeleton."""
     monkeypatch.chdir(tmp_path)

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -21,7 +21,10 @@
 - ``TestOAuthTokenConcurrency``：OAuth Token 并发刷新安全性
 """
 
+from pathlib import Path
+
 import pytest
+
 from souwen.models import (
     PaperResult,
     PatentResult,
@@ -52,6 +55,13 @@ from souwen.registry.meta import (
     get_sources_by_integration_type,
 )
 from souwen.registry.views import enum_values
+
+
+def test_project_urls_point_to_v2_dev_until_mergeback():
+    """v2-dev 的 wheel 元数据不能把文档和 changelog 指向尚未 mergeback 的 main。"""
+    pyproject = Path("pyproject.toml").read_text(encoding="utf-8")
+    assert 'Documentation = "https://github.com/BlueSkyXN/SouWen/tree/v2-dev/docs"' in pyproject
+    assert 'Changelog = "https://github.com/BlueSkyXN/SouWen/blob/v2-dev/CHANGELOG.md"' in pyproject
 
 
 class TestModels:

--- a/tests/test_integrations/test_mcp_server.py
+++ b/tests/test_integrations/test_mcp_server.py
@@ -86,6 +86,78 @@ async def test_search_papers_tool_uses_registry_defaults(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_search_patents_tool_uses_registry_defaults(monkeypatch):
+    """MCP 专利搜索省略 ``sources`` 时，也应透传 ``None`` 给 registry 默认源。"""
+    created: dict[str, _FakeServer] = {}
+
+    def fake_server_factory(name: str):
+        server = _FakeServer(name)
+        created["server"] = server
+        return server
+
+    monkeypatch.setattr(mcp_server, "Server", fake_server_factory, raising=False)
+    monkeypatch.setattr(mcp_server, "Tool", _FakeTool, raising=False)
+    monkeypatch.setattr(mcp_server, "TextContent", _FakeTextContent, raising=False)
+    monkeypatch.setattr(mcp_server, "get_bilibili_tools", lambda: [])
+    monkeypatch.setattr(mcp_server, "is_bilibili_tool", lambda name: False)
+
+    async def fake_dispatch(*args, **kwargs):
+        raise AssertionError("unexpected bilibili dispatch")
+
+    monkeypatch.setattr(mcp_server, "dispatch_bilibili_tool", fake_dispatch)
+
+    search_mod = importlib.import_module("souwen.search")
+    captured: dict = {}
+
+    async def fake_search_patents(query, sources=None, per_page=10, **kwargs):
+        captured["query"] = query
+        captured["sources"] = sources
+        captured["per_page"] = per_page
+        return []
+
+    monkeypatch.setattr(search_mod, "search_patents", fake_search_patents)
+
+    mcp_server.create_server()
+    server = created["server"]
+
+    tools = await server._list_tools()
+    patent_tool = next(tool for tool in tools if tool.name == "search_patents")
+    assert patent_tool.inputSchema["properties"]["sources"]["description"].endswith(
+        mcp_server._DEFAULT_PATENT_SOURCES_LABEL
+    )
+
+    result = await server._call_tool("search_patents", {"query": "foo"})
+    assert captured == {"query": "foo", "sources": None, "per_page": 5}
+    assert len(result) == 1
+    assert result[0].text == "[]"
+
+
+@pytest.mark.asyncio
+async def test_web_search_tool_mentions_registry_defaults(monkeypatch):
+    """MCP web_search 工具说明应同步 registry 的 web 默认源。"""
+    created: dict[str, _FakeServer] = {}
+
+    def fake_server_factory(name: str):
+        server = _FakeServer(name)
+        created["server"] = server
+        return server
+
+    monkeypatch.setattr(mcp_server, "Server", fake_server_factory, raising=False)
+    monkeypatch.setattr(mcp_server, "Tool", _FakeTool, raising=False)
+    monkeypatch.setattr(mcp_server, "TextContent", _FakeTextContent, raising=False)
+    monkeypatch.setattr(mcp_server, "get_bilibili_tools", lambda: [])
+
+    mcp_server.create_server()
+    tools = await created["server"]._list_tools()
+    web_tool = next(tool for tool in tools if tool.name == "web_search")
+
+    assert mcp_server._DEFAULT_WEB_ENGINES_LABEL in web_tool.description
+    assert web_tool.inputSchema["properties"]["engines"]["description"].endswith(
+        mcp_server._DEFAULT_WEB_ENGINES_LABEL
+    )
+
+
+@pytest.mark.asyncio
 async def test_fetch_content_tool_schema_mentions_scrapling(monkeypatch):
     """MCP fetch_content 工具说明应同步 fetch provider 能力。"""
     created: dict[str, _FakeServer] = {}

--- a/tests/test_server/test_app.py
+++ b/tests/test_server/test_app.py
@@ -1091,8 +1091,8 @@ class TestSearchWebResponseShape:
         assert data["total"] == 1
 
 
-class TestSearchPaperDefaults:
-    """API-PAPER-DEFAULTS: /search/paper 默认源与 registry 保持一致"""
+class TestSearchDefaults:
+    """API-SEARCH-DEFAULTS: /search/* 默认源与 registry 保持一致"""
 
     def test_paper_defaults_come_from_registry(self, client, monkeypatch):
         """未传 ``sources`` 时，应由 ``souwen.search`` 自行应用 registry 默认源。"""
@@ -1115,6 +1115,48 @@ class TestSearchPaperDefaults:
         assert data["sources"] == routes_search._DEFAULT_PAPER_SOURCES
         assert data["meta"]["requested"] == routes_search._DEFAULT_PAPER_SOURCES
         assert data["meta"]["failed"] == routes_search._DEFAULT_PAPER_SOURCES
+
+    def test_patent_defaults_come_from_registry(self, client, monkeypatch):
+        """未传 ``sources`` 时，专利搜索也应透传 ``None`` 让 registry 默认源生效。"""
+        import importlib
+
+        from souwen.server.routes import search as routes_search
+
+        search_mod = importlib.import_module("souwen.search")
+        captured: dict = {}
+
+        async def fake_search(q, sources=None, per_page=10, **kw):
+            captured["sources"] = sources
+            return []
+
+        monkeypatch.setattr(search_mod, "search_patents", fake_search)
+        resp = client.get("/api/v1/search/patent?q=foo")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert captured["sources"] is None
+        assert data["sources"] == routes_search._DEFAULT_PATENT_SOURCES
+        assert data["meta"]["requested"] == routes_search._DEFAULT_PATENT_SOURCES
+        assert data["meta"]["failed"] == routes_search._DEFAULT_PATENT_SOURCES
+
+    def test_web_defaults_come_from_registry(self, client, monkeypatch):
+        """未传 ``engines`` 时，web 搜索应透传 ``None`` 让 registry 默认源生效。"""
+        from souwen.server.routes import search as routes_search
+        from souwen.web import search as web_search_mod
+
+        captured: dict = {}
+
+        async def fake_web_search(q, engines=None, max_results_per_engine=10, **kw):
+            captured["engines"] = engines
+            return web_search_mod.WebSearchResponse(query=q, source="duckduckgo", results=[])
+
+        monkeypatch.setattr(web_search_mod, "web_search", fake_web_search)
+        resp = client.get("/api/v1/search/web?q=foo")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert captured["engines"] is None
+        assert data["engines"] == routes_search._DEFAULT_WEB_ENGINES
+        assert data["meta"]["requested"] == routes_search._DEFAULT_WEB_ENGINES
+        assert data["meta"]["failed"] == routes_search._DEFAULT_WEB_ENGINES
 
 
 class TestPerPageAlias:

--- a/tests/test_web/test_search.py
+++ b/tests/test_web/test_search.py
@@ -166,6 +166,29 @@ async def test_web_search_aggregates_engines():
     assert engines == {"duckduckgo", "bing"}
 
 
+async def test_web_search_uses_registry_defaults(monkeypatch):
+    """省略 ``engines`` 时，应从 registry default_for 派生默认 Web 源。"""
+    from souwen.web import search as web_search_mod
+
+    ddg_resp = _make_engine_response(
+        "duckduckgo", [_make_result("duckduckgo", "DDG 1", "https://ddg1.com")]
+    )
+    monkeypatch.setattr(web_search_mod, "_default_web_engines", lambda: ["duckduckgo"])
+
+    async with _override_adapters(
+        {
+            "duckduckgo": _make_fake_client_class(search_resp=ddg_resp),
+            "bing": _make_fake_client_class(
+                search_exc=AssertionError("bing should not be selected")
+            ),
+        }
+    ):
+        result = await web_search_mod.web_search("test query")
+
+    assert len(result.results) == 1
+    assert result.results[0].engine == "duckduckgo"
+
+
 async def test_web_search_deduplication():
     r1 = _make_result("duckduckgo", "Page", "https://example.com")
     r2 = _make_result("bing", "Page", "https://example.com/")


### PR DESCRIPTION
## 背景

本轮审查发现，`v2-dev` 的公开叙事已经把 SourceAdapter / `default_for` 作为数据源默认值的单一事实源，但部分入口仍保留硬编码默认值：

- `/api/v1/search/patent` 与 `souwen search patent` 默认写死 `google_patents`
- `/api/v1/search/web`、`souwen search web` 与 `web_search()` 默认写死 `duckduckgo,bing`
- MCP `search_patents` 默认参数仍直接填入 `google_patents`
- wheel metadata 的 Documentation / Changelog URL 仍指向 `main`，与当前 v2 仍在 `v2-dev` 的分支边界不一致

这些不影响当前默认值的实际结果，但会让后续调整 registry 默认源时出现入口漂移。

## 改动

- 让 patent/web 的 API、CLI、MCP 与 `web_search()` 省略参数时透传 `None`，由 registry `default_for` 派生默认源。
- 补充 API、CLI、MCP、web 聚合层测试，覆盖省略默认参数时的 registry 派生行为。
- 更新 `docs/api-reference.md`，把 patent/web 默认值说明改为 registry-derived。
- 更新 `pyproject.toml` 的 Documentation / Changelog URL 到 `v2-dev`，避免 v2 RC wheel 指向尚未 mergeback 的 `main` 文档。

## 验证

- `PYTHONPATH=src SOUWEN_PLUGIN_AUTOLOAD=0 python3 -m ruff format --check ...`
- `PYTHONPATH=src SOUWEN_PLUGIN_AUTOLOAD=0 python3 -m ruff check ...`
- `PYTHONPATH=src SOUWEN_PLUGIN_AUTOLOAD=0 python3 -m pytest tests/test_cli.py tests/test_server/test_app.py tests/test_integrations/test_mcp_server.py tests/test_web/test_search.py tests/test_infra.py -q`
- `PYTHONPATH=src SOUWEN_PLUGIN_AUTOLOAD=0 python3 scripts/ci/check_no_legacy_terms.py`
- `PYTHONPATH=src SOUWEN_PLUGIN_AUTOLOAD=0 python3 tools/gen_docs.py --check`
- `PYTHONPATH=src SOUWEN_PLUGIN_AUTOLOAD=0 python3 -m pytest tests/registry/test_consistency.py tests/test_gen_docs.py tests/test_import_surface.py -q`
- `actionlint`
- `PYTHONPATH=src SOUWEN_PLUGIN_AUTOLOAD=0 python3 -m pytest -q` (`1255 passed, 2 skipped`)
- `python3 -m pip wheel . --no-deps` 后检查 wheel METADATA 中 Documentation / Changelog 指向 `v2-dev`
