### PR TITLE
fix: enforce safe redirect handling in BaseScraper

### DIFF
--- a/src/souwen/core/scraper/base.py
+++ b/src/souwen/core/scraper/base.py
@@ -31,13 +31,13 @@
         - 功能：每次请求前等待随机时长，叠加自适应退避系数
         - 实现 "被限流时退避、恢复时逐步加速" 的礼貌爬取策略
 
-    _fetch(url, method="GET", params=None, headers=None) -> httpx.Response
+    _fetch(url, method="GET", params=None, headers=None, follow_redirects=None) -> httpx.Response
         - 功能：带礼貌延迟、自动重试和指纹伪装的请求方法
         - 输入：url 目标地址，method HTTP 方法，params 查询参数，headers 额外头
         - 输出：响应对象（httpx.Response 或 curl_cffi 兼容对象）
         - 异常：RateLimitError 持续被限流；SourceUnavailableError 网络/服务异常
 
-    _do_request(method, url, params, headers) -> Any
+    _do_request(method, url, params, headers, follow_redirects=None) -> Any
         - 功能：根据后端选择执行实际的 HTTP 请求
         - 优先 curl_cffi（TLS 指纹），回退 httpx
 
@@ -216,6 +216,7 @@ class BaseScraper:
         params: dict[str, Any] | None = None,
         headers: dict[str, str] | None = None,
         data: dict[str, Any] | None = None,
+        follow_redirects: bool | None = None,
     ) -> httpx.Response:
         """带重试和礼貌延迟的请求方法
 
@@ -228,6 +229,7 @@ class BaseScraper:
             params: 查询参数
             headers: 额外请求头
             data: POST 表单数据（application/x-www-form-urlencoded）
+            follow_redirects: 本次请求是否自动跟随重定向；None 使用实例默认值
 
         Returns:
             httpx.Response（或 curl_cffi 兼容的响应对象）
@@ -249,7 +251,14 @@ class BaseScraper:
             await self._polite_delay()
 
             try:
-                resp = await self._do_request(method, url, params, request_headers, data=data)
+                resp = await self._do_request(
+                    method,
+                    url,
+                    params,
+                    request_headers,
+                    data=data,
+                    follow_redirects=follow_redirects,
+                )
 
                 if resp.status_code == 429:
                     # 被限流：退避系数翻倍（上限 16x），大幅增加后续请求间隔
@@ -307,6 +316,7 @@ class BaseScraper:
                 params=params,
                 headers=headers,
                 data=data,
+                follow_redirects=False,
             )
             if resp.status_code not in _REDIRECT_CODES:
                 return resp
@@ -330,6 +340,7 @@ class BaseScraper:
         params: dict[str, Any] | None,
         headers: dict[str, str],
         data: dict[str, Any] | None = None,
+        follow_redirects: bool | None = None,
     ) -> Any:
         """执行实际的 HTTP 请求 — curl_cffi 或 httpx 双引擎
 
@@ -342,6 +353,7 @@ class BaseScraper:
             params: 查询参数字典
             headers: 请求头字典（已包含浏览器指纹和频道自定义头）
             data: POST 表单数据
+            follow_redirects: 本次请求的重定向策略；None 使用实例默认值
 
         Returns:
             响应对象（curl_cffi.Response 或 httpx.Response）
@@ -349,6 +361,10 @@ class BaseScraper:
         Raises:
             RuntimeError：无可用 HTTP 客户端（极少见）
         """
+        request_follow_redirects = (
+            self._follow_redirects if follow_redirects is None else follow_redirects
+        )
+
         if self._use_curl_cffi and self._curl_session is not None:
             # curl_cffi 路径 — TLS 指纹模拟
             return await self._curl_session.request(
@@ -357,12 +373,17 @@ class BaseScraper:
                 params=params,
                 headers=headers,
                 data=data,
-                allow_redirects=self._follow_redirects,
+                allow_redirects=request_follow_redirects,
             )
         elif self._httpx_client is not None:
             # httpx 回退路径
             return await self._httpx_client.request(
-                method, url, params=params, headers=headers, data=data
+                method,
+                url,
+                params=params,
+                headers=headers,
+                data=data,
+                follow_redirects=request_follow_redirects,
             )
         else:
             raise RuntimeError("无可用 HTTP 客户端")

--- a/tests/test_web/test_fetch.py
+++ b/tests/test_web/test_fetch.py
@@ -85,6 +85,48 @@ class TestSafeRedirects:
         with pytest.raises(SourceUnavailableError, match="SSRF"):
             await scraper._fetch_with_safe_redirects("https://example.com/start")
 
+    @pytest.mark.asyncio
+    async def test_base_scraper_safe_redirects_disable_auto_follow(self):
+        scraper = BaseScraper.__new__(BaseScraper)
+        follow_redirects_values = []
+
+        async def fake_fetch(_url, **kwargs):
+            follow_redirects_values.append(kwargs.get("follow_redirects"))
+            return SimpleNamespace(
+                status_code=200,
+                headers={},
+                url="https://example.com/start",
+            )
+
+        scraper._fetch = fake_fetch
+
+        await scraper._fetch_with_safe_redirects("https://example.com/start")
+
+        assert follow_redirects_values == [False]
+
+    @pytest.mark.asyncio
+    async def test_base_scraper_fetch_passes_redirect_override_to_backend(self):
+        scraper = BaseScraper.__new__(BaseScraper)
+        scraper._fingerprint = SimpleNamespace(headers={})
+        scraper._channel_headers = {}
+        scraper.max_retries = 1
+        scraper._backoff_multiplier = 1.0
+        captured_follow_redirects = []
+
+        async def fake_polite_delay():
+            return None
+
+        async def fake_do_request(_method, _url, _params, _headers, **kwargs):
+            captured_follow_redirects.append(kwargs.get("follow_redirects"))
+            return SimpleNamespace(status_code=200, headers={}, url=_url)
+
+        scraper._polite_delay = fake_polite_delay
+        scraper._do_request = fake_do_request
+
+        await scraper._fetch("https://example.com/start", follow_redirects=False)
+
+        assert captured_follow_redirects == [False]
+
 
 class TestFetchContent:
     """fetch_content 聚合测试"""


### PR DESCRIPTION
### Motivation
- 修复爬虫在处理重定向时的 SSRF 风险：底层 HTTP 客户端可能在逐跳校验前自动跟随重定向，绕过逐跳 SSRF 验证。 
- 需要支持按请求覆盖重定向行为以便在安全场景（手动逐跳校验）禁用自动跟随，同时保留实例默认行为。 

### Description
- 为 `BaseScraper._fetch` 增加了单次请求级别的 `follow_redirects: bool | None` 参数以允许按调用覆盖默认重定向策略。 
- 为 `BaseScraper._do_request` 增加了 `follow_redirects: bool | None` 参数并将其映射为 `curl_cffi` 的 `allow_redirects` 与 `httpx` 的 `follow_redirects`，确保后端请求遵循调用者意图。 
- 在 `BaseScraper._fetch_with_safe_redirects` 中显式传入 `follow_redirects=False`，在逐跳手动验证每一跳前禁用后端自动跟随重定向以确保 SSRF 校验生效。 
- 添加/更新了回归测试以覆盖上述行为（新增测试验证 `_fetch_with_safe_redirects` 禁用自动跟随且 `_fetch` 将 `follow_redirects` 覆盖传递到后端）。 
- 修改的主要文件：`src/souwen/core/scraper/base.py` 和 `tests/test_web/test_fetch.py`。 

### Testing
- 在开发环境依赖安装后使用 `pip install -e ".[dev]"` 安装了测试依赖并成功完成。 
- 运行 `pytest tests/test_web/test_fetch.py -v --tb=short`，测试通过并显示 `21 passed`（全部通过）。 
- 运行 `ruff check src/souwen/core/scraper/base.py tests/test_web/test_fetch.py` 与 `ruff format --check src/souwen/core/scraper/base.py tests/test_web/test_fetch.py` 均通过无格式/lint 错误。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a089fa1a6988332900dba9e1edd5605)