### PR TITLE
fix(v2): 对齐运行时默认源与插件契约

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -60,8 +60,9 @@ pip install -e .
 # API server (FastAPI) + TLS fingerprinting + web search
 pip install -e ".[server,tls,web,scraper]"
 
-# Full install (includes PDF / Crawl4AI / newspaper, etc.)
+# Heavy fetch providers are installed on demand: crawl4ai and scrapling are currently mutually exclusive.
 pip install -e ".[server,tls,web,scraper,pdf,crawl4ai,newspaper,readability,robots,mcp]"
+pip install -e ".[server,tls,web,scraper,pdf,scrapling,newspaper,readability,robots,mcp]"
 ```
 
 ## 🚀 Quick Start

--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ pip install -e .
 # API 服务（FastAPI）+ TLS 指纹 + 网页搜索
 pip install -e ".[server,tls,web,scraper]"
 
-# 全量（含 PDF / Crawl4AI / Scrapling / newspaper 等）
-pip install -e ".[server,tls,web,scraper,pdf,crawl4ai,scrapling,newspaper,readability,robots,mcp]"
+# 重型抓取能力按需选择：crawl4ai 与 scrapling 当前依赖树互斥，二选一安装
+pip install -e ".[server,tls,web,scraper,pdf,crawl4ai,newspaper,readability,robots,mcp]"
+pip install -e ".[server,tls,web,scraper,pdf,scrapling,newspaper,readability,robots,mcp]"
 ```
 
 ## 🚀 快速开始

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -33,7 +33,7 @@ from souwen import search, search_papers, search_patents, web_search
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `query` | `str` | — | 搜索关键词 |
-| `sources` | `list[str] \| None` | `["openalex", "crossref", "arxiv", "dblp", "pubmed"]` | 数据源列表 |
+| `sources` | `list[str] \| None` | `null`（registry `paper:search` 当前为 `["openalex", "crossref", "arxiv", "dblp", "pubmed", "biorxiv"]`） | 数据源列表 |
 | `per_page` | `int` | `10` | 每个源返回结果数 |
 
 #### `search_patents(query, sources=None, per_page=10, **kwargs)` → `list[SearchResponse]`
@@ -429,7 +429,7 @@ Cache-Control: public, max-age=3600
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `q` | string (1-500) | *(必填)* | 搜索关键词 |
-| `sources` | string | `"openalex,arxiv"` | 数据源列表，逗号分隔 |
+| `sources` | string \| null | `null`（registry `paper:search` 当前为 `openalex,crossref,arxiv,dblp,pubmed,biorxiv`） | 数据源列表，逗号分隔 |
 | `per_page` | int (1-100) | `10` | 每个数据源返回结果数 |
 | `timeout` | float (1-300) \| null | `null` | 端点硬超时（秒），超时返回 504；`null` 表示无超时 |
 
@@ -510,7 +510,7 @@ Cache-Control: public, max-age=3600
     }
   ],
   "defaults": {
-    "paper:search": ["arxiv", "biorxiv", "crossref", "dblp", "openalex", "pubmed"]
+    "paper:search": ["openalex", "crossref", "arxiv", "dblp", "pubmed", "biorxiv"]
   }
 }
 ```
@@ -976,7 +976,7 @@ python -m souwen.integrations.mcp_server
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `query` | string | — | 搜索关键词 |
-| `sources` | array | `["openalex", "arxiv", "crossref"]` | 数据源 |
+| `sources` | array | `null`（registry `paper:search` 当前为 `["openalex", "crossref", "arxiv", "dblp", "pubmed", "biorxiv"]`） | 数据源 |
 | `limit` | int | `5` | 每源返回数量 |
 
 返回：JSON `SearchResponse` 数组

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,10 +18,12 @@ pip install -e ".[server,tls,web,scraper]"
 pip install -e .
 ```
 
-需要 Crawl4AI、Scrapling、PDF、MCP 等能力时，再按需追加 extras：
+需要 Crawl4AI、Scrapling、PDF、MCP 等能力时，再按需追加 extras。`crawl4ai`
+与 `scrapling` 当前依赖树互斥，请按目标 provider 二选一：
 
 ```bash
-pip install -e ".[server,tls,web,scraper,pdf,crawl4ai,scrapling,newspaper,readability,robots,mcp]"
+pip install -e ".[server,tls,web,scraper,pdf,crawl4ai,newspaper,readability,robots,mcp]"
+pip install -e ".[server,tls,web,scraper,pdf,scrapling,newspaper,readability,robots,mcp]"
 ```
 
 ## CLI 搜索
@@ -47,7 +49,7 @@ from souwen.web.fetch import fetch_content
 
 async def main() -> None:
     papers = await search("transformer", domain="paper", limit=5)
-    mixed = await search_all("quantum", domains=["paper", "web", "knowledge"], limit=5)
+    mixed = await search_all("quantum", domains=["paper", "web", "knowledge"], per_domain_limit=5)
     pages = await fetch_content(["https://example.com"], providers=["builtin"])
     print(papers[0].source, len(mixed), pages.total_ok)
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -11,7 +11,7 @@ from souwen.search import search, search_all, search_by_capability
 papers = await search("transformer", domain="paper", limit=5)
 web = await search("python asyncio", domain="web", capability="search", limit=5)
 news = await search_by_capability("AI news", capability="search_news", limit=5)
-mixed = await search_all("quantum computing", domains=["paper", "web"], limit=5)
+mixed = await search_all("quantum computing", domains=["paper", "web"], per_domain_limit=5)
 ```
 
 `search()` 返回按源聚合的 `SearchResponse` 列表。单个源失败不会阻断其他源。

--- a/docs/source-catalog.md
+++ b/docs/source-catalog.md
@@ -29,7 +29,7 @@ Source Catalog 是 SouWen 的公开数据源契约。它不是手写清单，而
     }
   ],
   "defaults": {
-    "paper:search": ["arxiv", "biorxiv", "crossref", "dblp", "openalex", "pubmed"]
+    "paper:search": ["openalex", "crossref", "arxiv", "dblp", "pubmed", "biorxiv"]
   }
 }
 ```

--- a/src/souwen/registry/adapter.py
+++ b/src/souwen/registry/adapter.py
@@ -415,9 +415,7 @@ class SourceAdapter:
             raise ValueError(
                 f"SourceAdapter({self.name!r}) auth_requirement='none' 不能声明 credential_fields"
             )
-        if (
-            self.integration == "self_hosted" or effective_auth == "self_hosted"
-        ) and not resolved_fields:
+        if effective_auth == "self_hosted" and not resolved_fields:
             raise ValueError(
                 f"SourceAdapter({self.name!r}) self_hosted 源必须声明 config_field 或 credential_fields"
             )
@@ -448,4 +446,25 @@ class SourceAdapter:
             if ":" not in key:
                 raise ValueError(
                     f"SourceAdapter({self.name!r}) default_for 条目 {key!r} 必须是 'domain:capability' 形式"
+                )
+            default_domain, default_capability = key.split(":", 1)
+            if default_domain != FETCH_DOMAIN and default_domain not in DOMAINS:
+                raise ValueError(
+                    f"SourceAdapter({self.name!r}) default_for domain={default_domain!r} "
+                    "不在 DOMAINS ∪ {fetch} 中"
+                )
+            if default_capability not in CAPABILITIES:
+                raise ValueError(
+                    f"SourceAdapter({self.name!r}) default_for capability={default_capability!r} "
+                    "不在 CAPABILITIES 中"
+                )
+            if default_capability not in self.capabilities:
+                raise ValueError(
+                    f"SourceAdapter({self.name!r}) default_for={key!r} "
+                    f"但 methods 里没有 {default_capability!r}"
+                )
+            if default_domain not in self.domains:
+                raise ValueError(
+                    f"SourceAdapter({self.name!r}) default_for={key!r} "
+                    f"但 domain 不在 adapter.domains={self.domains}"
                 )

--- a/src/souwen/registry/catalog.py
+++ b/src/souwen/registry/catalog.py
@@ -251,11 +251,14 @@ def sources_by_category(category: str) -> list[SourceCatalogEntry]:
 def default_source_map() -> dict[str, tuple[str, ...]]:
     """返回 ``domain:capability`` 到默认源名的声明式映射。"""
 
-    result: dict[str, list[str]] = {}
-    for entry in source_catalog().values():
-        for key in entry.default_for:
-            result.setdefault(key, []).append(entry.name)
-    return {key: tuple(names) for key, names in sorted(result.items())}
+    keys = sorted(
+        {key for adapter in _views.all_adapters().values() for key in adapter.default_for}
+    )
+    result: dict[str, tuple[str, ...]] = {}
+    for key in keys:
+        domain, capability = key.split(":", 1)
+        result[key] = tuple(_views.defaults_for(domain, capability))
+    return result
 
 
 def available_source_catalog(config: Any) -> dict[str, SourceCatalogEntry]:

--- a/src/souwen/search.py
+++ b/src/souwen/search.py
@@ -347,6 +347,12 @@ async def search_all(
     **kwargs: Any,
 ) -> dict[str, list[SearchResponse]]:
     """跨多个 domain 并行搜索，按 domain 分组返回。"""
+    if "limit" in kwargs:
+        alias_limit = kwargs.pop("limit")
+        if per_domain_limit != 5 and alias_limit != per_domain_limit:
+            raise ValueError("search_all() 不应同时传入不同的 per_domain_limit 和 limit")
+        per_domain_limit = int(alias_limit)
+
     selected = list(domains) if domains else list(DEFAULT_AGGREGATE_DOMAINS)
     results: dict[str, list[SearchResponse]] = {}
 

--- a/src/souwen/web/search.py
+++ b/src/souwen/web/search.py
@@ -126,7 +126,7 @@ async def web_search(
         >>> for r in resp.results:
         ...     print(f"[{r.engine}] {r.title} → {r.url}")
     """
-    selected = engines or _default_web_engines()
+    selected = _default_web_engines() if engines is None else list(engines)
 
     tasks = []
     active_engines: list[str] = []

--- a/tests/registry/test_catalog.py
+++ b/tests/registry/test_catalog.py
@@ -198,17 +198,7 @@ def test_adapter_registration_order_snapshot() -> None:
 
 
 def test_default_source_order_snapshot() -> None:
-    assert {
-        "paper:search": defaults_for("paper", "search"),
-        "patent:search": defaults_for("patent", "search"),
-        "web:search": defaults_for("web", "search"),
-        "web:search_news": defaults_for("web", "search_news"),
-        "video:search": defaults_for("video", "search"),
-        "knowledge:search": defaults_for("knowledge", "search"),
-        "developer:search": defaults_for("developer", "search"),
-        "archive:archive_lookup": defaults_for("archive", "archive_lookup"),
-        "fetch:fetch": defaults_for("fetch", "fetch"),
-    } == {
+    expected = {
         "paper:search": ["openalex", "crossref", "arxiv", "dblp", "pubmed", "biorxiv"],
         "patent:search": ["google_patents"],
         "web:search": ["duckduckgo", "bing"],
@@ -219,6 +209,18 @@ def test_default_source_order_snapshot() -> None:
         "archive:archive_lookup": ["wayback"],
         "fetch:fetch": ["builtin"],
     }
+    assert {
+        "paper:search": defaults_for("paper", "search"),
+        "patent:search": defaults_for("patent", "search"),
+        "web:search": defaults_for("web", "search"),
+        "web:search_news": defaults_for("web", "search_news"),
+        "video:search": defaults_for("video", "search"),
+        "knowledge:search": defaults_for("knowledge", "search"),
+        "developer:search": defaults_for("developer", "search"),
+        "archive:archive_lookup": defaults_for("archive", "archive_lookup"),
+        "fetch:fetch": defaults_for("fetch", "fetch"),
+    } == expected
+    assert {key: list(names) for key, names in default_source_map().items()} == expected
 
 
 def test_non_public_high_risk_and_deprecated_sources_are_not_default_available() -> None:

--- a/tests/registry/test_consistency.py
+++ b/tests/registry/test_consistency.py
@@ -198,11 +198,27 @@ class TestSourceAdapterCatalogValidation:
         ):
             self._adapter(auth_requirement="self_hosted")
 
-    def test_self_hosted_integration_without_declared_fields_is_rejected(self):
-        with pytest.raises(
-            ValueError, match="self_hosted 源必须声明 config_field 或 credential_fields"
-        ):
-            self._adapter(integration="self_hosted", needs_config=False)
+    def test_self_hosted_integration_can_explicitly_be_zero_config(self):
+        adapter = self._adapter(integration="self_hosted", needs_config=False)
+        assert adapter.resolved_auth_requirement == "none"
+        assert adapter.resolved_credential_fields == ()
+        assert adapter.resolved_needs_config is False
+
+    def test_default_for_invalid_domain_is_rejected(self):
+        with pytest.raises(ValueError, match="default_for domain=.*DOMAINS"):
+            self._adapter(default_for=frozenset({"wiki:fetch"}))
+
+    def test_default_for_invalid_capability_is_rejected(self):
+        with pytest.raises(ValueError, match="default_for capability=.*CAPABILITIES"):
+            self._adapter(default_for=frozenset({"fetch:render"}))
+
+    def test_default_for_missing_method_is_rejected(self):
+        with pytest.raises(ValueError, match="methods 里没有"):
+            self._adapter(default_for=frozenset({"fetch:archive_lookup"}))
+
+    def test_default_for_domain_mismatch_is_rejected(self):
+        with pytest.raises(ValueError, match="adapter\\.domains"):
+            self._adapter(default_for=frozenset({"web:fetch"}))
 
     def test_has_required_credentials_rejects_required_meta_without_fields(self):
         from types import SimpleNamespace

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -254,6 +254,24 @@ def test_search_web_uses_registry_defaults_when_engines_omitted(monkeypatch):
     assert captured == {"query": "test", "engines": None, "max_results_per_engine": 10}
 
 
+def test_search_web_preserves_explicit_empty_engines(monkeypatch):
+    """网页搜索显式传空 ``--engines`` 时，应透传空列表而不是回退默认源。"""
+    from souwen.web import search as web_search_mod
+
+    captured = {}
+
+    async def fake_web_search(query, engines=None, max_results_per_engine=10, **kwargs):
+        captured["query"] = query
+        captured["engines"] = engines
+        captured["max_results_per_engine"] = max_results_per_engine
+        return web_search_mod.WebSearchResponse(query=query, source="duckduckgo", results=[])
+
+    monkeypatch.setattr(web_search_mod, "web_search", fake_web_search)
+    result = runner.invoke(app, ["search", "web", "test", "--engines", "", "--json"])
+    assert result.exit_code == 0
+    assert captured == {"query": "test", "engines": [], "max_results_per_engine": 10}
+
+
 def test_plugins_new_scaffolds_project(monkeypatch, tmp_path: Path):
     """``plugins new`` creates a complete plugin project skeleton."""
     monkeypatch.chdir(tmp_path)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -296,6 +296,35 @@ async def test_search_all_groups_domain_results(monkeypatch):
     ]
 
 
+async def test_search_all_accepts_limit_alias(monkeypatch):
+    """兼容公开示例中使用的 ``limit`` 别名，避免被 **kwargs 重复传参吞空。"""
+    search_mod = importlib.import_module("souwen.search")
+    calls = []
+
+    async def fake_search(query, domain="paper", **kwargs):
+        calls.append((query, domain, kwargs))
+        return [SearchResponse(query=query, source="openalex", results=[])]
+
+    monkeypatch.setattr(search_mod, "search", fake_search)
+
+    out = await search_mod.search_all("agent", domains=["paper"], limit=3)
+
+    assert sorted(out) == ["paper"]
+    assert calls == [("agent", "paper", {"limit": 3})]
+
+
+async def test_search_all_rejects_conflicting_limit_alias():
+    """两个限制参数同时传且值不同应显式失败。"""
+    search_mod = importlib.import_module("souwen.search")
+
+    try:
+        await search_mod.search_all("agent", domains=["paper"], per_domain_limit=2, limit=3)
+    except ValueError as exc:
+        assert "per_domain_limit 和 limit" in str(exc)
+    else:  # pragma: no cover - 失败路径
+        raise AssertionError("search_all() should reject conflicting limits")
+
+
 def test_semaphore_is_per_event_loop():
     """_get_semaphore 在不同 event loop 中返回不同实例，避免跨 loop 错误。
 

--- a/tests/test_web/test_search.py
+++ b/tests/test_web/test_search.py
@@ -189,6 +189,21 @@ async def test_web_search_uses_registry_defaults(monkeypatch):
     assert result.results[0].engine == "duckduckgo"
 
 
+async def test_web_search_empty_engines_is_explicit_noop(monkeypatch):
+    """显式传空 ``engines`` 不应回退到 registry 默认源。"""
+    from souwen.web import search as web_search_mod
+
+    def fail_if_defaulted():
+        raise AssertionError("empty engines must not use registry defaults")
+
+    monkeypatch.setattr(web_search_mod, "_default_web_engines", fail_if_defaulted)
+
+    result = await web_search_mod.web_search("test query", engines=[])
+
+    assert result.results == []
+    assert result.total_results == 0
+
+
 async def test_web_search_deduplication():
     r1 = _make_result("duckduckgo", "Page", "https://example.com")
     r2 = _make_result("bing", "Page", "https://example.com/")


### PR DESCRIPTION
## 背景

本 PR 收口 v2-dev 深审中发现的 runtime/default/docs 契约漂移问题，目标是让 registry、CLI、API、Python 示例和公开文档保持同一套语义。

## 主要变更

- 调整 `SourceAdapter` 注册期校验：只在最终 `auth_requirement=self_hosted` 时强制要求配置字段，允许显式 `needs_config=False` 的零配置自托管/嵌入式插件注册；同时补齐 `default_for` 的 domain、capability、methods 和 adapter domains 防呆。
- 修复 Source Catalog 默认源顺序：`default_source_map()` 复用 `defaults_for()`，避免 `/api/v1/sources` 与实际 dispatch 顺序漂移。
- 修复搜索入口边界：`web_search(engines=[])` 保持显式空列表语义，不再回退默认源；`search_all(limit=...)` 兼容旧示例别名并拒绝冲突参数。
- 更新 README、getting-started、Python/API/Source Catalog 文档：明确 `crawl4ai` 与 `scrapling` 当前依赖树互斥，需要按目标 provider 二选一安装；默认源示例与 registry 当前顺序一致。

## 验证

- `PYTHONPATH=src SOUWEN_PLUGIN_AUTOLOAD=0 python3 -m pytest -q` -> 1263 passed, 2 skipped
- `npm test` -> 76 passed
- `npx tsc --noEmit`
- `ruff check src tests scripts`
- `ruff format --check src tests scripts`
- `python3 -m compileall src tests -q`
- `PYTHONPATH=src python3 tools/gen_docs.py --check`
- `actionlint .github/workflows/*.yml`
- `PYTHONPATH=src SOUWEN_PLUGIN_AUTOLOAD=0 python3 scripts/ci/run_profile.py --profile server --profile minimal --profile full --profile plugin`
- `uv pip compile` 分别验证 crawl4ai-only 与 scrapling-only extras 可解，crawl4ai+scrapling 合装不可解
- 本机 `superweb2pdf` entry point 实测可通过 `ensure_plugins_loaded()` 正常注册，无插件加载错误

## 边界

- 未等待或依赖 Nuitka 构建结果。
- 未启用 v2-dev 到生产发布、PyPI 或 HF Space 自动部署。