### PR TITLE
fix: 将 Ark source 纳入凭据门控 smoke 清单

### DIFF
--- a/scripts/hf_space_smoke.py
+++ b/scripts/hf_space_smoke.py
@@ -199,6 +199,8 @@ EXCLUDED_REQUIRED_KEY_SEARCH_SOURCES = [
     "zhipuai",
     "aliyun_iqs",
     "kimi_code",
+    "uniapi_ark_annotations_deepseek_v3_2_251201",
+    "uniapi_ark_annotations_doubao_seed_2_0_lite_260428",
     "twitter",
     "facebook",
     "youtube",


### PR DESCRIPTION
## 修复

PR #159 新增的两个 UniAPI Ark source 都需要共享 gateway 凭据，但 `scripts/hf_space_smoke.py` 的 required-key search inventory 未同步。导致 `tests/test_hf_space_smoke.py::test_zero_key_search_sources_are_covered_or_explicitly_excluded` 在 CI 中失败。

本 PR 将这两个 source 加入 `EXCLUDED_REQUIRED_KEY_SEARCH_SOURCES`。这是对既有 zero-key smoke 分类的更新：不会尝试外部 API，也不会把 credential-gated source 伪装成 zero-key 可测源。

## 验证

```text
PYTHONPATH=src pytest tests/test_hf_space_smoke.py -q --tb=short
34 passed

ruff check scripts/hf_space_smoke.py tests/test_hf_space_smoke.py
PASS

ruff format --check scripts/hf_space_smoke.py tests/test_hf_space_smoke.py
PASS

git diff --check
PASS
```

## 边界

不修改 Ark request/parser、source registry、HFS 部署或 live smoke；该修复只恢复 credential-gated source 的 CI inventory 契约。