### PR TITLE
fix(hfs): 修复 reusable promotion 的 environment secret 传播

### DIFF
--- a/.github/workflows/deploy-hf-space.yml
+++ b/.github/workflows/deploy-hf-space.yml
@@ -19,6 +19,16 @@ on:
         description: "显式执行 HFS promotion 与验收"
         required: true
         type: boolean
+    secrets:
+      HF_TOKEN:
+        description: "具有目标 Space 管理权限的 Hugging Face token"
+        required: true
+      HF_SPACE_READ_TOKEN:
+        description: "用于访问 private Space edge 的 Hugging Face token"
+        required: true
+      SOUWEN_SMOKE_BEARER_TOKEN:
+        description: "用于 SouWen admin smoke 的应用密码"
+        required: true
     outputs:
       space_commit_sha:
         description: "Space repository commit verified by runtime.raw.sha"
@@ -392,19 +402,29 @@ jobs:
       prior_souwen_ref: ${{ steps.prior.outputs.prior_souwen_ref }}
       prior_runtime_stage: ${{ steps.prior.outputs.prior_runtime_stage }}
     steps:
+      - name: Require HFS deployment secrets
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_SPACE_READ_TOKEN: ${{ secrets.HF_SPACE_READ_TOKEN }}
+          SOUWEN_SMOKE_BEARER_TOKEN: ${{ secrets.SOUWEN_SMOKE_BEARER_TOKEN }}
+        run: |
+          missing=()
+          for name in HF_TOKEN HF_SPACE_READ_TOKEN SOUWEN_SMOKE_BEARER_TOKEN; do
+            if [ -z "${!name}" ]; then
+              missing+=("$name")
+            fi
+          done
+          if [ "${#missing[@]}" -ne 0 ]; then
+            for name in "${missing[@]}"; do
+              echo "::error::Required HFS environment secret is not configured: $name"
+            done
+            exit 1
+          fi
+
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.candidate_sha || github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
-
-      - name: Check HF token
-        env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: |
-          if [ -z "$HF_TOKEN" ]; then
-            echo "::error::HF_TOKEN is not configured. Add a Hugging Face write token to the hf environment secrets."
-            exit 1
-          fi
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -489,6 +489,9 @@ jobs:
       version: ${{ needs.validate.outputs.version }}
       verifier_sha: ${{ needs.validate.outputs.verifier_sha }}
       deploy_hfs: true
+    # Same-repository reusable workflows currently require explicit inheritance for
+    # environment-scoped secrets to resolve in the called workflow (actions/runner#4453).
+    secrets: inherit
 
   assemble:
     name: Verify and attest release bundle

--- a/docs/hf-space-cd.md
+++ b/docs/hf-space-cd.md
@@ -13,8 +13,11 @@
 - Space 仓库：<https://huggingface.co/spaces/BlueSkyXN/SouWen>
 
 目标 Space 必须在 promotion 前已是 `private=true`。仓库可见性与应用鉴权是两个独立结论：
-private Space 的 edge 访问仍需 Hugging Face READ token；进入应用后，SouWen admin API 还必须
-由独立的 admin password 保护。不能用“Space 是 private”推导“匿名请求不可能获得 admin”。
+private Space 的 edge 访问仍需 Hugging Face token；进入应用后，SouWen admin API 还必须由
+独立的 admin password 保护。最小 bootstrap 可以暂时把已确认的目标 Space write token 同时写入
+`HF_TOKEN` 与 `HF_SPACE_READ_TOKEN` 两个 GitHub secret 名称来打通链路；这只是过渡配置，不改变
+两个通道的职责，后续可无代码改动替换为独立 READ token。不能用“Space 是 private”推导“匿名
+请求不可能获得 admin”。
 
 `/panel#/` 中的 `#` 是前端 hash router 片段，不会发送到服务端；服务端实际校验 `/panel`。
 这些固定 URL 在 private Space 下不代表匿名公开可访问，调用方必须遵守 Hugging Face 的访问策略。
@@ -32,8 +35,11 @@ private Space 的 edge 访问仍需 Hugging Face READ token；进入应用后，
 Central workflow 的默认输入是 `publish=false`、`deploy_hfs=false`。默认运行只生成 RC-ready
 证据和 release bundle，不创建 tag/Release，也不写 HFS。`deploy_hfs=true` 时，candidate 必须
 等于当前 `origin/main`；不能从未合入分支向持有 secrets 的部署 job 注入 verifier。Central
-caller 不使用 `secrets: inherit`；所有 HF 凭据只在 reusable workflow 内绑定 `hf` environment
-的 job 中解析。
+caller 只在 HFS reusable call 上使用一次 `secrets: inherit`。这是同仓 reusable workflow 读取
+environment-scoped secrets 的已知兼容处理（`actions/runner#4453`）；其他 reusable jobs 不得继承
+secrets。`deploy-hf-space.yml` 的 `workflow_call` 显式声明 `HF_TOKEN`、
+`HF_SPACE_READ_TOKEN` 与 `SOUWEN_SMOKE_BEARER_TOKEN`，并在 checkout 和任何 HF API 调用前按
+secret 名称 fail fast，不输出值、长度或前缀。
 
 ### Local preflight
 
@@ -56,7 +62,7 @@ Hugging Face 官方 private Space HTTP 入口占用标准 `Authorization: Bearer
 | Secret | 用途 | 请求通道 |
 |---|---|---|
 | `HF_TOKEN` | 写 Space repo、restart/pause runtime | 仅 HFS 管理 API；需要 write 权限 |
-| `HF_SPACE_READ_TOKEN` | 通过 private Space edge | `Authorization: Bearer ...`；只需 READ |
+| `HF_SPACE_READ_TOKEN` | 通过 private Space edge | `Authorization: Bearer ...`；目标权限只需 READ，最小 bootstrap 可暂时复用已确认 write token |
 | `SOUWEN_SMOKE_BEARER_TOKEN` | SouWen 应用 admin password | `X-SouWen-Token: ...` |
 
 SouWen 仍以标准 `Authorization: Bearer <password>` 作为普通部署的首选应用鉴权。只有上游

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -85,7 +85,19 @@ def test_release_candidate_strictly_validates_promotion_inputs() -> None:
     assert "release-candidate must run from the current origin/main control plane" in text
     assert "candidate_sha to equal the current origin/main" in text
     assert "verifier_sha" in text
-    assert "secrets: inherit" not in text
+    assert text.count("secrets: inherit") == 1
+    hfs_call = text.split("  hfs:", maxsplit=1)[1].split("  assemble:", maxsplit=1)[0]
+    assert "uses: ./.github/workflows/deploy-hf-space.yml" in hfs_call
+    assert "secrets: inherit" in hfs_call
+
+
+def test_only_hfs_reusable_call_inherits_secrets() -> None:
+    inherited = {
+        path.name: path.read_text(encoding="utf-8").count("secrets: inherit")
+        for path in WORKFLOW_DIR.glob("*.yml")
+        if "secrets: inherit" in path.read_text(encoding="utf-8")
+    }
+    assert inherited == {"release-candidate.yml": 1}
 
 
 def test_release_candidate_aggregates_all_release_gates() -> None:
@@ -207,6 +219,16 @@ def test_hfs_reusable_promotion_is_candidate_pinned_and_live_verified() -> None:
     assert "workflow_call:" in text
     assert "candidate_sha:" in text
     assert "verifier_sha:" in text
+    workflow_call = text.split("  workflow_call:", maxsplit=1)[1].split(
+        "  pull_request:", maxsplit=1
+    )[0]
+    for secret_name in (
+        "HF_TOKEN",
+        "HF_SPACE_READ_TOKEN",
+        "SOUWEN_SMOKE_BEARER_TOKEN",
+    ):
+        assert f"      {secret_name}:" in workflow_call
+    assert workflow_call.count("required: true") == 7
     assert text.count(candidate_expression) >= 10
     assert "${{ inputs.candidate_sha || github.sha }}" not in text
     assert 'expected_pin = f"ARG SOUWEN_REF={candidate_sha}"' in text
@@ -239,6 +261,18 @@ def test_hfs_reusable_promotion_is_candidate_pinned_and_live_verified() -> None:
     assert "needs.rollback-space.result == 'cancelled'" in text
     assert "HF_SPACE_READ_TOKEN" in text
     assert '"X-SouWen-Token: $SOUWEN_SMOKE_BEARER_TOKEN"' in text
+
+    secret_gate = text.split("- name: Require HFS deployment secrets", maxsplit=1)[1].split(
+        "- uses: actions/checkout@v6", maxsplit=1
+    )[0]
+    for secret_name in (
+        "HF_TOKEN",
+        "HF_SPACE_READ_TOKEN",
+        "SOUWEN_SMOKE_BEARER_TOKEN",
+    ):
+        assert f"{secret_name}: ${{{{ secrets.{secret_name} }}}}" in secret_gate
+    assert "Required HFS environment secret is not configured: $name" in secret_gate
+    assert "${!name}" in secret_gate
 
     prior = text.split("- name: Capture immutable rollback point", maxsplit=1)[1].split(
         "- name: Sync changed HFS wrapper files", maxsplit=1


### PR DESCRIPTION
## 结果

修复 `release-candidate.yml` 调用同仓 HFS reusable workflow 时 `hf` environment secrets 解析为空的问题，使 candidate promotion 能在远端 mutation 前取得并校验三个必需凭据。

## 根因与改动

- HFS reusable caller 未显式继承 secrets；失败 run 中 `${{ secrets.HF_TOKEN }}` 被展开为空。
- 仅在 HFS call 增加一次 `secrets: inherit`，作为同仓 reusable + environment secret 的兼容处理；其他 reusable jobs 继续禁止继承。
- `deploy-hf-space.yml` 的 `workflow_call` 显式声明 `HF_TOKEN`、`HF_SPACE_READ_TOKEN`、`SOUWEN_SMOKE_BEARER_TOKEN`。
- 在 candidate checkout 和任何 HF API 调用前按 secret 名称 fail fast，不输出值、长度或前缀。
- 更新静态契约测试和 HFS CD 文档，记录最小 bootstrap 可临时复用已确认的目标 Space write token作为 edge token，但保留两个独立 secret 名称和职责。

## 边界

- 不修改 REST、CLI、配置 schema 或运行时应用逻辑。
- 不撤销、轮换或删除现有 Hugging Face token。
- 不处理 CodeQL/js-yaml，也不创建 tag/GitHub Release。
- 本 PR 未部署 HFS；合并后才会配置缺失 secrets、关闭 `admin_open` 和执行 immutable baseline bootstrap。

## 验证

- `pytest tests/test_release_candidate_workflows.py tests/test_binary_build_workflows.py -q`：22 passed
- `ruff check tests/test_release_candidate_workflows.py`：passed
- `git diff --check`：passed
- 两个变更 workflow 均通过本地 YAML parse
- `actionlint` 仅报告仓库既有的 `environment.deployment: false` 扩展键，不涉及本次变更

## Review focus

请重点确认 `secrets: inherit` 只存在于 HFS call，以及 fail-fast step 位于 candidate checkout 之前。
