### PR TITLE
fix(ci): 修复 RC workflow 的 reusable permission ceiling

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -208,6 +208,9 @@ jobs:
   external:
     name: External release smoke
     needs: validate
+    permissions:
+      contents: read
+      issues: write
     uses: ./.github/workflows/external-smoke-gate.yml
     with:
       candidate_sha: ${{ needs.validate.outputs.candidate_sha }}

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -105,6 +105,9 @@ def test_release_candidate_aggregates_all_release_gates() -> None:
     assert "name: Broad CI, coverage, performance, audit, and container gates" in text
     assert "suite: release" in text
 
+    external = text.split("  external:", maxsplit=1)[1].split("  pyinstaller:", maxsplit=1)[0]
+    assert "permissions:\n      contents: read\n      issues: write" in external
+
 
 def test_release_bundle_has_24_binaries_supply_chain_assets_and_attestation() -> None:
     text = _workflow("release-candidate.yml")


### PR DESCRIPTION
## 结果与问题

`release-candidate.yml` 首次从 `main` 以 `publish=false`、`deploy_hfs=false` 运行时在进入任何 job 前失败。GitHub 的 annotation 明确指出：调用 `external-smoke-gate.yml` 时，两个仅供 nightly 使用的 issue maintenance job 请求 `issues: write`，但 caller 只授予了 `issues: none`。

失败运行：https://github.com/BlueSkyXN/SouWen/actions/runs/29736943564

## 变更

- 仅在 `release-candidate.yml` 的 `external` reusable-workflow call 上增加：
  - `contents: read`
  - `issues: write`
- 增加静态契约测试，防止 caller permission ceiling 再次低于被调用 workflow 的声明。

## 权限与行为边界

- 没有全局扩大权限；额外 scope 只属于 `external` call。
- `open-nightly-failure-issue` 与 `close-nightly-failure-issue` 仍要求 `github.event_name == 'schedule'`；central RC 的 `workflow_dispatch` 路径不会创建、更新或关闭 issue。
- 不改变 `publish=false`、`deploy_hfs=false` 的边界；本 PR 不打 tag、不创建 Release、不部署 HF Space。

## 验证

- `pytest tests/test_release_candidate_workflows.py -q --tb=short`：`10 passed`
- `ruff check tests/test_release_candidate_workflows.py`：PASS
- `actionlint .github/workflows/release-candidate.yml .github/workflows/external-smoke-gate.yml`：PASS
- `git diff --check`：PASS

## 合并后

以实际新 `main` SHA 重新运行 centralized RC workflow，并继续核验 24 binaries、wheel/sdist、SBOM、checksums、attestation 与 `release-manifest.json`。失败的旧 run 不重跑，因为它绑定的是修复前 control-plane SHA。
