### PR TITLE
fix(fetch): ignore ambient proxies for pinned targets

### DIFF
--- a/src/souwen/core/scraper/base.py
+++ b/src/souwen/core/scraper/base.py
@@ -451,7 +451,9 @@ class BaseScraper:
         Untrusted direct URLs intentionally use HTTPX even when the configured scraper backend is
         curl_cffi. A shared curl session cannot safely install per-request DNS bindings without
         cross-request races. HTTPX receives an IP-literal URL, and clients are isolated by original
-        authority so different hostnames on one IP cannot share TLS connections or cookies.
+        authority so different hostnames on one IP cannot share TLS connections or cookies. Ambient
+        system proxies are disabled because they can re-route the validated IP literal; an explicit
+        SouWen/WARP proxy remains available through ``self._proxy``.
         """
         client_key = self._safe_client_key(target)
         safe_httpx_client = self._safe_httpx_clients.get(client_key)
@@ -459,6 +461,7 @@ class BaseScraper:
             safe_httpx_client = httpx.AsyncClient(
                 timeout=httpx.Timeout(self._request_timeout),
                 proxy=self._proxy,
+                trust_env=False,
                 follow_redirects=False,
             )
             self._safe_httpx_clients[client_key] = safe_httpx_client

--- a/tests/test_web/test_ssrf_binding.py
+++ b/tests/test_web/test_ssrf_binding.py
@@ -288,6 +288,7 @@ async def test_proxy_client_receives_only_ip_literal_connect_target(monkeypatch)
         await scraper.close()
 
     assert captured["init"]["proxy"] == "socks5://proxy.example:1080"
+    assert captured["init"]["trust_env"] is False
     _method, connect_url, request_kwargs = captured["request"]
     assert connect_url == "https://1.1.1.1/private-proxy-test"
     assert request_kwargs["headers"]["Host"] == "example.com"


### PR DESCRIPTION
## Summary

- disable ambient/system proxy discovery only for the IP-pinned SSRF-safe HTTPX client
- keep explicit SouWen/WARP proxy routing through `self._proxy`
- add a regression assertion for the pinned-target proxy boundary

## Root cause

RC run 29926844113 reached the HFS capability smoke after a successful wrapper sync, factory rebuild, runtime wait, and surface smoke. The required `builtin-fetch` probe then failed with `status=200, total_ok=0, total_failed=1`; job 88997915751 rolled back successfully in job 89000367062.

The pinned-target client connected to the validated IP literal but still used HTTPX's default `trust_env=True`. An ambient OS/environment proxy could therefore re-route that IP-literal connection and break TLS/SNI. The same target is repeatably successful when ambient proxy discovery is disabled. This change does not weaken DNS validation, IP pinning, redirect checks, Host/SNI preservation, or required smoke semantics.

## Validation

- regression test failed before the fix with `KeyError: 'trust_env'`
- `pytest tests/test_web/test_ssrf_binding.py tests/test_web/test_fetch.py tests/test_fetch_handlers.py -v --tb=short` (73 passed)
- `pytest tests/test_server/test_fetch_route.py tests/test_hf_space_smoke.py -v --tb=short` (64 passed)
- `pytest tests/test_rate_limiter.py tests/test_fingerprint.py tests/test_session_cache.py -v --tb=short` (43 passed)
- direct `fetch_content` loop against `https://example.com/`: `total_ok=1`, `total_failed=0`
- `ruff check` and `ruff format --check` for both changed files
- `git diff --check`

No release/tag is created by this PR, and its paths do not mutate the HF Space.
