### PR TITLE
test(openalex): 补齐匿名 live functional evidence

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -219,6 +219,7 @@ required `FAIL` 视为发布阻断。
 | Article extraction | PR required / release | `newspaper` / `readability` handler 注册、参数派发和错误聚合契约 | 真实 `newspaper4k` / `readability-lxml` import + 本地 HTML fixture；release 可用 `--require-runtime` 将缺 runtime 视为 FAIL | `Article extraction 云端功能测试` |
 | Plugin entry point | PR required / release | 插件契约、loader、manager、handler 注册的 mock/monkeypatch 单测 | 真实 `pip install -e examples/minimal-plugin`、entry point discovery、registry/plugin manager/fetch handler 视图、可选 `superweb2pdf` WARN；release 可用 `--require-web2pdf-runtime` 追加本地 HTML fixture → PDF 转换 | `插件云端功能测试` |
 | Zero-key live sources | Nightly / release | Google Patents / Wayback parser、SSRF guard、registry 契约和 mock HTTP 单测 | `scripts/zero_key_functional_check.py --mode live` 对 Google Patents search、Wayback Availability 与 CDX 做真实免 Key 探测；当 Availability API 无 closest 但同 URL 的 CDX 200 快照可证明可用时，availability check 记录 `cdx_fallback` 通过；默认 live 失败为 WARN，release 可加 `--required` | `Zero-key live source gate` |
+| OpenAlex anonymous contract | Manual | OpenAlex 请求参数、anonymous/key 行为和 registry metadata | `scripts/openalex_functional_check.py --mode live --execute --required` 只发送一次匿名 search，主动清除本地配置 key；写入 JSON/Markdown evidence，不进入普通 pytest 或自动 PR gate | Maintainer manual evidence |
 | HF Space smoke | deploy smoke / release gate | `hf_space_smoke` 参数、矩阵覆盖、admin-open gate 和 report 渲染的确定性单测 | private edge + 应用 admin 双层鉴权、surface/capability、admin-open required gate、统一 JSON Outcome report | `HF Space CD` |
 
 ## Secrets 边界

--- a/scripts/openalex_functional_check.py
+++ b/scripts/openalex_functional_check.py
@@ -1,0 +1,173 @@
+"""Manual anonymous OpenAlex functional smoke.
+
+This check deliberately stays outside ordinary pytest and is never scheduled
+from a pull request.  ``--mode live --execute`` sends one anonymous query to
+the official OpenAlex API so maintainers can collect timestamped evidence
+without using a configured API key or replaying a metered request.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from collections.abc import Callable, Sequence
+from typing import Any
+
+try:
+    from scripts._functional_common import Outcome, ResultRecorder, add_common_args, run_check
+except ModuleNotFoundError:  # pragma: no cover - direct `python scripts/...` execution.
+    from _functional_common import Outcome, ResultRecorder, add_common_args, run_check
+
+
+DEFAULT_QUERY = "open science"
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def verify_openalex_registered() -> tuple[str, dict[str, object]]:
+    """Confirm the live script targets the canonical optional-key source."""
+    from souwen.registry import get
+
+    adapter = get("openalex")
+    require(adapter is not None, "source 'openalex' is not registered")
+    require(adapter.domain == "paper", f"unexpected OpenAlex domain: {adapter.domain!r}")
+    require("search" in adapter.capabilities, "OpenAlex search capability is missing")
+    require(adapter.config_field == "openalex_api_key", "OpenAlex config_field drifted")
+    require(adapter.resolved_needs_config is False, "OpenAlex must remain anonymously available")
+    return (
+        "openalex registry contract passed",
+        {
+            "source": adapter.name,
+            "domain": adapter.domain,
+            "capabilities": sorted(adapter.capabilities),
+            "config_field": adapter.config_field,
+            "needs_config": adapter.resolved_needs_config,
+        },
+    )
+
+
+async def run_anonymous_openalex_search(
+    *,
+    query: str,
+    per_page: int,
+    client_factory: Callable[[], Any] | None = None,
+) -> tuple[str, dict[str, object]]:
+    """Run one search after clearing any configured key from the client instance."""
+    if client_factory is None:
+        from souwen.paper.openalex import OpenAlexClient
+
+        client_factory = OpenAlexClient
+
+    client = client_factory()
+    # A maintainer may have a key in a local config file.  The manual smoke is
+    # intentionally anonymous, so it must never send that credential upstream.
+    if hasattr(client, "api_key"):
+        client.api_key = None
+
+    async with client:
+        response = await client.search(query, per_page=per_page)
+
+    require(response.source == "openalex", f"unexpected source: {response.source!r}")
+    require(response.results, "OpenAlex returned no results for the live smoke query")
+    first = response.results[0]
+    require(first.source == "openalex", f"unexpected result source: {first.source!r}")
+    require(bool(first.title), "first OpenAlex result has no title")
+    require(bool(first.source_url), "first OpenAlex result has no source_url")
+    return (
+        f"anonymous OpenAlex search returned {len(response.results)} result(s)",
+        {
+            "query": query,
+            "per_page": per_page,
+            "returned": len(response.results),
+            "first_title": first.title,
+            "first_url": first.source_url,
+            "credential_mode": "anonymous",
+        },
+    )
+
+
+async def run_selected_checks(args: argparse.Namespace, recorder: ResultRecorder) -> None:
+    if args.mode == "offline":
+        recorder.record(
+            "offline_mode",
+            outcome=Outcome.SKIP,
+            required=False,
+            message="offline mode requested; OpenAlex live query was not sent",
+            details={"credential_mode": "anonymous"},
+        )
+        return
+
+    await run_check(
+        recorder,
+        "openalex_registry",
+        verify_openalex_registered,
+        required=True,
+        timeout=args.timeout,
+    )
+    await run_check(
+        recorder,
+        "openalex_anonymous_live_search",
+        lambda: run_anonymous_openalex_search(query=args.query, per_page=args.per_page),
+        required=bool(args.required),
+        timeout=args.timeout,
+    )
+
+
+async def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Run one explicit anonymous OpenAlex live smoke.")
+    add_common_args(parser, default_mode="offline", modes=("offline", "live"))
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Required together with --mode live before an external request is sent.",
+    )
+    parser.add_argument(
+        "--required",
+        action="store_true",
+        help="Treat a live upstream failure as FAIL instead of WARN.",
+    )
+    parser.add_argument("--query", default=DEFAULT_QUERY, help="Anonymous OpenAlex search query.")
+    parser.add_argument(
+        "--per-page",
+        type=int,
+        default=1,
+        help="Result count for the single search request (1..10).",
+    )
+    args = parser.parse_args(argv)
+    if not 1 <= args.per_page <= 10:
+        parser.error("--per-page must be within 1..10")
+    if args.mode == "live" and not args.execute:
+        parser.error("--mode live requires --execute")
+
+    recorder = ResultRecorder(
+        script="openalex_functional_check",
+        mode=args.mode,
+        environment={
+            "credential_mode": "anonymous",
+            "live_execution_confirmed": bool(args.execute),
+            "required_live_failures": bool(args.required),
+        },
+    )
+    try:
+        await run_selected_checks(args, recorder)
+    finally:
+        try:
+            recorder.write_reports(
+                json_report=args.json_report,
+                markdown_report=args.markdown_report,
+            )
+        except Exception as exc:  # noqa: BLE001 - report write failures have a fixed exit code.
+            print(f"failed to write functional check reports: {exc}", file=sys.stderr)
+            raise SystemExit(2) from exc
+
+    for check in recorder.checks:
+        print(f"{check.outcome.value} {check.name}: {check.message}")
+    raise SystemExit(recorder.exit_code())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_openalex_functional_check.py
+++ b/tests/test_openalex_functional_check.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts import openalex_functional_check as check
+from souwen.models import PaperResult, SearchResponse
+
+
+def test_verify_openalex_registered_reports_optional_key_contract() -> None:
+    message, details = check.verify_openalex_registered()
+
+    assert message == "openalex registry contract passed"
+    assert details == {
+        "source": "openalex",
+        "domain": "paper",
+        "capabilities": ["search"],
+        "config_field": "openalex_api_key",
+        "needs_config": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_anonymous_search_clears_configured_key_and_closes_client() -> None:
+    class FakeClient:
+        closed = False
+
+        def __init__(self) -> None:
+            self.api_key = "must-not-be-sent"
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            FakeClient.closed = True
+
+        async def search(self, query: str, *, per_page: int) -> SearchResponse:
+            assert self.api_key is None
+            assert query == "open science"
+            assert per_page == 1
+            return SearchResponse(
+                query=query,
+                source="openalex",
+                total_results=1,
+                per_page=per_page,
+                results=[
+                    PaperResult(
+                        source="openalex",
+                        title="Open science result",
+                        source_url="https://openalex.org/W1",
+                    )
+                ],
+            )
+
+    message, details = await check.run_anonymous_openalex_search(
+        query="open science", per_page=1, client_factory=FakeClient
+    )
+
+    assert message == "anonymous OpenAlex search returned 1 result(s)"
+    assert details["credential_mode"] == "anonymous"
+    assert details["first_url"] == "https://openalex.org/W1"
+    assert FakeClient.closed is True
+
+
+def test_offline_mode_writes_skip_report_without_network(tmp_path: Path) -> None:
+    json_report = tmp_path / "openalex.json"
+    markdown_report = tmp_path / "openalex.md"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/openalex_functional_check.py",
+            "--mode",
+            "offline",
+            "--json-report",
+            str(json_report),
+            "--markdown-report",
+            str(markdown_report),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    assert "SKIP offline_mode" in completed.stdout
+    report = json.loads(json_report.read_text(encoding="utf-8"))
+    assert report["script"] == "openalex_functional_check"
+    assert report["mode"] == "offline"
+    assert report["overall"] == "SKIP"
+    assert report["environment"]["credential_mode"] == "anonymous"
+    assert markdown_report.exists()
+
+
+def test_live_mode_requires_explicit_execute_flag() -> None:
+    with pytest.raises(SystemExit, match="2"):
+        asyncio.run(check.main(["--mode", "live"]))


### PR DESCRIPTION
## 结果

补齐数据源计划 `TASK-001` 缺失的 OpenAlex live functional evidence：新增独立脚本，只在明确传入 `--mode live --execute` 时发送一条匿名 search；默认 `offline` 不访问外网。

## 约束

- 实例化后主动清除本地配置的 `api_key`，避免手工 smoke 误用账户凭据。
- 不修改已在 `main` 的 OpenAlex key/quota 实现、公开 API 或 registry 数据。
- 不加入普通 pytest 或 PR 自动 live gate；实时执行由维护者显式决定。
- 不执行真实 OpenAlex 请求，不创建 tag、Release 或部署。

## 变更

- 新增 `scripts/openalex_functional_check.py`，输出 JSON/Markdown Outcome 报告，支持 `--required`。
- 添加匿名 credential 清除、registry contract、offline report 与 live opt-in 的确定性测试。
- 在 `docs/testing.md` 记录人工执行命令和边界。

## 验证

```text
PYTHONPATH=src python3 -m pytest tests/test_openalex_functional_check.py tests/test_paper/test_openalex.py tests/test_config.py tests/test_config_loader.py tests/registry/test_consistency.py tests/registry/test_catalog.py tests/test_gen_docs.py -q --tb=short
189 passed

ruff check / format check
PASS

PYTHONPATH=src python3 tools/gen_docs.py --check
PASS

PYTHONPATH=src python3 scripts/openalex_functional_check.py --mode offline ...
SKIP (expected; no network request sent)
```

## Review focus

确认 `--mode live --execute` 的显式授权、匿名 key 清除以及 report 不暴露凭据。