### PR TITLE
test: 同步 Ark source 的 Web catalog 基线

### DIFF
--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -571,7 +571,7 @@ class TestCLI:
                 "video",
             )
         )
-        assert total_web == 40
+        assert total_web == 42
         assert counts["fetch"] == 17
         assert counts["archive"] == 1
         assert counts["cn_tech"] == 9


### PR DESCRIPTION
## 修复

新增两条 UniAPI Ark Web source 后，公开 catalog 的 Web 分类实际总数从 40 变为 42，但 `tests/test_infra.py` 的稳定基线未同步，导致 `main` 的 V2 pytest matrix 全平台失败。

本 PR 将该基线更新为 42，恢复 catalog 变更后的 CI 契约。

## 影响与边界

- 不修改 Registry、Ark request/parser、gateway 配置、HFS、release 或外部 source 行为。
- 不新增网络调用、凭据或运行时依赖；仅修复确定性测试快照。
- PR 已打开到 `main`，尚未合并、未部署、未创建 tag/Release。

## 验证

```text
PYTHONPATH=src pytest tests/test_infra.py::TestCLI::test_cli_source_catalog_data tests/test_hf_space_smoke.py -q --tb=short
35 passed

PYTHONPATH=src pytest tests/registry/test_catalog.py tests/registry/test_consistency.py -q --tb=short
70 passed

ruff check tests/test_infra.py
ruff format --check tests/test_infra.py
PYTHONPATH=src python3 tools/gen_docs.py --check
PYTHONPATH=src python3 scripts/ci/check_no_legacy_terms.py
git diff --check
PASS
```

`check_no_legacy_terms.py` 保留既有文档措辞 warning，退出码为 0。GitHub Actions 是本 PR 的唯一构建验证；尚未等待远端结果。

## Review focus

确认 42 与当前 `public_source_catalog()` 的分类投影一致，以及此修复保持静态 catalog 基线测试的既有语义。