### PR TITLE
fix(ci): 固定 HFS fetch 探针并收紧 promotion 下游门禁

### DIFF
--- a/.github/workflows/deploy-hf-space.yml
+++ b/.github/workflows/deploy-hf-space.yml
@@ -56,6 +56,7 @@ on:
       - "scripts/ci/**"
       - "cli.py"
       - "scripts/hf_space_smoke.py"
+      - "scripts/fixtures/hf-space-fetch-probe.html"
       - "scripts/warp-init.sh"
       - "cloud/hfs/**"
       - ".github/workflows/deploy-hf-space.yml"

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1374,7 +1374,7 @@ jobs:
   publish:
     name: Publish GitHub Release
     needs: [validate, assemble]
-    if: ${{ inputs.publish }}
+    if: ${{ always() && inputs.publish && needs.validate.result == 'success' && needs.assemble.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:

--- a/scripts/fixtures/hf-space-fetch-probe.html
+++ b/scripts/fixtures/hf-space-fetch-probe.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>SouWen immutable HF Space fetch probe</title>
+    <meta name="description" content="Repository-owned fixture for the required builtin fetch smoke probe.">
+  </head>
+  <body>
+    <main>
+      <article>
+        <h1>SouWen immutable HF Space fetch probe</h1>
+        <p>
+          SOUWEN_IMMUTABLE_FETCH_PROBE_V1. This document is owned by the SouWen
+          repository and is fetched only through a raw GitHub URL pinned to the
+          release candidate commit. It is intentionally ordinary HTML with a
+          visible title, stable prose, headings, lists, and enough body text to
+          exercise the builtin HTTP fetch and extraction path without relying on
+          a mutable third-party page.
+        </p>
+        <h2>Purpose</h2>
+        <p>
+          A post-deploy smoke check must distinguish network reachability from
+          meaningful content extraction. A tiny connectivity page can return a
+          successful HTTP status while providing too little material to expose a
+          parser regression, an accidental empty-body response, or a change in
+          content normalization. This fixture keeps the probe deterministic at
+          the candidate level: the URL includes the exact forty-character Git
+          SHA that the deployment reports from its health and readiness routes.
+        </p>
+        <p>
+          The fixture does not contain credentials, customer data, external
+          links, JavaScript dependencies, tracking resources, forms, or browser
+          requirements. It is a static text document. Its wording is retained in
+          the repository so a reviewer can inspect the exact content that a
+          candidate smoke run requested and compare it with the fetch response
+          recorded in the resulting report.
+        </p>
+        <h2>Extraction expectations</h2>
+        <p>
+          The builtin provider should retain this marker and a substantial
+          portion of the article body after HTML processing. The smoke script
+          therefore requires the marker and a bounded minimum number of content
+          characters. The bound does not change production extraction logic or
+          weaken SSRF protections; it simply rejects an otherwise successful
+          response that is not evidence of useful text extraction.
+        </p>
+        <p>
+          The release workflow supplies the candidate SHA as an explicit
+          expected value. The smoke script derives this raw-content URL rather
+          than accepting a branch name, tag, redirect target, local address, or
+          mutable default. When that SHA is absent, the required builtin probe
+          fails closed instead of silently substituting a generic public page.
+        </p>
+        <h2>Audit notes</h2>
+        <ul>
+          <li>The fixture path is part of the repository source tree.</li>
+          <li>The raw URL contains an immutable candidate commit SHA.</li>
+          <li>The marker confirms that extraction reached this document.</li>
+          <li>The text length makes an empty or minimal extractor output fail.</li>
+          <li>Existing SSRF validation remains in the regular fetch route.</li>
+        </ul>
+        <p>
+          Keeping this final paragraph ensures the fixture remains comfortably
+          larger than the smoke threshold even if normal HTML cleanup removes
+          navigation or formatting elements. The content is intentionally
+          factual and self-contained so it can be safely served from the public
+          repository and inspected in release evidence without special access.
+        </p>
+      </article>
+    </main>
+  </body>
+</html>

--- a/scripts/hf_space_smoke.py
+++ b/scripts/hf_space_smoke.py
@@ -29,6 +29,10 @@ except ModuleNotFoundError:  # pragma: no cover - direct `python scripts/...` ex
 DEFAULT_BASE_URL = "https://blueskyxn-souwen.hf.space"
 USER_AGENT = "SouWen HF Space CD report/1.0"
 DEFAULT_SMOKE_EDITION = "pro"
+REQUIRED_BUILTIN_FETCH_PROBE_PATH = "scripts/fixtures/hf-space-fetch-probe.html"
+REQUIRED_BUILTIN_FETCH_PROBE_RAW_BASE_URL = "https://raw.githubusercontent.com/BlueSkyXN/SouWen"
+REQUIRED_BUILTIN_FETCH_PROBE_MARKER = "SOUWEN_IMMUTABLE_FETCH_PROBE_V1"
+REQUIRED_BUILTIN_FETCH_MIN_CONTENT_CHARS = 600
 EDITION_RANK = {
     "basic": 0,
     "pro": 1,
@@ -357,6 +361,18 @@ def normalize_expected_source_sha(raw: str | None) -> str | None:
     if re.fullmatch(r"[0-9a-fA-F]{40}", value) is None:
         raise ValueError("expected source SHA must be exactly 40 hexadecimal characters")
     return value.lower()
+
+
+def immutable_builtin_fetch_probe_url(expected_source_sha: str | None) -> str | None:
+    """Build the required builtin probe URL from an immutable candidate SHA."""
+
+    candidate_sha = normalize_expected_source_sha(expected_source_sha)
+    if candidate_sha is None:
+        return None
+    return (
+        f"{REQUIRED_BUILTIN_FETCH_PROBE_RAW_BASE_URL}/{candidate_sha}/"
+        f"{REQUIRED_BUILTIN_FETCH_PROBE_PATH}"
+    )
 
 
 def bool_or_none(value: Any) -> bool | None:
@@ -1923,11 +1939,21 @@ def bilibili_video_detail_route(client: ApiClient) -> ProbeResult:
     )
 
 
-def fetch_builtin(client: ApiClient) -> ProbeResult:
+def fetch_builtin(client: ApiClient, config: SmokeConfig) -> ProbeResult:
+    probe_url = immutable_builtin_fetch_probe_url(config.expected_source_sha)
+    if probe_url is None:
+        return fail_result(
+            "zero-key-fetch",
+            "builtin-fetch",
+            "required immutable builtin fetch probe needs an expected candidate SHA",
+            required=True,
+            meta={"probe_kind": "candidate-pinned-repository-fixture"},
+        )
+
     resp = client.post(
         "/api/v1/fetch",
         body={
-            "urls": ["https://example.com/"],
+            "urls": [probe_url],
             "provider": "builtin",
             "timeout": 15,
             "max_length": 1200,
@@ -1938,10 +1964,43 @@ def fetch_builtin(client: ApiClient) -> ProbeResult:
     )
     ok_count = int(resp.data.get("total_ok") or 0)
     failed_count = int(resp.data.get("total_failed") or 0)
-    ok = resp.status == 200 and ok_count >= 1
     diagnostic = _fetch_result_diagnostic(resp.data)
+    result = next(
+        (
+            item
+            for item in resp.data.get("results", [])
+            if isinstance(item, dict) and item.get("source") == "builtin"
+        ),
+        {},
+    )
+    content = result.get("content") if isinstance(result, dict) else None
+    content_chars = len(content) if isinstance(content, str) else 0
+    fixture_marker_found = (
+        isinstance(content, str) and REQUIRED_BUILTIN_FETCH_PROBE_MARKER in content
+    )
+    result_url = result.get("url") if isinstance(result, dict) else None
+    url_pinned = result_url == probe_url
+    ok = (
+        resp.status == 200
+        and ok_count >= 1
+        and url_pinned
+        and fixture_marker_found
+        and content_chars >= REQUIRED_BUILTIN_FETCH_MIN_CONTENT_CHARS
+    )
+    meta = {
+        "probe_kind": "candidate-pinned-repository-fixture",
+        "content_chars": content_chars,
+        "fixture_marker_found": fixture_marker_found,
+        "url_pinned": url_pinned,
+        **diagnostic,
+    }
     detail = _fetch_detail_with_diagnostic(
-        f"status={resp.status}, total_ok={ok_count}, total_failed={failed_count}",
+        (
+            f"status={resp.status}, total_ok={ok_count}, total_failed={failed_count}, "
+            f"url_pinned={url_pinned}, fixture_marker_found={fixture_marker_found}, "
+            f"content_chars={content_chars}, min_content_chars="
+            f"{REQUIRED_BUILTIN_FETCH_MIN_CONTENT_CHARS}"
+        ),
         diagnostic,
     )
     return (
@@ -1951,7 +2010,7 @@ def fetch_builtin(client: ApiClient) -> ProbeResult:
             detail,
             required=True,
             elapsed=resp.elapsed,
-            meta=diagnostic,
+            meta=meta,
         )
         if ok
         else fail_result(
@@ -1960,7 +2019,7 @@ def fetch_builtin(client: ApiClient) -> ProbeResult:
             detail,
             required=True,
             elapsed=resp.elapsed,
-            meta=diagnostic,
+            meta=meta,
         )
     )
 
@@ -2544,7 +2603,12 @@ def run_zero_key_checks(
         )
     )
     results.append(
-        safe_call("zero-key-fetch", "builtin-fetch", lambda: fetch_builtin(client), required=True)
+        safe_call(
+            "zero-key-fetch",
+            "builtin-fetch",
+            lambda: fetch_builtin(client, config),
+            required=True,
+        )
     )
     if edition_allows(edition, "pro"):
         results.append(

--- a/tests/test_hf_space_smoke.py
+++ b/tests/test_hf_space_smoke.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -126,7 +127,13 @@ def test_builtin_fetch_failure_records_sanitized_item_diagnostic():
                 0.1,
             )
 
-    result = smoke.fetch_builtin(FakeFetchClient())
+    config = smoke.SmokeConfig(
+        base_url="https://example.test",
+        expected_version="1.2.3",
+        expected_source_sha="a" * 40,
+        request_timeout=1,
+    )
+    result = smoke.fetch_builtin(FakeFetchClient(), config)
 
     assert result.outcome == "fail"
     assert result.required is True
@@ -138,6 +145,87 @@ def test_builtin_fetch_failure_records_sanitized_item_diagnostic():
     assert "raw-bearer" not in result.detail
     assert "raw-token" not in result.meta["result_error"]
     assert "raw-bearer" not in result.meta["result_error"]
+
+
+def test_required_builtin_fetch_uses_candidate_pinned_repository_fixture():
+    calls: list[dict] = []
+    candidate_sha = "a" * 40
+    config = smoke.SmokeConfig(
+        base_url="https://example.test",
+        expected_version="1.2.3",
+        expected_source_sha=candidate_sha,
+        request_timeout=1,
+    )
+    expected_url = smoke.immutable_builtin_fetch_probe_url(candidate_sha)
+
+    class FakeFetchClient:
+        def post(self, _path, **kwargs):
+            calls.append(kwargs)
+            return smoke.ResponseData(
+                200,
+                {
+                    "total_ok": 1,
+                    "total_failed": 0,
+                    "results": [
+                        {
+                            "url": expected_url,
+                            "final_url": expected_url,
+                            "source": "builtin",
+                            "content": (
+                                f"{smoke.REQUIRED_BUILTIN_FETCH_PROBE_MARKER} "
+                                + ("fixture content " * 100)
+                            ),
+                        }
+                    ],
+                },
+                0.1,
+            )
+
+    result = smoke.fetch_builtin(FakeFetchClient(), config)
+
+    assert result.outcome == "pass"
+    assert result.required is True
+    assert calls[0]["body"]["urls"] == [expected_url]
+    assert candidate_sha in expected_url
+    assert "example.com" not in expected_url
+    assert calls[0]["body"]["respect_robots_txt"] is False
+    assert result.meta["content_chars"] >= smoke.REQUIRED_BUILTIN_FETCH_MIN_CONTENT_CHARS
+    assert result.meta["fixture_marker_found"] is True
+
+
+def test_required_builtin_fetch_fails_without_a_candidate_sha_before_request():
+    class FakeFetchClient:
+        def post(self, *_args, **_kwargs):
+            raise AssertionError("missing candidate SHA must not fall back to a mutable URL")
+
+    config = smoke.SmokeConfig(
+        base_url="https://example.test",
+        expected_version="1.2.3",
+        request_timeout=1,
+    )
+
+    result = smoke.fetch_builtin(FakeFetchClient(), config)
+
+    assert result.outcome == "fail"
+    assert result.required is True
+    assert "candidate SHA" in result.detail
+
+
+def test_required_builtin_fetch_fixture_is_repository_owned_and_content_sufficient():
+    fixture = Path(__file__).resolve().parents[1] / smoke.REQUIRED_BUILTIN_FETCH_PROBE_PATH
+    content = fixture.read_text(encoding="utf-8")
+
+    assert smoke.REQUIRED_BUILTIN_FETCH_PROBE_MARKER in content
+    assert len(content) >= smoke.REQUIRED_BUILTIN_FETCH_MIN_CONTENT_CHARS
+
+    from souwen.web.builtin import _extract_with_trafilatura
+
+    extracted = _extract_with_trafilatura(
+        content,
+        smoke.immutable_builtin_fetch_probe_url("a" * 40) or "",
+    )["content"]
+    assert smoke.REQUIRED_BUILTIN_FETCH_PROBE_MARKER in extracted
+    assert len(extracted) >= smoke.REQUIRED_BUILTIN_FETCH_MIN_CONTENT_CHARS
 
 
 def test_required_failures_only_counts_required_failed_rows():

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import json
+import re
 import textwrap
 from pathlib import Path
+from typing import TypedDict
 
 import pytest
 
@@ -22,6 +24,74 @@ def _job(text: str, name: str, next_name: str) -> str:
 def _python_heredoc(block: str, index: int = 0) -> str:
     source = block.split("python3 - <<'PY'")[index + 1].split("\n          PY", maxsplit=1)[0]
     return textwrap.dedent(source).lstrip()
+
+
+class WorkflowJob(TypedDict):
+    needs: list[str]
+    condition: str
+
+
+def _release_candidate_job_graph(text: str) -> dict[str, WorkflowJob]:
+    """Parse the workflow's top-level job dependencies and conditions.
+
+    The release candidate keeps ``needs`` inline today, but this intentionally
+    handles both inline and block lists so the downstream-gate contract follows
+    the graph rather than a hand-maintained job list.
+    """
+
+    jobs_text = text.split("\njobs:\n", maxsplit=1)[1]
+    jobs: dict[str, WorkflowJob] = {}
+    current: WorkflowJob | None = None
+    collecting_needs = False
+    job_pattern = re.compile(r"^  ([A-Za-z0-9_-]+):\s*$")
+    inline_needs_pattern = re.compile(r"^    needs:\s*\[([^]]*)\]\s*$")
+
+    for line in jobs_text.splitlines():
+        job_match = job_pattern.match(line)
+        if job_match:
+            current = {"needs": [], "condition": ""}
+            jobs[job_match.group(1)] = current
+            collecting_needs = False
+            continue
+        if current is None:
+            continue
+
+        inline_needs = inline_needs_pattern.match(line)
+        if inline_needs:
+            current["needs"] = [
+                job_id.strip() for job_id in inline_needs.group(1).split(",") if job_id.strip()
+            ]
+            collecting_needs = False
+            continue
+        if line == "    needs:":
+            current["needs"] = []
+            collecting_needs = True
+            continue
+        if collecting_needs and line.startswith("      - "):
+            current["needs"].append(line.removeprefix("      - ").strip())
+            continue
+        collecting_needs = False
+        if line.startswith("    if:"):
+            current["condition"] = line.split(":", maxsplit=1)[1].strip()
+
+    return jobs
+
+
+def _downstream_jobs(graph: dict[str, WorkflowJob], root: str) -> set[str]:
+    reverse: dict[str, set[str]] = {job_id: set() for job_id in graph}
+    for job_id, job in graph.items():
+        for dependency in job["needs"]:
+            reverse.setdefault(dependency, set()).add(job_id)
+
+    discovered: set[str] = set()
+    pending = list(reverse.get(root, set()))
+    while pending:
+        job_id = pending.pop()
+        if job_id in discovered:
+            continue
+        discovered.add(job_id)
+        pending.extend(reverse.get(job_id, set()))
+    return discovered
 
 
 def test_workflow_embedded_python_blocks_compile() -> None:
@@ -160,6 +230,33 @@ def test_deployment_profile_skips_release_binary_matrices_and_gates_hfs() -> Non
     assert "if: ${{ always() && inputs.deploy_hfs" in hfs
     assert "needs.promotion-gate.result == 'success'" in hfs
     assert "secrets: inherit" in hfs
+
+
+def test_promotion_gate_descendants_always_run_to_observe_skipped_parents() -> None:
+    graph = _release_candidate_job_graph(_workflow("release-candidate.yml"))
+
+    assert graph["promotion-gate"]["needs"] == [
+        "validate",
+        "ci",
+        "source",
+        "external",
+        "pyinstaller",
+        "nuitka",
+        "package",
+        "clean-install",
+        "container",
+    ]
+    # Deployment deliberately skips both release binary matrices. They must stay
+    # ordinary parents so promotion-gate can explicitly verify that contract.
+    for binary_job in ("pyinstaller", "nuitka"):
+        assert graph[binary_job]["condition"] == "${{ inputs.evidence_profile == 'release' }}"
+
+    downstream = _downstream_jobs(graph, "promotion-gate")
+    assert downstream == {"hfs", "assemble-deployment", "assemble", "publish"}
+    for job_id in downstream:
+        assert "always()" in graph[job_id]["condition"], (
+            f"{job_id} must use always() so it can observe skipped/failing promotion parents"
+        )
 
 
 def test_deployment_evidence_is_non_publishable_and_contains_no_release_binaries() -> None:
@@ -336,6 +433,13 @@ def test_hfs_deployment_keeps_one_basic_pyinstaller_smoke() -> None:
     assert 'pip install -e ".[edition-basic]"' in pyinstaller
     assert "profile: basic-cli" in pyinstaller
     assert "builder: pyinstaller" in pyinstaller
+
+
+def test_hfs_required_fetch_fixture_change_triggers_workflow() -> None:
+    text = _workflow("deploy-hf-space.yml")
+
+    assert '- "scripts/hf_space_smoke.py"' in text
+    assert '- "scripts/fixtures/hf-space-fetch-probe.html"' in text
 
 
 def test_only_hfs_reusable_call_inherits_secrets() -> None:


### PR DESCRIPTION
## 结果与边界

修复当前 deployment profile 的两个前置缺口：required `builtin-fetch` 不再依赖内容过短的 `example.com`，并让 `promotion-gate` 的所有传递下游显式处理 skipped/failing parents。

本 PR 只调整 HFS smoke、workflow contract 和确定性测试；尚未部署到 HFS，也不创建 tag、Release 或发布制品。

## 变更

- 新增仓库自有 `scripts/fixtures/hf-space-fetch-probe.html`。
- required builtin fetch 使用 `raw.githubusercontent.com/BlueSkyXN/SouWen/<candidate_sha>/...`，校验 URL pin、固定 marker 和最小抽取长度；缺少 candidate SHA 时 fail-closed。
- 保留 `example.com` 为 non-required connectivity probe；不修改 production extractor 阈值或 SSRF 行为。
- 从 `promotion-gate` 解析传递下游 job graph，要求 `hfs`、两个 assemble job 和 `publish` 均包含 `always()`。
- `publish` 同时显式要求 `validate` 与 `assemble` success，避免 `always()` 扩大发布条件。
- fixture 文件变化纳入 `deploy-hf-space.yml` 的 PR path trigger。

## 兼容性与风险

- deployment profile 仍跳过 PyInstaller/Nuitka release matrices；`promotion-gate` 继续显式验证其为 skipped。
- 新 required probe 依赖 candidate commit 已推送到 GitHub raw；release-candidate/HFS 流程本身要求 immutable candidate SHA。
- HFS live smoke、rollback 和 deployment evidence 需要合并到 trusted `main` 后通过 central release-candidate workflow 验证。

## 验证

- `python3 -m pytest tests/test_hf_space_smoke.py tests/test_release_candidate_workflows.py tests/test_ci_profile_runner.py -q`：83 passed。
- `python3 scripts/ci/run_profile.py --profile pro-cli --profile basic-cli`：PASS。
- `python3 -m ruff check ...`：通过。
- `python3 -m ruff format --check ...`：通过。
- `PYTHONPATH=src python3 tools/gen_docs.py --check`：通过。
- `actionlint .github/workflows/release-candidate.yml`：通过。
- `actionlint .github/workflows/deploy-hf-space.yml` 仍报告 4 个 `environment.deployment` schema 错误；对 `origin/main` 同一 workflow 运行结果相同，不是本 PR 引入。
- `git diff --check`：通过。

## Review focus

- `fetch_builtin()` 对 candidate-pinned fixture 的 fail-closed 与成功判据。
- job graph parser 对 `needs` 传递下游的覆盖。
- `publish.if` 是否保持 fail-closed，且不会因 `always()` 在 assemble 失败时执行发布。
