### PR TITLE
fix(ci): allow HFS after skipped release matrices

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -553,7 +553,7 @@ jobs:
   hfs:
     name: Candidate-only HF Space promotion
     needs: [validate, promotion-gate]
-    if: ${{ inputs.deploy_hfs && needs.promotion-gate.result == 'success' }}
+    if: ${{ always() && inputs.deploy_hfs && needs.promotion-gate.result == 'success' }}
     uses: ./.github/workflows/deploy-hf-space.yml
     with:
       candidate_sha: ${{ needs.validate.outputs.candidate_sha }}

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -157,6 +157,7 @@ def test_deployment_profile_skips_release_binary_matrices_and_gates_hfs() -> Non
     ):
         assert gate in promotion_gate
     assert "needs: [validate, promotion-gate]" in hfs
+    assert "if: ${{ always() && inputs.deploy_hfs" in hfs
     assert "needs.promotion-gate.result == 'success'" in hfs
     assert "secrets: inherit" in hfs
 


### PR DESCRIPTION
## Summary

- force evaluation of the HFS reusable job after the deployment profile intentionally skips both release binary matrices
- retain the requirement that `promotion-gate` succeeds before any HFS write
- add a deterministic assertion for the `always()` skip-propagation guard

## Live failure evidence

Deployment-profile run #29977743462 reached a successful `promotion-gate`, with both outer binary jobs `skipped`, but GitHub Actions then skipped `Candidate-only HF Space promotion`. The deployment assembler failed closed because `hfs.result` was `skipped`. Space repo/runtime remained at the prior immutable baseline, so the failed run caused no HFS mutation.

## Validation

- `pytest tests/test_release_candidate_workflows.py -v --tb=short` (18 passed)
- `ruff check tests/test_release_candidate_workflows.py`
- `ruff format --check tests/test_release_candidate_workflows.py`
- `actionlint .github/workflows/release-candidate.yml`
- `actionlint .github/workflows/release-candidate.yml .github/workflows/deploy-hf-space.yml`
- `python3 tools/gen_docs.py --check`
- `git diff --check`

This PR does not modify secrets, environment policy, SSRF behavior, rollback/pause behavior, tag rules, or release asset contracts. PR checks cannot deploy HFS; live acceptance will rerun the explicit `deployment` profile after merge.
