### PR TITLE
ci: pin compatible Ruff toolchain

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -37,7 +37,7 @@ jobs:
           cache: 'pip'
 
       - name: 安装 ruff
-        run: pip install ruff
+        run: pip install "ruff==0.15.22"
 
       - name: 运行 ruff check --fix（仅安全修复）
         run: ruff check --fix src/ tests/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           cache: 'pip'
 
       - name: 安装 ruff
-        run: pip install ruff
+        run: pip install "ruff==0.15.22"
 
       - name: Ruff 语法检查
         run: ruff check src tests scripts tools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ edition-full = ["souwen[edition-pro,newspaper,readability,pdf,web2pdf]"]
 edition-full-crawl4ai = ["souwen[edition-full,crawl4ai]"]
 edition-full-scrapling = ["souwen[edition-full,scrapling]"]
 # 开发工具：单元测试、覆盖率、代码检查
-dev = ["pytest>=8.0", "pytest-asyncio>=0.23", "pytest-httpx>=0.30", "pytest-cov>=4", "ruff>=0.4", "markdown-it-py>=2.2"]
+dev = ["pytest>=8.0", "pytest-asyncio>=0.23", "pytest-httpx>=0.30", "pytest-cov>=4", "ruff==0.15.22", "markdown-it-py>=2.2"]
 
 [tool.uv]
 conflicts = [

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -557,6 +557,17 @@ def test_ci_has_stable_aggregate_and_required_readiness_gates() -> None:
     assert 'git push "$bare" HEAD:refs/heads/ci-candidate' in container
 
 
+def test_ruff_toolchain_version_is_pinned_consistently() -> None:
+    version = "0.15.22"
+    pyproject = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    assert f'"ruff=={version}"' in pyproject
+
+    for workflow_name in ("ci.yml", "auto-format.yml"):
+        workflow = _workflow(workflow_name)
+        assert f'pip install "ruff=={version}"' in workflow
+        assert "pip install ruff\n" not in workflow
+
+
 def test_hfs_reusable_promotion_is_candidate_pinned_and_live_verified() -> None:
     text = _workflow("deploy-hf-space.yml")
     candidate_expression = (


### PR DESCRIPTION
## Problem

PR #191 exposed a toolchain drift rather than a source regression:

- CI run #30055736761 and V2 run #30055736752 resolved the unbounded Ruff dependency to newly released `ruff 0.16.0`
- both lint gates reported 828 existing repository violations
- the latest successful main CI run #29978385319 used `ruff 0.15.22`
- `pyproject.toml`, `ci.yml`, and `auto-format.yml` did not share a bounded version contract

The merge push CI at `main@4d05d7a4` was cancelled, so it did not expose this drift before the next PR.

## Fix

- pin the development extra to `ruff==0.15.22`
- pin direct CI and auto-format installs to the same version
- add a workflow contract test that prevents the three version surfaces from drifting

This intentionally does not bulk-rewrite 828 unrelated Python findings under Ruff 0.16. A future Ruff upgrade should be a dedicated migration with its own diff and validation.

## Validation

- `uvx ruff==0.15.22 check src tests scripts tools` — passed
- `uvx ruff==0.15.22 format --check src tests scripts tools` — 449 files already formatted
- `PYTHONPATH=src SOUWEN_PLUGIN_AUTOLOAD=0 pytest tests/test_release_candidate_workflows.py -q --tb=short` — 21 passed
- `PYTHONPATH=src SOUWEN_PLUGIN_AUTOLOAD=0 pytest tests/test_ci_profile_runner.py tests/test_package_extras.py -q --tb=short` — 23 passed
- `git diff --check` — passed
