### PR TITLE
fix(panel): add missing book domain translation

### DIFF
--- a/panel/src/core/i18n/zh-CN.json
+++ b/panel/src/core/i18n/zh-CN.json
@@ -1,5 +1,6 @@
 {
   "domains": {
+    "book": "图书",
     "paper": "论文",
     "patent": "专利",
     "web": "网页",


### PR DESCRIPTION
Fixes the post-merge Panel CI failure from PR #167.

`SEARCH_DOMAINS` now includes `book`, so the dynamic key `domains.book` must exist in `zh-CN.json`.

Validation: `python3 -m json.tool panel/src/core/i18n/zh-CN.json` and `git diff --check`.

No local Panel build or test was run; GitHub Actions is the build authority.