### PR TITLE
fix(ci): restore Windows catalog cleanup and panel test gate

### DIFF
--- a/panel/src/skins/souwen-google/test/searchPage.test.tsx
+++ b/panel/src/skins/souwen-google/test/searchPage.test.tsx
@@ -486,7 +486,7 @@ describe('SearchPage', () => {
     const user = userEvent.setup()
 
     await user.click(screen.getByRole('button', { name: 'domains.research_output' }))
-    expect(await screen.findByText('datacite')).toBeInTheDocument()
+    expect(await screen.findByRole('button', { name: /datacite/ })).toBeInTheDocument()
     await user.type(screen.getByRole('textbox'), 'dataset')
     await user.click(screen.getByRole('button', { name: '搜索' }))
 

--- a/src/souwen/local_catalog/store.py
+++ b/src/souwen/local_catalog/store.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from collections.abc import Iterable, Iterator, Mapping
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from collections.abc import Iterable, Mapping
 
 from souwen.core.exceptions import LocalCatalogUnavailableError, NotFoundError
 from souwen.models import BookResult
@@ -54,6 +55,19 @@ class LocalCatalog:
         conn.row_factory = sqlite3.Row
         return conn
 
+    @contextmanager
+    def _connection(self, *, create: bool) -> Iterator[sqlite3.Connection]:
+        """Commit or roll back a catalog operation and always release its SQLite handle."""
+        conn = self._connect(create=create)
+        try:
+            yield conn
+            conn.commit()
+        except BaseException:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
     @staticmethod
     def _fts5_available(conn: sqlite3.Connection) -> bool:
         try:
@@ -64,7 +78,7 @@ class LocalCatalog:
             return False
 
     def initialize(self) -> CatalogStatus:
-        with self._connect(create=True) as conn:
+        with self._connection(create=True) as conn:
             row = conn.execute(
                 "SELECT name FROM sqlite_master WHERE type='table' AND name='catalog_schema_version'"
             ).fetchone()
@@ -106,7 +120,7 @@ class LocalCatalog:
         if not self.path.is_file():
             return CatalogStatus(self.path, False, None, False, None, {}, {}, {})
         try:
-            with self._connect(create=False) as conn:
+            with self._connection(create=False) as conn:
                 row = conn.execute(
                     "SELECT MAX(version) AS version FROM catalog_schema_version"
                 ).fetchone()
@@ -185,7 +199,7 @@ class LocalCatalog:
         self.ensure_source_ready(source)
         if not 1 <= limit <= 100:
             raise ValueError("limit 必须在 1..100")
-        with self._connect(create=False) as conn:
+        with self._connection(create=False) as conn:
             rows = conn.execute(
                 "SELECT r.payload_json FROM catalog_book_fts f JOIN catalog_records r "
                 "ON f.record_key = r.source || ':' || r.source_record_id "
@@ -196,7 +210,7 @@ class LocalCatalog:
 
     def get_book(self, source: str, source_record_id: str) -> BookResult:
         self.ensure_source_ready(source)
-        with self._connect(create=False) as conn:
+        with self._connection(create=False) as conn:
             row = conn.execute(
                 "SELECT payload_json FROM catalog_records WHERE source=? AND source_record_id=?",
                 (source, source_record_id),
@@ -219,7 +233,7 @@ class LocalCatalog:
         """Upsert records and preserve a checkpoint after every committed record."""
         self.initialize()
         acquisition_json = json.dumps(dict(acquisition or {}), ensure_ascii=False, sort_keys=True)
-        with self._connect(create=False) as conn:
+        with self._connection(create=False) as conn:
             previous = conn.execute(
                 "SELECT * FROM catalog_import_runs WHERE source=? AND source_revision=?",
                 (source, source_revision),

--- a/tests/test_local_catalog/test_store.py
+++ b/tests/test_local_catalog/test_store.py
@@ -5,6 +5,7 @@ import sqlite3
 import pytest
 
 from souwen.core.exceptions import LocalCatalogUnavailableError
+from souwen.local_catalog import store as store_module
 from souwen.local_catalog.store import CatalogRecord, LocalCatalog
 from souwen.models import BookResult
 
@@ -83,3 +84,32 @@ def test_fts_unavailable_is_not_silently_accepted(tmp_path, monkeypatch) -> None
     monkeypatch.setattr(LocalCatalog, "_fts5_available", staticmethod(lambda _conn: False))
     with pytest.raises(LocalCatalogUnavailableError, match="FTS5"):
         LocalCatalog(tmp_path / "catalog.sqlite3").initialize()
+
+
+def test_catalog_operations_close_sqlite_connections(tmp_path, monkeypatch) -> None:
+    class TrackingConnection(sqlite3.Connection):
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+            super().close()
+
+    original_connect = sqlite3.connect
+    connections: list[TrackingConnection] = []
+
+    def tracking_connect(*args, **kwargs) -> TrackingConnection:
+        kwargs.setdefault("factory", TrackingConnection)
+        connection = original_connect(*args, **kwargs)
+        connections.append(connection)
+        return connection
+
+    monkeypatch.setattr(store_module.sqlite3, "connect", tracking_connect)
+    catalog = LocalCatalog(tmp_path / "catalog.sqlite3")
+
+    catalog.import_records("gutenberg", "r1", "a" * 64, [_record("11")])
+    catalog.status()
+    catalog.search_books("gutenberg", "Alice", limit=1)
+    catalog.get_book("gutenberg", "11")
+
+    assert connections
+    assert all(connection.closed for connection in connections)


### PR DESCRIPTION
## 修复范围

- 统一 LocalCatalog 的 SQLite 连接生命周期：commit/rollback 后始终 close，修复 Windows TemporaryDirectory 删除数据库时的 WinError 32。
- 添加回归测试，覆盖 initialize/status/import/search/detail 全部 catalog 操作路径都会关闭连接。
- 将 Panel research-output 测试改为断言唯一的 source card button，而不是会匹配名称和描述两处文本的 `findByText`。

## 本地验证（未执行本地构建）

- `PYTHONPATH=src python3 -m pytest tests/test_local_catalog/test_store.py tests/test_local_catalog/test_functional_check.py -q --tb=short` — 10 passed
- `PYTHONPATH=src python3 -m ruff check src/souwen/local_catalog/store.py tests/test_local_catalog/test_store.py`
- `PYTHONPATH=src python3 -m ruff format --check src/souwen/local_catalog/store.py tests/test_local_catalog/test_store.py`
- `git diff --check`

GitHub Actions 是本 PR 的构建验证来源；未在本地运行 Panel / wheel / Docker / binary build。