### PR TITLE
fix(v2): 对齐 optional dependency 元数据与构建安装面

### DIFF
--- a/.github/workflows/build-nuitka.yml
+++ b/.github/workflows/build-nuitka.yml
@@ -134,7 +134,7 @@ jobs:
         if: matrix.build_type == 'full'
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[server,tls,web,scraper,newspaper,readability,pdf,mcp,web2pdf]"
+          pip install -e ".[server,tls,web,scraper,newspaper,readability,pdf,mcp]"
           pip install nuitka ordered-set zstandard
 
       - name: Install C compiler (Ubuntu)

--- a/.github/workflows/build-pyinstaller.yml
+++ b/.github/workflows/build-pyinstaller.yml
@@ -192,7 +192,7 @@ jobs:
         if: matrix.build_type == 'full'
         run: |
           python -m pip install --upgrade pip
-          pip install ".[server,tls,web,scraper,newspaper,readability,pdf,mcp,web2pdf]"
+          pip install ".[server,tls,web,scraper,newspaper,readability,pdf,mcp]"
           pip install "setuptools<82" pyinstaller
 
       - name: Verify CLI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Source Catalog 成为 Source metadata、capability、credential、risk、distribution、docs、API、CLI 和 Panel 的正式派生中心。
 - result `source` 字段标准化为 adapter name，避免历史 category/name 双轨。
 - 插件加载显式化，避免 registry import 阶段自动执行第三方 entry point。
+- SuperWeb2PDF 保持外部插件形态，不再作为 SouWen 的 optional dependency 随公开 extras 分发；Docker / 镜像场景改由插件包预装。
 - Fetch API 支持 `fallback` / `fanout` 策略，多 provider 行为与签名一致。
 - 内置 source registry 拆分为 `registry/sources/` package，降低单文件事实源维护压力。
 
@@ -137,14 +138,14 @@
 ### Architecture
 - 新增插件系统：通过 setuptools entry_points 或配置文件发现外部数据源
 - Fetch dispatch 重构：20 个 if/elif 分支 → handler 注册表模式
-- 支持双模式加载：运行时发现 (`pip install superweb2pdf`) 和打包嵌入 (`pip install -e ".[web2pdf]"`)
+- 支持运行时发现；早期打包嵌入方案已在 RC 收口时改为外部插件 / 镜像预装。
 
 ### Features
 - `src/souwen/plugin.py`：插件发现与加载模块
 - `register_fetch_handler()`：外部 fetch provider 注册 API
 - `_reg_external()`：外部适配器注册（重名自动跳过）
 - `SOUWEN_PLUGINS` 环境变量 / `plugins` 配置字段支持手动指定插件
-- `web2pdf` optional dependency：`pip install -e ".[web2pdf]"`
+- `superweb2pdf` 保持外部插件包，由运行时安装或镜像预装接入。
 
 ### Docs
 - 新增 `docs/plugin-integration-spec.md`：插件对接规范
@@ -157,7 +158,7 @@
 - 更新 `tests/registry/test_consistency.py`：外部插件一致性检查
 
 ### CI
-- 新增 `plugin-test` job：安装 web2pdf extra，验证 entry_point 发现
+- 新增 `plugin-test` job：验证 entry_point 发现，并将可选 `superweb2pdf` 缺失记录为非阻断 WARN。
 - import-check 步骤扩展：插件模块导入验证
 
 ## v0.9.0 — v1 过渡版（2026-04-22）

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,9 @@ ARG WGCF_VERSION=2.2.30
 ARG WIREPROXY_VERSION=1.1.2
 # usque: MASQUE/QUIC 协议 WARP 客户端
 ARG USQUE_VERSION=3.0.0
-# 默认安装 web2pdf/SuperWeb2PDF 插件及其浏览器运行时
+# SuperWeb2PDF 是外部插件；设置 WITH_WEB2PDF=1 时按 WEB2PDF_PACKAGE 预装
 ARG WITH_WEB2PDF=0
+ARG WEB2PDF_PACKAGE=superweb2pdf
 
 # 环境变量配置
 # WARP 代理环境变量
@@ -41,7 +42,7 @@ ENV PYTHONUNBUFFERED=1 \
 # ===== 系统依赖安装 =====
 # 安装 WARP 相关工具：curl、wireguard-tools
 # 安装时区数据、网络工具和 Playwright Chromium 运行库
-# 以下为 Playwright Chromium 运行所需系统库（web2pdf/SuperWeb2PDF 插件需要）
+# 以下为 Playwright Chromium 运行所需系统库（SuperWeb2PDF 外部插件需要）
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl tzdata wireguard-tools iptables iproute2 \
         libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 \
@@ -81,27 +82,22 @@ WORKDIR /app
 
 # 步骤 1：复制项目配置和版本信息，安装核心依赖
 # 注：curl_cffi 位于 [tls] extras，用于专利爬虫/反爬指纹，必须同时安装
-# 默认安装 web2pdf/SuperWeb2PDF 插件；可通过 --build-arg WITH_WEB2PDF=0 关闭
+# 默认只安装 SouWen server/tls；SuperWeb2PDF 需通过外部插件包显式预装
 COPY pyproject.toml README.md LICENSE ./
 COPY src/souwen/__init__.py ./src/souwen/__init__.py
-RUN if [ "${WITH_WEB2PDF}" = "1" ]; then \
-        pip install ".[server,tls,web2pdf]"; \
-    else \
-        pip install ".[server,tls]"; \
+RUN pip install ".[server,tls]" \
+    && if [ "${WITH_WEB2PDF}" = "1" ]; then \
+        pip install "${WEB2PDF_PACKAGE}"; \
     fi
 
 # 步骤 2：复制全部源码并重新安装（确保最新版本）
 COPY src/ ./src/
 # 复制前端面板的构建产物
 COPY --from=panel-builder /panel/dist/index.html ./src/souwen/server/panel.html
-RUN if [ "${WITH_WEB2PDF}" = "1" ]; then \
-        pip install --no-deps ".[server,tls,web2pdf]"; \
-    else \
-        pip install --no-deps ".[server,tls]"; \
-    fi \
+RUN pip install --no-deps ".[server,tls]" \
     && python -c "import curl_cffi; print('curl_cffi OK')"
 
-# 步骤 2.5：安装 Playwright Chromium（仅 web2pdf 插件需要）
+# 步骤 2.5：安装 Playwright Chromium（仅 SuperWeb2PDF 外部插件需要）
 RUN if [ "${WITH_WEB2PDF}" = "1" ]; then \
         playwright install chromium \
         && echo "✅ Playwright Chromium installed"; \

--- a/cloud/hfs/Dockerfile
+++ b/cloud/hfs/Dockerfile
@@ -18,15 +18,16 @@ ARG SOUWEN_REPO=https://github.com/BlueSkyXN/SouWen.git
 ARG SOUWEN_REF=main
 ARG WGCF_VERSION=2.2.30
 ARG WIREPROXY_VERSION=1.1.2
-# 默认安装 web2pdf/SuperWeb2PDF 插件及其浏览器运行时
+# SuperWeb2PDF 是外部插件；设置 WITH_WEB2PDF=1 时按 WEB2PDF_PACKAGE 预装
 ARG WITH_WEB2PDF=0
+ARG WEB2PDF_PACKAGE=superweb2pdf
 
 ENV PORT=49265 \
     PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     TZ=Asia/Shanghai
 
-# 安装基础工具和 Playwright Chromium 运行库（web2pdf/SuperWeb2PDF 插件需要）
+# 安装基础工具和 Playwright Chromium 运行库（SuperWeb2PDF 外部插件需要）
 RUN apt-get update && apt-get install -y --no-install-recommends \
         git ca-certificates curl tzdata \
         libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 \
@@ -58,13 +59,14 @@ RUN git init . \
 COPY --from=panel-builder /build/panel/dist/index.html ./src/souwen/server/panel.html
 
 RUN if [ "${WITH_WEB2PDF}" = "1" ]; then \
-        pip install ".[server,tls,web2pdf]"; \
+        pip install ".[server,tls]" \
+        && pip install "${WEB2PDF_PACKAGE}"; \
     else \
         pip install ".[server,tls]"; \
     fi \
     && python -c "import curl_cffi; print('curl_cffi OK')"
 
-# 安装 Playwright Chromium（仅 web2pdf 插件需要）
+# 安装 Playwright Chromium（仅 SuperWeb2PDF 外部插件需要）
 RUN if [ "${WITH_WEB2PDF}" = "1" ]; then \
         playwright install chromium \
         && echo "✅ Playwright Chromium installed"; \

--- a/cloud/modelscope/Dockerfile
+++ b/cloud/modelscope/Dockerfile
@@ -17,8 +17,9 @@ ARG WGCF_VERSION=2.2.30
 ARG WIREPROXY_VERSION=1.1.2
 ARG USQUE_VERSION=3.0.0
 ARG GH_PROXY=""
-# 默认安装 web2pdf/SuperWeb2PDF 插件及其浏览器运行时
+# SuperWeb2PDF 是外部插件；设置 WITH_WEB2PDF=1 时按 WEB2PDF_PACKAGE 预装
 ARG WITH_WEB2PDF=0
+ARG WEB2PDF_PACKAGE=superweb2pdf
 # 可选：指定 Playwright 浏览器下载镜像（国内环境可用）
 ARG PLAYWRIGHT_DOWNLOAD_HOST=""
 
@@ -27,8 +28,8 @@ ENV PORT=7860 \
     PIP_NO_CACHE_DIR=1 \
     TZ=Asia/Shanghai
 
-# 安装基础工具和 Playwright Chromium 运行库（web2pdf/SuperWeb2PDF 插件需要）
-# 以下为 Playwright Chromium 运行所需系统库（web2pdf/SuperWeb2PDF 插件需要）
+# 安装基础工具和 Playwright Chromium 运行库（SuperWeb2PDF 外部插件需要）
+# 以下为 Playwright Chromium 运行所需系统库（SuperWeb2PDF 外部插件需要）
 RUN apt-get update && apt-get install -y --no-install-recommends \
         git ca-certificates curl tzdata \
         libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 \
@@ -62,13 +63,14 @@ RUN git clone --depth 1 --branch "${SOUWEN_REF}" "${SOUWEN_REPO}" .
 COPY --from=panel-builder /build/panel/dist/index.html ./src/souwen/server/panel.html
 
 RUN if [ "${WITH_WEB2PDF}" = "1" ]; then \
-        pip install ".[server,tls,web2pdf]"; \
+        pip install ".[server,tls]" \
+        && pip install "${WEB2PDF_PACKAGE}"; \
     else \
         pip install ".[server,tls]"; \
     fi \
     && python -c "import curl_cffi; print('curl_cffi OK')"
 
-# 安装 Playwright Chromium（仅 web2pdf 插件需要，国内环境可配置下载镜像）
+# 安装 Playwright Chromium（仅 SuperWeb2PDF 外部插件需要，国内环境可配置下载镜像）
 RUN if [ "${WITH_WEB2PDF}" = "1" ]; then \
         if [ -n "${PLAYWRIGHT_DOWNLOAD_HOST}" ]; then \
             PLAYWRIGHT_DOWNLOAD_HOST="${PLAYWRIGHT_DOWNLOAD_HOST}" playwright install chromium; \

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -213,16 +213,16 @@ client_cls = adapter.client_loader()  # 此刻才 importlib.import_module
 注册表除了承载内置的 94 个 `_reg()`，还能在运行时**通过外部插件**追加新的
 `SourceAdapter`，让第三方 / 私有源在不改主仓代码的前提下被 SouWen 发现。
 
-### 双模式加载
+### 运行时发现与打包边界
 
-插件可以通过两种方式部署，二者使用同一套 entry_points 机制：
+插件通过 entry_points 发现。第三方插件不固定进 SouWen 的公开 extras；需要随
+镜像预装时，由镜像或部署脚本单独安装对应插件包：
 
 | 模式 | 安装命令 | 适用场景 |
 |---|---|---|
 | **运行时发现** | `pip install superweb2pdf` | 第三方包单独分发；与 SouWen 解耦升级 |
-| **打包嵌入** | `pip install -e ".[web2pdf]"` | Docker / 一键部署；插件依赖随 SouWen extras 自动拉取 |
+| **镜像预装** | 在镜像或部署脚本中单独安装插件包 | 私有索引、内部插件或固定部署镜像 |
 
-Docker 镜像示例：`pip install ".[server,tls,web2pdf]"`。
 两种模式都依赖同一个 `[project.entry-points."souwen.plugins"]` 声明，
 CLI / server 启动时通过 `ensure_plugins_loaded(get_config())` 显式扫描发现。
 单纯 `import souwen.registry` 只注册内置源，不执行第三方 entry point。

--- a/docs/plugin-integration-spec.md
+++ b/docs/plugin-integration-spec.md
@@ -40,29 +40,21 @@ SouWen 的所有数据源都通过 [`SourceAdapter`](../src/souwen/registry/adap
 my-source = "my_plugin:plugin"
 ```
 
-### 双模式加载（运行时发现 vs 打包嵌入）
+### 运行时发现与打包边界
 
-同一份 entry_points 声明支持两种部署形态，二者使用**完全相同**的发现机制：
+同一份 entry_points 声明支持运行时发现；如需在私有镜像中预装插件，也应通过
+镜像自己的 dependency set 或私有索引安装，而不是把第三方插件固定进 SouWen
+主仓的公开 extras：
 
 | 模式 | 安装方式 | 适用场景 |
 |---|---|---|
 | **运行时发现** | `pip install superweb2pdf` 单独安装第三方包 | 第三方包单独分发；插件随宿主升级解耦；社区分发 |
-| **打包嵌入（optional dependency）** | `pip install -e ".[web2pdf]"` | Docker 镜像 / 一键部署；插件依赖随 SouWen extras 自动安装 |
+| **镜像预装** | 在镜像或部署脚本中单独安装插件包 | 私有索引、内部插件或固定部署镜像 |
 
-**Docker / 多 extras**：`pip install ".[server,tls,web2pdf]"`。
-
-要把插件挂到 SouWen 的 optional dependencies 上，宿主项目在 `pyproject.toml`
-中追加（仅 SouWen 主仓维护者关心）：
-
-```toml
-[project.optional-dependencies]
-web2pdf = ["superweb2pdf[capture]>=0.2.0"]
-```
-
-无论哪种模式，SouWen 的 CLI / server bootstrap 都会调用
+无论哪种部署形态，SouWen 的 CLI / server bootstrap 都会调用
 `ensure_plugins_loaded(get_config())`，再通过
 `importlib.metadata.entry_points(group="souwen.plugins")` 扫描发现。
-**插件作者通常只需声明 entry_points**，是否打包嵌入由宿主决定。
+**插件作者通常只需声明 entry_points**，是否随镜像预装由部署方决定。
 单纯 `import souwen.registry` 只注册内置源，不会执行第三方 entry point。
 
 ### Entry Point 目标可以是四种形态

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,10 +75,16 @@ scraper = ["curl-cffi>=0.14.0"]
 server = ["fastapi>=0.111", "uvicorn[standard]>=0.29"]
 # MCP 服务器协议支持
 mcp = ["mcp>=1.0"]
-# SuperWeb2PDF 网页截图转 PDF（可选外挂插件，源码目录执行 pip install -e ".[web2pdf]"）
-web2pdf = ["superweb2pdf[capture]>=0.2.0"]
 # 开发工具：单元测试、覆盖率、代码检查
 dev = ["pytest>=8.0", "pytest-asyncio>=0.23", "pytest-httpx>=0.30", "pytest-cov>=4", "ruff>=0.4"]
+
+[tool.uv]
+conflicts = [
+    [
+        { extra = "crawl4ai" },
+        { extra = "scrapling" },
+    ],
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/souwen"]


### PR DESCRIPTION
## 概述

修复 `v2-dev` 依赖元数据、二进制构建安装面和 Docker 部署面中会影响可复现性的边界问题：

- `crawl4ai` 与 `scrapling` 当前依赖树互斥，但项目未向 `uv` 声明 extra conflict，导致 `uv lock` / `uv run` 在解析全部 extras 时失败。
- `web2pdf` optional extra 指向公开索引不可解析的 `superweb2pdf[capture]>=0.2.0`，并被 full binary build / Docker 镜像安装面纳入，fresh runner 或 fresh Docker build 会在依赖安装阶段失败。

## 修复内容

- 在 `pyproject.toml` 增加 `tool.uv.conflicts`，显式声明 `crawl4ai` 与 `scrapling` extras 互斥。
- 移除 `web2pdf` optional extra，避免公开 package metadata 暴露不可解析依赖。
- `Build with PyInstaller` / `Build with Nuitka` 的 full install 不再安装 `web2pdf` extra。
- `Dockerfile`、`cloud/hfs/Dockerfile`、`cloud/modelscope/Dockerfile` 不再依赖 `.[web2pdf]`；`WITH_WEB2PDF=1` 改为通过 `WEB2PDF_PACKAGE` 显式预装外部插件包。
- 更新 `docs/architecture.md`、`docs/plugin-integration-spec.md` 和 `CHANGELOG.md`，把 SuperWeb2PDF 口径收敛为外部插件 / 镜像预装，不再承诺 `.[web2pdf]`。

## 验证

- `uv lock --dry-run`
- `uv sync --dry-run --extra crawl4ai --extra scrapling` 返回声明式 conflict，而不是 resolver 级依赖爆炸
- `python3 -m pip install --dry-run -e ".[dev,server,tls,web,scraper,newspaper,readability,pdf,mcp]"`
- `python3 -m pip install --dry-run -e ".[server,tls]"`
- `python3 -m pip install --dry-run -e ".[web2pdf]"` 仅提示 SouWen 不再提供该 extra，不再拉取不可解析依赖
- `PYTHONPATH=src python3 -m pytest tests/registry/test_consistency.py tests/registry/test_catalog.py tests/test_gen_docs.py tests/test_plugin_manager.py tests/test_plugin_functional_check.py -q`
- `PYTHONPATH=src python3 tools/gen_docs.py --check`
- `ruff check src tests scripts`
- `actionlint .github/workflows/*.yml`
- `git diff --check`
- 残留扫描：`rg` 未再发现 `.[web2pdf]` / `server,tls,web2pdf` 安装引用

## 文件清单

- `pyproject.toml`
- `.github/workflows/build-pyinstaller.yml`
- `.github/workflows/build-nuitka.yml`
- `Dockerfile`
- `cloud/hfs/Dockerfile`
- `cloud/modelscope/Dockerfile`
- `docs/architecture.md`
- `docs/plugin-integration-spec.md`
- `CHANGELOG.md`
