### PR TITLE
fix(ci): 保留脱敏的 HFS fetch 失败诊断

### DIFF
--- a/scripts/hf_space_smoke.py
+++ b/scripts/hf_space_smoke.py
@@ -35,6 +35,13 @@ EDITION_RANK = {
     "full": 2,
 }
 TRUTHY_VALUES = {"1", "true", "yes", "on"}
+_FETCH_ERROR_MAX_LENGTH = 240
+_FETCH_ERROR_URL_RE = re.compile(r"https?://[^\s'\"<>]+", re.IGNORECASE)
+_FETCH_ERROR_BEARER_RE = re.compile(r"\bbearer\s+[^\s,;]+", re.IGNORECASE)
+_FETCH_ERROR_SECRET_RE = re.compile(
+    r"\b(?:authorization|token|api[_-]?key|password|secret)\b\s*[:=]\s*[^\s,;]+",
+    re.IGNORECASE,
+)
 
 DEFAULT_PAPER_SOURCES = [
     "openalex",
@@ -692,6 +699,52 @@ def safe_call(
             f"{type(exc).__name__}: {exc}",
             required=required,
         )
+
+
+def _sanitize_fetch_error(value: Any) -> str | None:
+    """Return a bounded diagnostic without endpoint URLs or credentials."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = _FETCH_ERROR_URL_RE.sub("<url>", value.strip())
+    text = _FETCH_ERROR_BEARER_RE.sub("Bearer <redacted>", text)
+    text = _FETCH_ERROR_SECRET_RE.sub("<redacted>", text)
+    if len(text) > _FETCH_ERROR_MAX_LENGTH:
+        text = f"{text[: _FETCH_ERROR_MAX_LENGTH - 1]}…"
+    return text
+
+
+def _fetch_result_diagnostic(data: Any) -> dict[str, Any]:
+    """Extract the first failed item as safe evidence for fetch smoke reports."""
+    if not isinstance(data, dict) or not isinstance(data.get("results"), list):
+        return {}
+    for result in data["results"]:
+        if not isinstance(result, dict):
+            continue
+        error = _sanitize_fetch_error(result.get("error"))
+        if error is None:
+            continue
+        diagnostic: dict[str, Any] = {"result_error": error}
+        source = result.get("source")
+        safe_source = _sanitize_fetch_error(source)
+        if safe_source is not None:
+            diagnostic["result_source"] = safe_source[:80]
+        raw = result.get("raw")
+        status_code = raw.get("status_code") if isinstance(raw, dict) else None
+        if isinstance(status_code, int):
+            diagnostic["result_status_code"] = status_code
+        return diagnostic
+    return {}
+
+
+def _fetch_detail_with_diagnostic(detail: str, diagnostic: dict[str, Any]) -> str:
+    if not diagnostic:
+        return detail
+    fields = [
+        f"{key}={diagnostic[key]!r}"
+        for key in ("result_source", "result_status_code", "result_error")
+        if key in diagnostic
+    ]
+    return f"{detail}, {', '.join(fields)}"
 
 
 def run_basic_checks(client: ApiClient, config: SmokeConfig, state: RunState) -> list[ProbeResult]:
@@ -1886,12 +1939,28 @@ def fetch_builtin(client: ApiClient) -> ProbeResult:
     ok_count = int(resp.data.get("total_ok") or 0)
     failed_count = int(resp.data.get("total_failed") or 0)
     ok = resp.status == 200 and ok_count >= 1
-    detail = f"status={resp.status}, total_ok={ok_count}, total_failed={failed_count}"
+    diagnostic = _fetch_result_diagnostic(resp.data)
+    detail = _fetch_detail_with_diagnostic(
+        f"status={resp.status}, total_ok={ok_count}, total_failed={failed_count}",
+        diagnostic,
+    )
     return (
-        pass_result("zero-key-fetch", "builtin-fetch", detail, required=True, elapsed=resp.elapsed)
+        pass_result(
+            "zero-key-fetch",
+            "builtin-fetch",
+            detail,
+            required=True,
+            elapsed=resp.elapsed,
+            meta=diagnostic,
+        )
         if ok
         else fail_result(
-            "zero-key-fetch", "builtin-fetch", detail, required=True, elapsed=resp.elapsed
+            "zero-key-fetch",
+            "builtin-fetch",
+            detail,
+            required=True,
+            elapsed=resp.elapsed,
+            meta=diagnostic,
         )
     )
 
@@ -1912,7 +1981,11 @@ def fetch_jina_reader(client: ApiClient) -> ProbeResult:
     ok_count = int(resp.data.get("total_ok") or 0)
     failed_count = int(resp.data.get("total_failed") or 0)
     outcome = "pass" if resp.status == 200 and ok_count >= 1 else "warn"
-    detail = f"status={resp.status}, total_ok={ok_count}, total_failed={failed_count}"
+    diagnostic = _fetch_result_diagnostic(resp.data)
+    detail = _fetch_detail_with_diagnostic(
+        f"status={resp.status}, total_ok={ok_count}, total_failed={failed_count}",
+        diagnostic,
+    )
     return ProbeResult(
         "zero-key-fetch",
         "jina-reader-fetch",
@@ -1920,7 +1993,7 @@ def fetch_jina_reader(client: ApiClient) -> ProbeResult:
         detail,
         False,
         resp.elapsed,
-        {"total_ok": ok_count, "total_failed": failed_count},
+        {"total_ok": ok_count, "total_failed": failed_count, **diagnostic},
     )
 
 
@@ -1950,10 +2023,12 @@ def fetch_provider_probe(
     failed_count = int(resp.data.get("total_failed") or 0)
     total = int(resp.data.get("total") or ok_count + failed_count)
     outcome = "pass" if resp.status == 200 and ok_count >= 1 else "warn"
+    diagnostic = _fetch_result_diagnostic(resp.data)
     detail = (
         f"status={resp.status}, total_ok={ok_count}, total_failed={failed_count}, "
         f"note={provider_test.get('note', '-')}"
     )
+    detail = _fetch_detail_with_diagnostic(detail, diagnostic)
     return ProbeResult(
         "zero-key-fetch-source",
         f"{provider}+{backend}+warp-{warp}",
@@ -1971,6 +2046,7 @@ def fetch_provider_probe(
             "total_ok": ok_count,
             "total_failed": failed_count,
             "note": provider_test.get("note", ""),
+            **diagnostic,
         },
     )
 

--- a/tests/test_hf_space_smoke.py
+++ b/tests/test_hf_space_smoke.py
@@ -104,6 +104,42 @@ def test_private_space_uses_separate_outer_and_application_auth_headers(monkeypa
     assert captured["timeout"] == 3
 
 
+def test_builtin_fetch_failure_records_sanitized_item_diagnostic():
+    class FakeFetchClient:
+        def post(self, _path, **_kwargs):
+            return smoke.ResponseData(
+                200,
+                {
+                    "total_ok": 0,
+                    "total_failed": 1,
+                    "results": [
+                        {
+                            "source": "builtin",
+                            "error": (
+                                "upstream rejected https://example.test/page?token=raw-token; "
+                                "Authorization: Bearer raw-bearer"
+                            ),
+                            "raw": {"status_code": 403},
+                        }
+                    ],
+                },
+                0.1,
+            )
+
+    result = smoke.fetch_builtin(FakeFetchClient())
+
+    assert result.outcome == "fail"
+    assert result.required is True
+    assert result.meta["result_source"] == "builtin"
+    assert result.meta["result_status_code"] == 403
+    assert "<url>" in result.meta["result_error"]
+    assert "<redacted>" in result.meta["result_error"]
+    assert "raw-token" not in result.detail
+    assert "raw-bearer" not in result.detail
+    assert "raw-token" not in result.meta["result_error"]
+    assert "raw-bearer" not in result.meta["result_error"]
+
+
 def test_required_failures_only_counts_required_failed_rows():
     results = [
         smoke.ProbeResult("basic", "health", "pass", "ok", required=True),


### PR DESCRIPTION
## 问题与结果

完整 RC [#29944322654](https://github.com/BlueSkyXN/SouWen/actions/runs/29944322654) 的 HFS capability post-deploy smoke 仅显示 required `builtin-fetch` 的 `total_ok=0` / `total_failed=1`，没有保留 fetch item 的失败原因，无法以证据定位下一步修复。

此 PR 为失败项增加受限、脱敏的诊断：首个 item 的 error、source 和 HTTP status code 会写入既有 JSON/Markdown smoke artifact。

## 变更与边界

- `scripts/hf_space_smoke.py`：提取首个失败 fetch item，并对 URL、Bearer credential 以及常见 secret 字段脱敏；错误文本限制为 240 个字符。
- `tests/test_hf_space_smoke.py`：覆盖 required `builtin-fetch` 失败时的 artifact 诊断和脱敏边界。
- 不修改 PASS/WARN/FAIL、required gate、target、WARP、SSRF、部署或 release 语义；不记录正文、headers、完整 `raw` 或原始 response payload。

## 验证

- `pytest tests/test_hf_space_smoke.py tests/test_functional_common.py -v --tb=short` — 53 passed
- `ruff check scripts/hf_space_smoke.py tests/test_hf_space_smoke.py` — passed
- `ruff format --check scripts/hf_space_smoke.py tests/test_hf_space_smoke.py` — passed
- `git diff --check` — passed

## 后续验证边界

该 PR 仅提供排障证据，不会在 PR 中触发 HFS mutation。合并后需以新的精确 `main` SHA 运行完整中央 `release-candidate.yml`（`publish=false`、`deploy_hfs=true`）取得 candidate 环境的真实错误，再据此决定产品层最小修复。