### PR TITLE
refactor: 提取 Common Runtime request context

### DIFF
--- a/docs/internal/spec-06-common-runtime-lld.md
+++ b/docs/internal/spec-06-common-runtime-lld.md
@@ -142,8 +142,16 @@ Rollback 是让 consumers 恢复 legacy import 并恢复原实现文件；不需
 
 ### 6.1 Request context
 
-仅可抽取 `ContextVar`、`get_request_id()` 与给 `LogRecord` 注入 ID 的 filter。ASGI scope、
+Canonical path 为 `souwen.common_runtime.observability`，内部接口为
+`request_id_var: ContextVar[str]`、`get_request_id() -> str` 和 `RequestIDFilter`。默认值为
+`"-"`；调用方负责以 `ContextVar.set()` 的 token 在 `finally` 中 reset。filter 只给传入的
+`LogRecord` 设置当前 `request_id` 并返回 `True`，不验证、生成或记录 ID。
+
+`souwen.server.middleware` 保留 compatibility re-export 和 `RequestIDMiddleware`。ASGI scope、
 incoming header validation、UUID generation、response header、timing 和 access log 保留在 Delivery。
+该切片无 I/O、timeout、retry 或 cooperative cancellation；ContextVar 由 Python runtime 按 task
+隔离。退出证据必须包含旧/新 object identity、task isolation、logging filter 和 Server
+error-response correlation parity。
 
 ### 6.2 SSRF resolver
 
@@ -209,7 +217,7 @@ Transport v1 若进入实施，必须先冻结：
 | Task | Scope | Exit evidence |
 |---|---|---|
 | CR-01 | provenance canonical move + legacy re-export + two consumers | VAL-CR-001–006 |
-| CR-02 | request context primitive | no ASGI dependency; request/error/log ID parity |
+| CR-02 | request context primitive | canonical context 无 ASGI dependency；旧路径 re-export；request/error/log ID parity |
 | CR-03 | SSRF resolver primitive | DNS/IP/Host/SNI/redirect fixtures parity; no `FetchResult` import |
 | CR-04 | generic redaction split | no Pydantic/LLM policy in primitive; secret fixtures parity |
 | CR-05 | trusted Provider HTTP transport | explicit cancellation/redirect/config contract and parity |

--- a/src/souwen/common_runtime/observability/__init__.py
+++ b/src/souwen/common_runtime/observability/__init__.py
@@ -9,10 +9,18 @@ from souwen.common_runtime.observability.provenance import (
     SOURCE_SHA_FILENAME,
     get_source_sha,
 )
+from souwen.common_runtime.observability.request_context import (
+    RequestIDFilter,
+    get_request_id,
+    request_id_var,
+)
 
 __all__ = [
+    "RequestIDFilter",
     "SOURCE_SHA_ENV",
     "SOURCE_SHA_FILE_ENV",
     "SOURCE_SHA_FILENAME",
+    "get_request_id",
     "get_source_sha",
+    "request_id_var",
 ]

--- a/src/souwen/common_runtime/observability/request_context.py
+++ b/src/souwen/common_runtime/observability/request_context.py
@@ -1,0 +1,25 @@
+"""Request correlation context shared by protocol and logging adapters."""
+
+from __future__ import annotations
+
+import logging
+from contextvars import ContextVar
+
+
+request_id_var: ContextVar[str] = ContextVar("request_id", default="-")
+
+
+def get_request_id() -> str:
+    """Return the current correlation ID or ``"-"`` outside a request context."""
+    return request_id_var.get()
+
+
+class RequestIDFilter(logging.Filter):
+    """Inject the current correlation ID into a log record."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = get_request_id()
+        return True
+
+
+__all__ = ["RequestIDFilter", "get_request_id", "request_id_var"]

--- a/src/souwen/logging_config.py
+++ b/src/souwen/logging_config.py
@@ -49,7 +49,7 @@
     - json: JSON 格式化
     - datetime/timezone: 时间戳
     - re: 正则匹配敏感数据
-    - souwen.server.middleware.RequestIDFilter: 请求 ID 追踪
+    - souwen.common_runtime.observability.RequestIDFilter: 请求 ID 追踪
 """
 
 from __future__ import annotations
@@ -60,8 +60,8 @@ import os
 import sys
 from datetime import datetime, timezone
 
+from souwen.common_runtime.observability import RequestIDFilter
 from souwen.core.redaction import redact_secret_text
-from souwen.server.middleware import RequestIDFilter
 
 _CONFIGURED = False
 

--- a/src/souwen/server/app.py
+++ b/src/souwen/server/app.py
@@ -85,9 +85,9 @@ from souwen.config import ensure_config_file, get_config
 from souwen.core.redaction import redact_secret_text, redact_secret_value
 from souwen.logging_config import setup_logging
 from souwen.plugin import ensure_plugins_loaded, get_loaded_plugins
-from souwen.common_runtime.observability import get_source_sha
+from souwen.common_runtime.observability import get_request_id, get_source_sha
 from souwen.server.auth import is_admin_open_enabled
-from souwen.server.middleware import RequestIDMiddleware, get_request_id
+from souwen.server.middleware import RequestIDMiddleware
 from souwen.server.routes import router, admin_router
 from souwen.server.schemas import ErrorResponse, HealthResponse, ReadinessResponse
 from souwen.web.fetch import _current_plugin_owner

--- a/src/souwen/server/middleware.py
+++ b/src/souwen/server/middleware.py
@@ -33,8 +33,8 @@ r"""SouWen ASGI 中间件 — 请求 ID 注入 + 响应计时 + 访问日志
     _SKIP_LOG_PATHS：无需记录访问日志的路径集合
 
 模块依赖：
-    - contextvars：上下文变量
-    - logging：日志系统
+    - logging：访问日志
+    - souwen.common_runtime.observability：请求关联上下文与日志过滤器
 """
 
 from __future__ import annotations
@@ -42,11 +42,13 @@ from __future__ import annotations
 import logging
 import re
 import time
-from contextvars import ContextVar
 from uuid import uuid4
 
-# 当前请求 ID — 任何模块均可通过 get_request_id() 读取
-request_id_var: ContextVar[str] = ContextVar("request_id", default="-")
+from souwen.common_runtime.observability import (
+    RequestIDFilter,
+    get_request_id,
+    request_id_var,
+)
 
 logger = logging.getLogger("souwen.server")
 
@@ -54,18 +56,6 @@ _VALID_REQUEST_ID = re.compile(r"^[\w\-]{1,64}$")
 
 # 不记录访问日志的路径（健康检查 / 面板静态资源）
 _SKIP_LOG_PATHS = frozenset({"/health", "/panel"})
-
-
-def get_request_id() -> str:
-    """获取当前请求的关联 ID — 支持跨协程调用
-
-    返回存储在 contextvars 中的 request_id。可在任何异步上下文（如背景任务、
-    异步依赖、日志等）中调用，无需显式传递 request_id 参数。
-
-    Returns:
-        request_id 字符串，或默认值 "-" 当 context 未设置
-    """
-    return request_id_var.get()
 
 
 class RequestIDMiddleware:
@@ -147,18 +137,4 @@ class RequestIDMiddleware:
             request_id_var.reset(token)
 
 
-class RequestIDFilter(logging.Filter):
-    """日志过滤器 — 自动将 request_id 注入所有日志记录
-
-    允许日志格式中包含 %(request_id)s 占位符，自动替换为当前请求的 ID。
-
-    使用示例：
-        handler = logging.StreamHandler()
-        handler.addFilter(RequestIDFilter())
-        formatter = logging.Formatter("%(asctime)s [%(request_id)s] %(message)s")
-        handler.setFormatter(formatter)
-    """
-
-    def filter(self, record):
-        record.request_id = request_id_var.get()
-        return True
+__all__ = ["RequestIDFilter", "RequestIDMiddleware", "get_request_id", "request_id_var"]

--- a/tests/contracts/fixtures/current_python_dependency_graph_v1.json
+++ b/tests/contracts/fixtures/current_python_dependency_graph_v1.json
@@ -56,8 +56,8 @@
       "web",
       "wikisource"
     ],
-    "cross_unit_edge_count": 117,
-    "cross_unit_edge_sha256": "64883b82cc81325afa850df36fe47a055bfd96330e38ce151d31efc5bf9651e2",
+    "cross_unit_edge_count": 116,
+    "cross_unit_edge_sha256": "0bc53839ea6b3aab14f6106e20ce547f116790c25d607068c22d5068ea3c2f71",
     "strongly_connected_components": [
       [
         "citations",
@@ -75,10 +75,6 @@
         "search",
         "web",
         "wikisource"
-      ],
-      [
-        "logging_config",
-        "server"
       ]
     ]
   },

--- a/tests/test_request_context.py
+++ b/tests/test_request_context.py
@@ -1,0 +1,73 @@
+"""Common Runtime request-correlation context parity tests."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+
+import pytest
+
+from souwen import logging_config
+from souwen.common_runtime.observability import (
+    RequestIDFilter,
+    get_request_id,
+    request_id_var,
+)
+from souwen.common_runtime.observability import request_context as canonical_context
+from souwen.server import middleware as legacy_middleware
+
+
+def test_legacy_request_context_path_reexports_canonical_interface() -> None:
+    assert legacy_middleware.RequestIDFilter is RequestIDFilter
+    assert legacy_middleware.get_request_id is get_request_id
+    assert legacy_middleware.request_id_var is request_id_var
+    assert logging_config.RequestIDFilter is RequestIDFilter
+
+
+def test_request_context_defaults_and_resets() -> None:
+    assert get_request_id() == "-"
+
+    token = request_id_var.set("request-123")
+    try:
+        assert get_request_id() == "request-123"
+    finally:
+        request_id_var.reset(token)
+
+    assert get_request_id() == "-"
+
+
+def test_request_id_filter_injects_current_context() -> None:
+    record = logging.LogRecord("test", logging.INFO, __file__, 1, "message", (), None)
+    token = request_id_var.set("filter-request")
+    try:
+        assert RequestIDFilter().filter(record) is True
+    finally:
+        request_id_var.reset(token)
+
+    assert record.request_id == "filter-request"
+
+
+@pytest.mark.asyncio
+async def test_request_context_is_isolated_across_tasks() -> None:
+    async def observe(request_id: str) -> tuple[str, str]:
+        token = request_id_var.set(request_id)
+        try:
+            await asyncio.sleep(0)
+            current = get_request_id()
+        finally:
+            request_id_var.reset(token)
+        return current, get_request_id()
+
+    assert await asyncio.gather(observe("request-a"), observe("request-b")) == [
+        ("request-a", "-"),
+        ("request-b", "-"),
+    ]
+    assert get_request_id() == "-"
+
+
+def test_canonical_request_context_has_only_stdlib_dependencies() -> None:
+    source = Path(canonical_context.__file__).read_text(encoding="utf-8")
+
+    assert "from souwen" not in source
+    assert "import souwen" not in source


### PR DESCRIPTION
## 结果

本 PR 交付 SPEC-06 / CR-02：把 request correlation 的 `ContextVar`、getter 和 logging filter 抽取到 `souwen.common_runtime.observability`，同时保留 `souwen.server.middleware` compatibility re-export。`logging_config` 因此不再反向依赖 Server middleware。

这是 stacked Draft PR，base 为 PR #194 的 `codex/phase3-common-runtime-security`，只显示 CR-02 的 7-file diff。#193/#194 合并前不得 retarget/merge 到 `main`；当前未转 Ready、未合并、未发布、未部署。

## 边界

Common Runtime 只拥有：

- `request_id_var: ContextVar[str]`，默认值 `"-"`；
- `get_request_id() -> str`；
- `RequestIDFilter`，只向 `LogRecord` 注入当前 ID 并返回 `True`。

Delivery 继续拥有且本 PR不移动：

- `RequestIDMiddleware` 与 ASGI scope；
- incoming `X-Request-ID` validation；
- UUID generation；
- response `X-Request-ID` / `X-Response-Time` headers；
- request timing、status capture 和 access log；
- context token 的 request-lifecycle set/reset。

## 变更

- 新增 `common_runtime/observability/request_context.py`，仅依赖 Python stdlib。
- `common_runtime.observability` export canonical context interface。
- `server.middleware` 删除重复实现，改为 canonical imports + legacy re-export；`RequestIDMiddleware` 保持原位。
- `logging_config` 直接依赖 Common Runtime filter，消除 `logging_config -> server.middleware` 反向边。
- `server.app` 直接使用 canonical `get_request_id`，middleware import 只保留 Delivery class。
- SPEC-06 补充 CR-02 interface、默认值、set/reset ownership、task isolation、error/timeout/cancellation 和退出证据。
- 新增 identity、default/reset、logging filter、async task isolation 和 stdlib-only dependency tests。

## 行为保持

- 旧、新 `RequestIDFilter`、`get_request_id`、`request_id_var` 是相同对象。
- 默认 request ID 仍为 `"-"`；合法/非法 incoming ID、response headers、error schema correlation 和访问日志行为不变。
- CR-02 无 I/O、retry、timeout 或 cooperative cancellation；ContextVar 继续由 Python runtime 按 async task 隔离。
- 不改变 API DTO、认证、Provider、Fetch、配置、UI、workflow、HFS 或线上状态。

## 本地验证

- `python3 scripts/ci/check_architecture_dependencies.py`：通过。
- request-context/logging/provenance/module/architecture/import/Server 定向回归：`345 passed, 1 skipped`。
- `PYTHONPATH=src pytest tests/ -q --tb=short`：`2351 passed, 3 skipped`。
- `uvx ruff==0.15.22 check src tests scripts tools`：通过。
- `uvx ruff==0.15.22 format --check src tests scripts tools`：`490 files already formatted`。
- generated docs、Markdown links、legacy-term gate、stdlib dependency AST、private-path/secret scan、`git diff --check`：通过。
- 本地 wheel build 成功，canonical request-context 与 legacy middleware paths 均存在。

## Review focus

1. Common Runtime 与 Delivery 的 set/reset、validation 和 response-header ownership 是否保持清晰。
2. `logging_config -> server.middleware` 反向依赖是否已完全消除。
3. legacy identity、task isolation 与 Server correlation tests 是否足以证明 behavior parity。

## 精确 head 远端验证

验证 head：`cef5bcd6f12763ff33b11596369d06c2bc7f2791`。

- CI run [#30061528915](https://github.com/BlueSkyXN/SouWen/actions/runs/30061528915)：29 successful，0 skipped，0 failing，0 pending；`CI / aggregate` success。
- V2 CI run [#30061530333](https://github.com/BlueSkyXN/SouWen/actions/runs/30061530333)：12 successful，0 skipped，0 failing，0 pending；`V2 CI / v2 release readiness summary` success。
- 这是 base=`codex/phase3-common-runtime-security` 的 stacked Draft PR；由于不是以 `main` 为 base，本 PR 未单独触发 pull-request CodeQL/HFS gates。依赖链合并并 retarget `main` 后，必须重新运行自动 required checks，不能拿当前手动 dispatch 代替最终门禁。