### PR TITLE
fix(hfs): 修复无 checkout 的 factory rebuild pip cache 失败

### DIFF
--- a/.github/workflows/deploy-hf-space.yml
+++ b/.github/workflows/deploy-hf-space.yml
@@ -661,7 +661,6 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
-          cache: pip
 
       - name: Install Hugging Face Hub client
         run: python -m pip install "huggingface_hub>=1.8,<2"

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -295,6 +295,17 @@ def test_hfs_reusable_promotion_is_candidate_pinned_and_live_verified() -> None:
     assert "ref: ${{ inputs.candidate_sha || github.sha }}" not in post_deploy
 
 
+def test_hfs_rebuild_job_avoids_checkout_and_dependency_cache() -> None:
+    text = _workflow("deploy-hf-space.yml")
+    rebuild = text.split("  rebuild-space:", maxsplit=1)[1].split(
+        "  post-deploy-smoke:", maxsplit=1
+    )[0]
+
+    assert "actions/setup-python@v6" in rebuild
+    assert "actions/checkout@" not in rebuild
+    assert "cache: pip" not in rebuild
+
+
 def test_external_release_gate_requires_superweb2pdf_runtime_fixture() -> None:
     text = _workflow("external-smoke-gate.yml")
     assert "Plugin and SuperWeb2PDF release/nightly gate" in text


### PR DESCRIPTION
## 结果与根因

修复 HF Space promotion 的 `Factory rebuild Space` job 在调用 Hugging Face API 前失败的问题。RC run 29903544761 的 job 88907799408 在没有 checkout 的 job 中为 `actions/setup-python@v6` 启用了 `cache: pip`，因此找不到 `requirements.txt` 或 `pyproject.toml` 并直接退出。

本 PR 尚未部署 HFS；PR 路径只运行本地 preflight。合并并通过完整 RC 后才会执行远端 promotion。

## 变更

- 删除 `rebuild-space` job 的 `cache: pip`。
- 保持该 secret-bearing lifecycle job 不 checkout candidate 仓库内容。
- 增加静态回归，要求该 job 使用 setup-python，但不得 checkout 或启用 dependency cache。

## 边界

- 不修改 secrets、environment、permissions、timeout、rollback、pause 或 post-deploy smoke。
- 不新增 HFS-only 快速路径，不修改 OIDC、token 生命周期、public API、Panel、依赖或文档。
- 不创建 tag 或 GitHub Release。

## 验证

- 新回归在修复前按预期失败。
- `pytest tests/test_release_candidate_workflows.py -v --tb=short`：13 passed。
- `actionlint .github/workflows/deploy-hf-space.yml .github/workflows/release-candidate.yml`：通过，无输出。
- `git diff --check`：通过。

## Review focus

确认删除 cache 而不增加 checkout，既修复 setup-python 的 dependency-file lookup，又保持 HFS lifecycle job 不执行 candidate 仓库内容的边界。
