### PR TITLE
docs(llm): 收口 enriched search 的文档合同漂移

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -735,6 +735,15 @@ scheme 与 model，因此接口不接受 `model`、`model_id`、`scheme_id`、`a
 
 - `results[]` 只包含通过非空 title + HTTP(S) URL 硬门槛的资料。`discoveries[]` 保留每条
   source provenance；不会返回 provider raw response、gateway URL 或凭据。
+- 结果中的文本字段有明确来源，不能统一解释成“网页摘要”：
+
+  | 字段 | `type` | 语义 |
+  |---|---|---|
+  | `provider_snippet` | `provider_snippet` 或 `provider_summary` | upstream search receipt 中可见的文本；它不是 SouWen 对页面内容的验证，也不能替代 title/URL 或 fetch 证据 |
+  | `content_excerpt` | `extractive` | 由 `fetch_status="success"` 的受限页面正文截取；长度受 `fetch.max_excerpt_chars` 限制 |
+  | `content` | — | 仅 `fetch.include_content=true` 时返回的受限真实正文；长度受 `fetch.max_content_chars` 限制 |
+  | `summary` | `generated` | 仅 optional synthesis 由成功 fetch 的受限材料生成；带 model provenance，不能冒充 extractive 页面原文 |
+
 - `meta.source_outcomes` 区分 `success_with_results`、`success_empty`、`timeout` 与
   `failed`。至少一个 source 成功时返回 `200`，其余失败以 `meta.partial=true` 表示。
 - `meta.visible_search_calls` 只统计响应中可见的 search call；它不是费用推断。provider

--- a/docs/internal/llm-search-foundation-spec.md
+++ b/docs/internal/llm-search-foundation-spec.md
@@ -1,19 +1,53 @@
 # LLM Search Foundation SPEC
 
-状态：Implementation baseline
-范围：`TASK-001`、`TASK-002`
+状态：Foundation completed；后续 LLM-search 状态见本页的 Current State
+范围：`TASK-001`、`TASK-002` 的历史 foundation 合同
 基线：`78635c7e9ae53967b6e834459b77941c58ad45ee`
+
+## 0. Current State（2026-07-21）
+
+本页保留的是第一单元的设计与验证合同，不能把其中的“本单元不做”理解为当前
+仓库没有后续功能。`TASK-001` / `TASK-002` 已合入 `main`；后续实现已经在这个
+foundation 上增加了 additive 的 `POST /api/v1/search/web/enriched`、Ark annotation
+scheme 和两个默认关闭的 concrete source。旧 `GET /api/v1/search/web` 保持不变。
+
+当前 Registry 已声明的 concrete sources 只有：
+
+| Source ID | Scheme ID | Exact model ID | Catalog state | Evidence boundary |
+|---|---|---|---|---|
+| `uniapi_ark_annotations_deepseek_v3_2_251201` | `uniapi_ark_annotations_v1` | `deepseek-v3-2-251201` | `experimental`、default disabled | deterministic fixture/dry-run 已覆盖；一次真实付费 receipt 仍须经明确授权 |
+| `uniapi_ark_annotations_doubao_seed_2_0_lite_260428` | `uniapi_ark_annotations_v1` | `doubao-seed-2-0-lite-260428` | `experimental`、default disabled | 与上行相同；不得自动切换到另一个 model |
+
+下表是截至 2026-07-20 的 research inventory，而不是可调用 source 清单。每一个
+`planned` 或 `conditional` 项在实现当天仍须重新验证 exact endpoint、requested/served
+model、tool schema 和 receipt；不得仅因本表出现而配置、启用或宣传为可用。
+
+| Scheme ID | 当前状态 | 当前仓库含义 |
+|---|---|---|
+| `uniapi_ark_annotations_v1` | implemented | 上述两个 immutable source 是唯一已声明的第一批 source；live evidence 仍需授权 |
+| `uniapi_openai_responses_search_v1` | planned | 未注册 concrete source；需要每个 model 组合的独立 gate |
+| `uniapi_qwen_responses_search_v1` | planned | 未注册 concrete source；URL-only candidates 必须先通过 fetch title gate |
+| `uniapi_anthropic_messages_search_v1` | planned | 未注册 concrete source；需重验 tool version 与 UniAPI native protocol |
+| `uniapi_gemini_grounding_v1` | conditional | 只有 receipt gate 成立后才可注册 concrete source |
+| `uniapi_kimi_builtin_search_v1` | rejected | 当前结果不透明，不能形成资料清单 |
+| `uniapi_alibaba_chat_search_v1` | rejected | 当前没有可审计 source/tool/citation 证据 |
+| `uniapi_zhipu_chat_search_v1` | rejected | 当前 UniAPI 组合没有透传可用结构 |
+
+真实 Ark evidence 只允许通过
+`scripts/uniapi_search_functional_check.py --source <concrete-source> --mode live --execute --required`
+在明确计费授权后产生。dry-run、fixture、历史 probe 或 CI success 都不能替代这一
+receipt，也不应被写成当前 upstream availability。
 
 ## 1. 目标与边界
 
-本 SPEC 只建立 LLM Search 的配置、身份、可用性、超时、单次请求和共享 deadline
-基础，不注册任何 UniAPI source，不调用外部 API，也不新增公开 REST、CLI、MCP 或 Panel
-入口。
+本 SPEC 的**原始单元**只建立 LLM Search 的配置、身份、可用性、超时、单次请求和共享
+deadline 基础。当时不注册 UniAPI source、不调用外部 API，也不新增公开 REST、CLI、MCP
+或 Panel 入口；后续实现状态以第 0 节为准。
 
-未来 Citation API 必须是 additive 的 `POST /api/v1/search/web/enriched`。当前
+后续 Citation API 已作为 additive 的 `POST /api/v1/search/web/enriched` 实现；当前
 `GET /api/v1/search/web` 的请求、响应、认证、限流和错误语义保持不变。
 
-本单元明确不做：
+原始 foundation 单元明确不做：
 
 - Ark/OpenAI/Anthropic/Qwen/Gemini wire adapter 或 fixture parser；
 - `SearchCandidate`、enrichment、fetch、summary、answer；
@@ -159,7 +193,8 @@ llm_search_gateways.<gateway_id>.base_url
   继续递归脱敏 `api_key`，并将 gateway `base_url` 显示为 `***`。
 - Python API：新 contract 放在 `souwen.web.llm_search`；`souwen` package root 不导入它，
   避免启动或 optional dependency 回归。
-- Registry：不注册任何 concrete source，因此本 PR 不改变 source catalog 数量。
+- Registry：原始 foundation PR 不注册 concrete source，因此它本身不改变 source catalog 数量；
+  当前 Registry 的后续声明以第 0 节为准。
 - Tests：全部使用 fixture/mock，不读真实 HOME，不访问网络或凭据。
 
 ## 6. Validation Plan
@@ -210,7 +245,9 @@ release-candidate workflow。
 
 ## 8. Rollback
 
-本单元无 migration、无 source registration、无 live deployment。回滚可按模块独立进行：
+原始 foundation 单元无 migration、无 source registration、无 live deployment。其回滚可按模块
+独立进行；不要把这段 rollback 直接用于移除第 0 节列出的后续 source 或 API：它们必须按各自
+的 PR/manifest 回滚。
 
 1. 移除未被 source 使用的 `llm_search_gateways` 和 `souwen.web.llm_search` contract；
 2. 移除 additive source timeout，普通 web timeout 自动回到原 15 秒实现；

--- a/tests/test_server/test_api_reference_routes.py
+++ b/tests/test_server/test_api_reference_routes.py
@@ -79,3 +79,25 @@ def test_api_reference_fetch_summarize_request_fields_match_model() -> None:
 
     missing = [name for name in FetchSummarizeRequest.model_fields if name not in section]
     assert missing == []
+
+
+def test_api_reference_explains_enriched_text_and_failure_semantics() -> None:
+    """Enriched-search docs must not blur provider, fetched, and generated text."""
+    docs = Path("docs/api-reference.md").read_text(encoding="utf-8")
+    section = docs.split("#### `POST /api/v1/search/web/enriched`", 1)[1].split(
+        "#### `GET /api/v1/sources`", 1
+    )[0]
+
+    for required in (
+        "provider_snippet",
+        "provider_summary",
+        "extractive",
+        "generated",
+        'fetch_status="success"',
+        "visible_search_calls",
+        "不是费用推断",
+        "不会伪造 `0`",
+        "synthesis_status",
+        "仍返回 `200`",
+    ):
+        assert required in section


### PR DESCRIPTION
## 结果与问题

`docs/internal/llm-search-foundation-spec.md` 仍把“未注册 UniAPI source / 未新增 enriched endpoint”写成当前事实，但 `main` 上 Ark scheme、两个 concrete source 和 additive `POST /api/v1/search/web/enriched` 已分别经 PR #159/#160/#162/#180/#181 合入。本 PR 修正这处文档漂移，让 spec 反映当前已实现面与 live-evidence 边界，不把历史 foundation 单元的“本单元不做”误读成当前仓库没有后续功能。

## 变更

- `llm-search-foundation-spec.md`：新增第 0 节 Current State，记录两个已注册 Ark concrete source（`uniapi_ark_annotations_deepseek_v3_2_251201`、`uniapi_ark_annotations_doubao_seed_2_0_lite_260428`）、八套 scheme 的当前状态（implemented/planned/conditional/rejected）和付费 live evidence 边界；原“本单元不做”改述为“原始 foundation 单元不做”，避免与后续实现冲突。
- `api-reference.md`：在 enriched endpoint 段补一张字段语义表，区分 `provider_snippet` / `provider_summary` / `content_excerpt`(extractive) / `content` / `summary`(generated)，并明确这些文本不能统一解释成“网页摘要”。
- `tests/test_server/test_api_reference_routes.py`：新增回归测试，断言 enriched docs 段落必须解释 provider/fetched/generated 文本语义与 partial/failure 语义，防止文档再次漂移。

## 边界

- 纯文档 + 回归测试，无源码行为变更，无配置/迁移/接口改动。
- 不注册新 source、不声明任何 planned scheme 已 ready；不把不可见工具费标成 0。
- 不调用真实/付费 UniAPI；不做本地 wheel、Panel、Docker 或 binary build；未创建 tag/Release，未部署 HFS。

## 验证

本地确定性校验（`enriched-search-closeout` worktree，基于 `origin/main` `b32418da`）：

- `pytest tests/test_server/test_api_reference_routes.py tests/test_server/test_enriched_search_route.py tests/test_web/test_enriched_search.py tests/test_web/test_uniapi_ark.py tests/test_llm -q --tb=short` → `126 passed`
- `ruff check src tests scripts` → All checks passed
- `ruff format --check src tests scripts` → 445 files already formatted
- `python tools/gen_docs.py --check` → docs/README 均已更新
- `python scripts/ci/check_no_legacy_terms.py` → exit 0（剩余 warning 均在 `adding-a-source.md`/`configuration.md`，本 PR 未触及，且在 base `b32418da` 上完全一致）
- `git diff --check` → 无空白错误

CI 远端构建为权威；本地不替代远端 check。

## Review focus

请重点确认 spec 第 0 节的 scheme 状态表与当前 registry 声明一致，以及 api-reference 字段语义表未把 `provider_summary` 与 extractive/generated 混用。
