### PR TITLE
refactor: 提取 Common Runtime SSRF resolver

### DIFF
--- a/docs/internal/spec-06-common-runtime-lld.md
+++ b/docs/internal/spec-06-common-runtime-lld.md
@@ -155,10 +155,44 @@ error-response correlation parity。
 
 ### 6.2 SSRF resolver
 
-Security 可拥有 target value object、scheme/userinfo/host/port/IP/DNS validation 和 IP-bound target
-描述。构造 `FetchResult`、provider fallback、content quality 或 Browser Worker 路由仍属于 Fetch。
-同步 `socket.getaddrinfo()` 的阻塞与不可 cooperative-cancel 现状必须先写入 validation fixture；
-迁移不能顺手改为 async DNS。
+Canonical path 为 `souwen.common_runtime.security`，repository-internal interface 为：
+
+```python
+@dataclass(frozen=True, slots=True)
+class ResolvedFetchTarget:
+    original_url: str
+    connect_url: str
+    host_header: str
+    sni_hostname: str | None
+
+def resolve_fetch_target(url: str) -> tuple[ResolvedFetchTarget | None, str]: ...
+def validate_fetch_url(url: str) -> tuple[bool, str]: ...
+```
+
+Security 只拥有 scheme/userinfo/host/port/IP/DNS validation 和 IP-bound target 描述。输入是单个
+URL string；成功时输出保留原 URL、已校验 IP literal `connect_url`、原 authority `Host` 和
+HTTPS DNS hostname SNI，失败时输出 `None`/`False` 与现有中文 reason。规则保持 http/https only、
+userinfo reject、localhost/private/reserved/legacy numeric IPv4 reject、IDNA lowercase、mixed DNS
+fail-closed、去重后 IPv4 preference、fake-IP DNS `198.18.0.0/15` allow，以及 IP literal 无 SNI。
+
+DNS 继续同步调用 `socket.getaddrinfo(host, None, AF_UNSPEC, SOCK_STREAM)`。接口没有 timeout、retry
+或 cooperative cancellation 参数；阻塞期间不能由 asyncio task cancellation 中断。调用方拥有外层
+budget，但本切片不声称外层 async timeout 能终止正在执行的同步 DNS。迁移不能顺手改为 async DNS、
+thread offload、resolver cache 或多 IP retry。
+
+预期解析/验证失败以 `(None, reason)` / `(False, reason)` 返回；只将 `socket.gaierror`、`OSError`、
+端口 `ValueError`、IDNA `UnicodeError` 和现有解析分支映射为既有 reason，不新增 logging 或 exception
+surface。函数无 cache/global mutable state，不发 HTTP，不记录 URL/hostname，不读取配置或 secret。
+
+`souwen.web.fetch` 必须 object-identical re-export 三个 canonical symbols，使既有 import path 保持可用；
+Fetch helpers 继续通过 legacy module global 调用 `validate_fetch_url`，因此现有针对
+`souwen.web.fetch.validate_fetch_url` 的 deterministic monkeypatch contract 保留。`BaseScraper` 改用
+canonical import，消除 Core → Web reverse edge。local fixture functional harness 必须同时 patch/restore
+canonical resolver 与已绑定的真实 consumer，不得扩大 production allowlist。
+
+禁止迁移：构造 `FetchResult` 的 `ssrf_blocked_fetch_result()`、`raise_if_fetch_url_blocked()`、
+`split_fetch_urls_by_ssrf()`，以及 Provider fallback、content quality、Browser Worker 路由和任何
+Fetch DTO。Rollback 是恢复 legacy implementation 和 consumer import；没有数据或配置迁移。
 
 ### 6.3 Redaction
 
@@ -189,6 +223,10 @@ Transport v1 若进入实施，必须先冻结：
 | VAL-CR-004 | `doctor.py` 与 `server/app.py` 使用 canonical import；external `souwen.provenance` 保持可用 |
 | VAL-CR-005 | architecture checker、import surface、provenance、doctor/server targeted tests 通过 |
 | VAL-CR-006 | 全量 pytest、Ruff、generated docs、wheel surface 与 CI/V2 aggregate 通过 |
+| VAL-CR-007 | canonical/legacy SSRF 三个 symbols object identity 相同；`BaseScraper` 使用 canonical import |
+| VAL-CR-008 | scheme/userinfo/port/IDNA/IP/legacy numeric/fake-IP/mixed DNS/reason 与 Host/SNI fixture parity |
+| VAL-CR-009 | 同步 DNS、单一 `url` interface、无 timeout/cancellation 参数和 stdlib-only AST fixture 通过 |
+| VAL-CR-010 | Fetch helpers/DTO 未迁移；legacy validate monkeypatch 与 local fixture override regression 通过 |
 
 未来 conditional slice 必须各自增加 old/new parity、negative dependency、cancellation 和资源清理
 证据；不能仅以 import 成功作为退出门槛。

--- a/scripts/article_extract_functional_check.py
+++ b/scripts/article_extract_functional_check.py
@@ -95,10 +95,13 @@ def local_fixture_server() -> Iterator[str]:
 @contextmanager
 def allow_local_fixture_url(url: str) -> Iterator[None]:
     """Bind this script's exact local fixture origin without weakening production SSRF rules."""
+    from souwen.common_runtime.security import fetch_target as canonical_fetch_target
+    from souwen.core.scraper import base as scraper_base_module
     from souwen.web import fetch as fetch_module
 
     fixture = urlparse(url)
-    original_resolve = fetch_module.resolve_fetch_target
+    original_resolve = canonical_fetch_target.resolve_fetch_target
+    original_scraper_resolve = scraper_base_module.resolve_fetch_target
 
     def _resolve(candidate: str):
         parsed = urlparse(candidate)
@@ -121,10 +124,14 @@ def allow_local_fixture_url(url: str) -> Iterator[None]:
             )
         return original_resolve(candidate)
 
+    canonical_fetch_target.resolve_fetch_target = _resolve
+    scraper_base_module.resolve_fetch_target = _resolve
     fetch_module.resolve_fetch_target = _resolve
     try:
         yield
     finally:
+        canonical_fetch_target.resolve_fetch_target = original_resolve
+        scraper_base_module.resolve_fetch_target = original_scraper_resolve
         fetch_module.resolve_fetch_target = original_resolve
 
 

--- a/src/souwen/common_runtime/security/__init__.py
+++ b/src/souwen/common_runtime/security/__init__.py
@@ -1,3 +1,5 @@
 """Security runtime boundary. Owner: Common Runtime. Allowed dependencies: standard library and common runtime."""
 
-__all__: list[str] = []
+from .fetch_target import ResolvedFetchTarget, resolve_fetch_target, validate_fetch_url
+
+__all__ = ["ResolvedFetchTarget", "resolve_fetch_target", "validate_fetch_url"]

--- a/src/souwen/common_runtime/security/fetch_target.py
+++ b/src/souwen/common_runtime/security/fetch_target.py
@@ -1,0 +1,275 @@
+"""Resolve untrusted HTTP(S) URLs to validated, IP-pinned fetch targets."""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from dataclasses import dataclass
+from urllib.parse import urlparse, urlunparse
+
+
+_BLOCKED_HOSTNAMES = frozenset(
+    {
+        "localhost",
+        "localhost.localdomain",
+        "localhost4",
+        "localhost6",
+    }
+)
+
+_DNS_SSRF_BLOCKED_NETS = tuple(
+    ipaddress.ip_network(net)
+    for net in (
+        "0.0.0.0/8",
+        "10.0.0.0/8",
+        "100.64.0.0/10",
+        "127.0.0.0/8",
+        "169.254.0.0/16",
+        "172.16.0.0/12",
+        "192.0.0.0/24",
+        "192.0.2.0/24",
+        "192.168.0.0/16",
+        "198.51.100.0/24",
+        "203.0.113.0/24",
+        "224.0.0.0/4",
+        "::/128",
+        "::1/128",
+        "fc00::/7",
+        "fe80::/10",
+        "ff00::/8",
+        "2001:db8::/32",
+    )
+)
+_DIRECT_SSRF_BLOCKED_NETS = _DNS_SSRF_BLOCKED_NETS + (ipaddress.ip_network("198.18.0.0/15"),)
+
+_IPV4_EMBEDDING_NETS = tuple(
+    ipaddress.ip_network(net)
+    for net in (
+        "::/96",
+        "::ffff:0:0/96",
+        "64:ff9b::/96",
+    )
+)
+
+_IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
+_IPNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedFetchTarget:
+    """A validated URL pinned to one already-checked public IP address."""
+
+    original_url: str
+    connect_url: str
+    host_header: str
+    sni_hostname: str | None
+
+
+def _embedded_ipv4_address(addr: _IPAddress) -> ipaddress.IPv4Address | None:
+    """Return IPv4 embedded in an IPv6 address form, when one is present."""
+    if not isinstance(addr, ipaddress.IPv6Address):
+        return None
+
+    if addr.ipv4_mapped is not None:
+        return addr.ipv4_mapped
+    if addr.sixtofour is not None:
+        return addr.sixtofour
+    if addr.teredo is not None:
+        return addr.teredo[1]
+    if any(addr in net for net in _IPV4_EMBEDDING_NETS):
+        return ipaddress.IPv4Address(int(addr) & 0xFFFFFFFF)
+    return None
+
+
+def _is_ssrf_blocked_address(
+    addr: _IPAddress,
+    blocked_nets: tuple[_IPNetwork, ...],
+) -> bool:
+    """Check an address and any embedded IPv4 address against SSRF block nets."""
+    candidates = [addr]
+    embedded = _embedded_ipv4_address(addr)
+    if embedded is not None:
+        candidates.append(embedded)
+
+    return any(
+        candidate.version == net.version and candidate in net
+        for candidate in candidates
+        for net in blocked_nets
+    )
+
+
+def _parse_legacy_ipv4_literal(hostname: str) -> ipaddress.IPv4Address | None:
+    """Parse legacy IPv4 numeric forms accepted by some resolvers."""
+    parts = hostname.split(".")
+    if not 1 <= len(parts) <= 4 or any(part == "" for part in parts):
+        return None
+
+    values: list[int] = []
+    for part in parts:
+        lower = part.lower()
+        if lower.startswith("0x"):
+            digits = lower[2:]
+            if not digits or any(ch not in "0123456789abcdef" for ch in digits):
+                return None
+            value = int(digits, 16)
+        elif lower.isdigit():
+            if len(lower) > 1 and lower.startswith("0"):
+                if any(ch not in "01234567" for ch in lower):
+                    return None
+                value = int(lower, 8)
+            else:
+                value = int(lower, 10)
+        else:
+            return None
+        values.append(value)
+
+    if len(values) == 1:
+        if values[0] > 0xFFFFFFFF:
+            return None
+        packed = values[0]
+    elif len(values) == 2:
+        if values[0] > 0xFF or values[1] > 0xFFFFFF:
+            return None
+        packed = (values[0] << 24) | values[1]
+    elif len(values) == 3:
+        if values[0] > 0xFF or values[1] > 0xFF or values[2] > 0xFFFF:
+            return None
+        packed = (values[0] << 24) | (values[1] << 16) | values[2]
+    else:
+        if any(value > 0xFF for value in values):
+            return None
+        packed = (values[0] << 24) | (values[1] << 16) | (values[2] << 8) | values[3]
+    return ipaddress.IPv4Address(packed)
+
+
+def _is_legacy_ipv4_numeric_hostname(hostname: str) -> bool:
+    """Return whether a host looks like a non-standard IPv4 numeric form."""
+    parts = hostname.split(".")
+    if not 1 <= len(parts) <= 4 or any(part == "" for part in parts):
+        return False
+
+    for part in parts:
+        lower = part.lower()
+        if lower.startswith("0x"):
+            digits = lower[2:]
+            if not digits or any(ch not in "0123456789abcdef" for ch in digits):
+                return False
+            continue
+        if not lower.isdigit():
+            return False
+    return True
+
+
+def _format_connect_host(addr: _IPAddress) -> str:
+    text = str(addr)
+    return f"[{text}]" if addr.version == 6 else text
+
+
+def _format_original_host(hostname: str, port: int | None) -> str:
+    host = f"[{hostname}]" if ":" in hostname and not hostname.startswith("[") else hostname
+    return f"{host}:{port}" if port is not None else host
+
+
+def resolve_fetch_target(url: str) -> tuple[ResolvedFetchTarget | None, str]:
+    """Validate a URL and bind it to a checked public IP to prevent DNS rebinding.
+
+    The resolver intentionally preserves the current synchronous ``socket.getaddrinfo`` contract.
+    It has no timeout or cooperative-cancellation parameter; callers own any outer budget.
+    """
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return None, "URL 解析失败"
+
+    if parsed.scheme not in ("http", "https"):
+        return None, f"不允许的协议: {parsed.scheme}"
+    if parsed.username or parsed.password:
+        return None, "URL 不允许包含用户信息"
+
+    hostname = parsed.hostname
+    if not hostname:
+        return None, "缺少主机名"
+
+    try:
+        port = parsed.port
+    except ValueError:
+        return None, "端口号无效"
+
+    hostname_for_ip = hostname.split("%", 1)[0]
+    try:
+        literal_addr = ipaddress.ip_address(hostname_for_ip)
+    except ValueError:
+        literal_addr = None
+    if literal_addr is None:
+        try:
+            transport_hostname = hostname.encode("idna").decode("ascii").lower()
+        except UnicodeError:
+            return None, f"主机名无效: {hostname}"
+    else:
+        transport_hostname = hostname
+
+    hostname_key = transport_hostname.rstrip(".").lower()
+    if hostname_key in _BLOCKED_HOSTNAMES:
+        return None, f"目标主机名为本地主机: {hostname}"
+
+    if literal_addr is not None:
+        if _is_ssrf_blocked_address(literal_addr, _DIRECT_SSRF_BLOCKED_NETS):
+            return None, f"目标地址为内部/私有 IP: {hostname}"
+        connect_addr = literal_addr
+    else:
+        if _is_legacy_ipv4_numeric_hostname(hostname_key):
+            legacy_ipv4_addr = _parse_legacy_ipv4_literal(hostname_key)
+            resolved_suffix = (
+                f" (解析为 {legacy_ipv4_addr})" if legacy_ipv4_addr is not None else ""
+            )
+            return None, f"非规范 IPv4 数字写法: {hostname}{resolved_suffix}"
+
+        try:
+            infos = socket.getaddrinfo(
+                transport_hostname,
+                None,
+                socket.AF_UNSPEC,
+                socket.SOCK_STREAM,
+            )
+        except (socket.gaierror, OSError):
+            return None, f"DNS 解析失败: {hostname}"
+
+        resolved: list[_IPAddress] = []
+        for info in infos:
+            try:
+                addr_str = info[4][0].split("%", 1)[0]
+            except (AttributeError, IndexError, TypeError):
+                return None, "DNS 返回无效地址"
+            try:
+                addr = ipaddress.ip_address(addr_str)
+            except ValueError:
+                return None, f"DNS 返回无效地址: {addr_str}"
+            if _is_ssrf_blocked_address(addr, _DNS_SSRF_BLOCKED_NETS):
+                return None, f"目标地址为内部/私有 IP: {addr_str}"
+            if addr not in resolved:
+                resolved.append(addr)
+
+        if not resolved:
+            return None, f"DNS 未返回可用地址: {hostname}"
+        connect_addr = next((addr for addr in resolved if addr.version == 4), resolved[0])
+
+    connect_host = _format_connect_host(connect_addr)
+    connect_netloc = f"{connect_host}:{port}" if port is not None else connect_host
+    connect_url = urlunparse(parsed._replace(netloc=connect_netloc))
+    return (
+        ResolvedFetchTarget(
+            original_url=url,
+            connect_url=connect_url,
+            host_header=_format_original_host(transport_hostname, port),
+            sni_hostname=(
+                transport_hostname if parsed.scheme == "https" and literal_addr is None else None
+            ),
+        ),
+        "",
+    )
+
+
+def validate_fetch_url(url: str) -> tuple[bool, str]:
+    """Return whether a URL resolves only to allowed public targets."""
+    target, reason = resolve_fetch_target(url)
+    return target is not None, reason

--- a/src/souwen/core/scraper/base.py
+++ b/src/souwen/core/scraper/base.py
@@ -54,17 +54,15 @@ from __future__ import annotations
 import asyncio
 import logging
 import random
-from typing import TYPE_CHECKING, Any
+from typing import Any
 from urllib.parse import urljoin, urlparse
 
 import httpx
 
+from souwen.common_runtime.security import ResolvedFetchTarget, resolve_fetch_target
 from souwen.config import get_config
 from souwen.core.exceptions import RateLimitError, SourceUnavailableError
 from souwen.core.fingerprint import get_random_fingerprint
-
-if TYPE_CHECKING:
-    from souwen.web.fetch import ResolvedFetchTarget
 
 logger = logging.getLogger("souwen.core.scraper")
 _REDIRECT_CODES = frozenset({301, 302, 303, 307, 308})
@@ -324,8 +322,6 @@ class BaseScraper:
         max_redirects: int = 5,
     ) -> httpx.Response:
         """手动跟踪重定向，并在每一跳执行 SSRF 校验。"""
-        from souwen.web.fetch import resolve_fetch_target
-
         current_url = url
         current_method = method
         current_params = params

--- a/src/souwen/web/fetch.py
+++ b/src/souwen/web/fetch.py
@@ -35,8 +35,7 @@
 
 模块依赖：
     - asyncio: 异步并发与超时控制
-    - ipaddress: IP 地址类型判定（私有/回环/链路本地/保留）
-    - socket: DNS 解析（getaddrinfo）
+    - souwen.common_runtime.security: SSRF target 解析与 IP-bound validation
     - logging: 日志记录
     - souwen.config: 配置读取（API Key）
     - souwen.models: FetchResult, FetchResponse 数据模型
@@ -57,16 +56,19 @@ from __future__ import annotations
 
 import asyncio
 import contextvars
-import ipaddress
 import inspect
 import logging
-import socket
 from collections import defaultdict, deque
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any, Literal
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import urlparse
 
+from souwen.common_runtime.security import (
+    ResolvedFetchTarget as ResolvedFetchTarget,
+    resolve_fetch_target as resolve_fetch_target,
+    validate_fetch_url,
+)
 from souwen.config import get_config
 from souwen.models import FetchResponse, FetchResult
 
@@ -92,154 +94,6 @@ class _HandlerEntry:
 
 
 _FETCH_HANDLERS: dict[str, _HandlerEntry] = {}
-
-_BLOCKED_HOSTNAMES = frozenset(
-    {
-        "localhost",
-        "localhost.localdomain",
-        "localhost4",
-        "localhost6",
-    }
-)
-
-_DNS_SSRF_BLOCKED_NETS = tuple(
-    ipaddress.ip_network(net)
-    for net in (
-        "0.0.0.0/8",
-        "10.0.0.0/8",
-        "100.64.0.0/10",
-        "127.0.0.0/8",
-        "169.254.0.0/16",
-        "172.16.0.0/12",
-        "192.0.0.0/24",
-        "192.0.2.0/24",
-        "192.168.0.0/16",
-        "198.51.100.0/24",
-        "203.0.113.0/24",
-        "224.0.0.0/4",
-        "::/128",
-        "::1/128",
-        "fc00::/7",
-        "fe80::/10",
-        "ff00::/8",
-        "2001:db8::/32",
-    )
-)
-_DIRECT_SSRF_BLOCKED_NETS = _DNS_SSRF_BLOCKED_NETS + (ipaddress.ip_network("198.18.0.0/15"),)
-
-_IPV4_EMBEDDING_NETS = tuple(
-    ipaddress.ip_network(net)
-    for net in (
-        "::/96",
-        "::ffff:0:0/96",
-        "64:ff9b::/96",
-    )
-)
-
-_IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
-_IPNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
-
-
-@dataclass(frozen=True, slots=True)
-class ResolvedFetchTarget:
-    """A validated URL pinned to one already-checked public IP address."""
-
-    original_url: str
-    connect_url: str
-    host_header: str
-    sni_hostname: str | None
-
-
-def _embedded_ipv4_address(addr: _IPAddress) -> ipaddress.IPv4Address | None:
-    """Return IPv4 embedded in an IPv6 address form, when one is present."""
-    if not isinstance(addr, ipaddress.IPv6Address):
-        return None
-
-    if addr.ipv4_mapped is not None:
-        return addr.ipv4_mapped
-    if addr.sixtofour is not None:
-        return addr.sixtofour
-    if addr.teredo is not None:
-        return addr.teredo[1]
-    if any(addr in net for net in _IPV4_EMBEDDING_NETS):
-        return ipaddress.IPv4Address(int(addr) & 0xFFFFFFFF)
-    return None
-
-
-def _is_ssrf_blocked_address(addr: _IPAddress, blocked_nets: tuple[_IPNetwork, ...]) -> bool:
-    """Check an address and any embedded IPv4 address against SSRF block nets."""
-    candidates = [addr]
-    embedded = _embedded_ipv4_address(addr)
-    if embedded is not None:
-        candidates.append(embedded)
-
-    return any(
-        candidate.version == net.version and candidate in net
-        for candidate in candidates
-        for net in blocked_nets
-    )
-
-
-def _parse_legacy_ipv4_literal(hostname: str) -> ipaddress.IPv4Address | None:
-    """Parse legacy IPv4 numeric forms accepted by some resolvers."""
-    parts = hostname.split(".")
-    if not 1 <= len(parts) <= 4 or any(part == "" for part in parts):
-        return None
-
-    values: list[int] = []
-    for part in parts:
-        lower = part.lower()
-        if lower.startswith("0x"):
-            digits = lower[2:]
-            if not digits or any(ch not in "0123456789abcdef" for ch in digits):
-                return None
-            value = int(digits, 16)
-        elif lower.isdigit():
-            if len(lower) > 1 and lower.startswith("0"):
-                if any(ch not in "01234567" for ch in lower):
-                    return None
-                value = int(lower, 8)
-            else:
-                value = int(lower, 10)
-        else:
-            return None
-        values.append(value)
-
-    if len(values) == 1:
-        if values[0] > 0xFFFFFFFF:
-            return None
-        packed = values[0]
-    elif len(values) == 2:
-        if values[0] > 0xFF or values[1] > 0xFFFFFF:
-            return None
-        packed = (values[0] << 24) | values[1]
-    elif len(values) == 3:
-        if values[0] > 0xFF or values[1] > 0xFF or values[2] > 0xFFFF:
-            return None
-        packed = (values[0] << 24) | (values[1] << 16) | values[2]
-    else:
-        if any(value > 0xFF for value in values):
-            return None
-        packed = (values[0] << 24) | (values[1] << 16) | (values[2] << 8) | values[3]
-    return ipaddress.IPv4Address(packed)
-
-
-def _is_legacy_ipv4_numeric_hostname(hostname: str) -> bool:
-    """Return whether a host looks like a non-standard IPv4 numeric form."""
-    parts = hostname.split(".")
-    if not 1 <= len(parts) <= 4 or any(part == "" for part in parts):
-        return False
-
-    for part in parts:
-        lower = part.lower()
-        if lower.startswith("0x"):
-            digits = lower[2:]
-            if not digits or any(ch not in "0123456789abcdef" for ch in digits):
-                return False
-            continue
-        if not lower.isdigit():
-            return False
-    return True
 
 
 def register_fetch_handler(
@@ -381,128 +235,6 @@ def _get_provider_global_timeout(provider: str, url_count: int, timeout: float) 
         waves = math.ceil(max(1, url_count) / 2)
         return timeout * waves + 30
     return timeout + 10
-
-
-def _format_connect_host(addr: _IPAddress) -> str:
-    text = str(addr)
-    return f"[{text}]" if addr.version == 6 else text
-
-
-def _format_original_host(hostname: str, port: int | None) -> str:
-    host = f"[{hostname}]" if ":" in hostname and not hostname.startswith("[") else hostname
-    return f"{host}:{port}" if port is not None else host
-
-
-def resolve_fetch_target(url: str) -> tuple[ResolvedFetchTarget | None, str]:
-    """Validate a URL and bind it to a checked public IP to prevent DNS rebinding.
-
-    仅允许 http/https 协议，拒绝直连私有/内部 IP；域名解析后仍拒绝危险网段，
-    但允许常见 fake-IP DNS 代理返回的 198.18.0.0/15 地址。返回的 ``connect_url``
-    使用已校验的 IP literal；调用方必须同时传递 ``Host`` 和 HTTPS SNI。
-
-    Args:
-        url: 待校验的 URL
-
-    Returns:
-        (resolved target, reason) 元组
-    """
-    try:
-        parsed = urlparse(url)
-    except Exception:
-        return None, "URL 解析失败"
-
-    if parsed.scheme not in ("http", "https"):
-        return None, f"不允许的协议: {parsed.scheme}"
-    if parsed.username or parsed.password:
-        return None, "URL 不允许包含用户信息"
-
-    hostname = parsed.hostname
-    if not hostname:
-        return None, "缺少主机名"
-
-    try:
-        port = parsed.port
-    except ValueError:
-        return None, "端口号无效"
-
-    hostname_for_ip = hostname.split("%", 1)[0]
-    try:
-        literal_addr = ipaddress.ip_address(hostname_for_ip)
-    except ValueError:
-        literal_addr = None
-    if literal_addr is None:
-        try:
-            transport_hostname = hostname.encode("idna").decode("ascii").lower()
-        except UnicodeError:
-            return None, f"主机名无效: {hostname}"
-    else:
-        transport_hostname = hostname
-
-    hostname_key = transport_hostname.rstrip(".").lower()
-    if hostname_key in _BLOCKED_HOSTNAMES:
-        return None, f"目标主机名为本地主机: {hostname}"
-
-    if literal_addr is not None:
-        if _is_ssrf_blocked_address(literal_addr, _DIRECT_SSRF_BLOCKED_NETS):
-            return None, f"目标地址为内部/私有 IP: {hostname}"
-        connect_addr = literal_addr
-    else:
-        if _is_legacy_ipv4_numeric_hostname(hostname_key):
-            legacy_ipv4_addr = _parse_legacy_ipv4_literal(hostname_key)
-            resolved_suffix = (
-                f" (解析为 {legacy_ipv4_addr})" if legacy_ipv4_addr is not None else ""
-            )
-            return None, f"非规范 IPv4 数字写法: {hostname}{resolved_suffix}"
-
-        try:
-            infos = socket.getaddrinfo(
-                transport_hostname,
-                None,
-                socket.AF_UNSPEC,
-                socket.SOCK_STREAM,
-            )
-        except (socket.gaierror, OSError):
-            return None, f"DNS 解析失败: {hostname}"
-
-        resolved: list[_IPAddress] = []
-        for info in infos:
-            try:
-                addr_str = info[4][0].split("%", 1)[0]
-            except (AttributeError, IndexError, TypeError):
-                return None, "DNS 返回无效地址"
-            try:
-                addr = ipaddress.ip_address(addr_str)
-            except ValueError:
-                return None, f"DNS 返回无效地址: {addr_str}"
-            if _is_ssrf_blocked_address(addr, _DNS_SSRF_BLOCKED_NETS):
-                return None, f"目标地址为内部/私有 IP: {addr_str}"
-            if addr not in resolved:
-                resolved.append(addr)
-
-        if not resolved:
-            return None, f"DNS 未返回可用地址: {hostname}"
-        connect_addr = next((addr for addr in resolved if addr.version == 4), resolved[0])
-
-    connect_host = _format_connect_host(connect_addr)
-    connect_netloc = f"{connect_host}:{port}" if port is not None else connect_host
-    connect_url = urlunparse(parsed._replace(netloc=connect_netloc))
-    return (
-        ResolvedFetchTarget(
-            original_url=url,
-            connect_url=connect_url,
-            host_header=_format_original_host(transport_hostname, port),
-            sni_hostname=(
-                transport_hostname if parsed.scheme == "https" and literal_addr is None else None
-            ),
-        ),
-        "",
-    )
-
-
-def validate_fetch_url(url: str) -> tuple[bool, str]:
-    """Return whether a URL resolves only to allowed public targets."""
-    target, reason = resolve_fetch_target(url)
-    return target is not None, reason
 
 
 def ssrf_blocked_fetch_result(

--- a/tests/contracts/fixtures/current_python_dependency_graph_v1.json
+++ b/tests/contracts/fixtures/current_python_dependency_graph_v1.json
@@ -56,8 +56,8 @@
       "web",
       "wikisource"
     ],
-    "cross_unit_edge_count": 116,
-    "cross_unit_edge_sha256": "0bc53839ea6b3aab14f6106e20ce547f116790c25d607068c22d5068ea3c2f71",
+    "cross_unit_edge_count": 115,
+    "cross_unit_edge_sha256": "1b2eeb1d4c7622cbe1aa0b1289e3edfaa78aa9fc6d66e55a503b4680ca298eec",
     "strongly_connected_components": [
       [
         "citations",

--- a/tests/test_common_runtime_ssrf.py
+++ b/tests/test_common_runtime_ssrf.py
@@ -1,0 +1,142 @@
+"""Common Runtime SSRF target resolver parity and dependency tests."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+import socket
+import threading
+from typing import Any
+
+import pytest
+
+from souwen.common_runtime.security import (
+    ResolvedFetchTarget,
+    resolve_fetch_target,
+    validate_fetch_url,
+)
+from souwen.common_runtime.security import fetch_target as canonical_fetch_target
+from souwen.core.scraper import base as scraper_base
+from souwen.web import fetch as legacy_fetch
+
+
+def _addrinfo(address: str, port: int = 443) -> tuple[Any, ...]:
+    family = socket.AF_INET6 if ":" in address else socket.AF_INET
+    return (family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", (address, port))
+
+
+def test_legacy_fetch_path_reexports_canonical_ssrf_interface() -> None:
+    assert legacy_fetch.ResolvedFetchTarget is ResolvedFetchTarget
+    assert legacy_fetch.resolve_fetch_target is resolve_fetch_target
+    assert legacy_fetch.validate_fetch_url is validate_fetch_url
+
+
+def test_base_scraper_uses_canonical_ssrf_interface() -> None:
+    assert scraper_base.ResolvedFetchTarget is ResolvedFetchTarget
+    assert scraper_base.resolve_fetch_target is resolve_fetch_target
+
+
+def test_canonical_fetch_target_has_only_stdlib_dependencies() -> None:
+    path = Path(canonical_fetch_target.__file__)
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imported_roots = {
+        alias.name.split(".", maxsplit=1)[0]
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    imported_roots.update(
+        (node.module or "").split(".", maxsplit=1)[0]
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+    )
+
+    assert imported_roots == {"__future__", "dataclasses", "ipaddress", "socket", "urllib"}
+
+
+@pytest.mark.parametrize(
+    ("url", "reason"),
+    [
+        ("ftp://example.com/file", "不允许的协议: ftp"),
+        ("http://user:pass@example.com/", "URL 不允许包含用户信息"),
+        ("http:///path", "缺少主机名"),
+        ("http://example.com:invalid/", "端口号无效"),
+        ("http://localhost./", "目标主机名为本地主机: localhost."),
+        ("http://127.0.0.1/", "目标地址为内部/私有 IP: 127.0.0.1"),
+        ("https://198.18.1.47/", "目标地址为内部/私有 IP: 198.18.1.47"),
+        ("http://2130706433/", "非规范 IPv4 数字写法: 2130706433 (解析为 127.0.0.1)"),
+    ],
+)
+def test_ssrf_rejection_reason_contract_is_preserved(url: str, reason: str) -> None:
+    assert resolve_fetch_target(url) == (None, reason)
+    assert validate_fetch_url(url) == (False, reason)
+
+
+def test_resolver_preserves_synchronous_dns_and_ipv4_preference(monkeypatch) -> None:
+    calls: list[tuple[int, str, int | None, int, int]] = []
+
+    def getaddrinfo(
+        host: str,
+        port: int | None,
+        family: int,
+        socktype: int,
+    ) -> list[tuple[Any, ...]]:
+        calls.append((threading.get_ident(), host, port, family, socktype))
+        return [
+            _addrinfo("2606:4700:4700::1111"),
+            _addrinfo("1.1.1.1"),
+        ]
+
+    monkeypatch.setattr(socket, "getaddrinfo", getaddrinfo)
+
+    target, reason = resolve_fetch_target("https://example.com:8443/path?q=1")
+
+    assert inspect.iscoroutinefunction(resolve_fetch_target) is False
+    assert list(inspect.signature(resolve_fetch_target).parameters) == ["url"]
+    assert calls == [
+        (
+            threading.get_ident(),
+            "example.com",
+            None,
+            socket.AF_UNSPEC,
+            socket.SOCK_STREAM,
+        )
+    ]
+    assert reason == ""
+    assert target == ResolvedFetchTarget(
+        original_url="https://example.com:8443/path?q=1",
+        connect_url="https://1.1.1.1:8443/path?q=1",
+        host_header="example.com:8443",
+        sni_hostname="example.com",
+    )
+
+
+def test_resolver_still_fails_closed_on_mixed_dns_answers(monkeypatch) -> None:
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *_args, **_kwargs: [
+            _addrinfo("1.1.1.1"),
+            _addrinfo("169.254.169.254"),
+        ],
+    )
+
+    assert resolve_fetch_target("https://example.com/resource") == (
+        None,
+        "目标地址为内部/私有 IP: 169.254.169.254",
+    )
+
+
+def test_legacy_validate_monkeypatch_still_controls_fetch_helpers(monkeypatch) -> None:
+    monkeypatch.setattr(
+        legacy_fetch,
+        "validate_fetch_url",
+        lambda _url: (False, "patched legacy guard"),
+    )
+
+    result = legacy_fetch.ssrf_blocked_fetch_result("https://example.com", "fixture")
+
+    assert result is not None
+    assert result.error == "SSRF 校验失败: patched legacy guard"
+    assert result.raw == {"provider": "fixture", "blocked_by_ssrf": True}

--- a/tests/test_phase2_module_skeleton.py
+++ b/tests/test_phase2_module_skeleton.py
@@ -43,7 +43,6 @@ SKELETON_PACKAGES = (
     "souwen.common_runtime",
     "souwen.common_runtime.transport",
     "souwen.common_runtime.resilience",
-    "souwen.common_runtime.security",
     "souwen.common_runtime.configuration",
     "souwen.common_runtime.testing",
     "souwen.providers",


### PR DESCRIPTION
## 结果

本 PR 交付 SPEC-06 / CR-03：把 DNS-bound SSRF target value object、resolve/validate primitive 和纯 stdlib helpers 迁到 `souwen.common_runtime.security`，同时保留 `souwen.web.fetch` object-identical compatibility re-export。

这是 stacked Draft PR，base 为 PR #195 的 `codex/phase3-request-context`，只承载 CR-03 diff。#193/#194/#195 合并前不得直接合入 `main`；当前未转 Ready、未合并、未发布、未部署。

## Common Runtime 边界

迁入：

- `ResolvedFetchTarget`
- `resolve_fetch_target(url)`
- `validate_fetch_url(url)`
- scheme/userinfo/host/port/IP/DNS validation 与 IP-bound target helpers

保留在 Fetch domain：

- `ssrf_blocked_fetch_result()`
- `raise_if_fetch_url_blocked()`
- `split_fetch_urls_by_ssrf()`
- `FetchResult` / `FetchResponse`
- Provider fallback、content quality、Browser Worker routing

## 行为保持

- 继续只允许 http/https，拒绝 userinfo、localhost、private/reserved、legacy numeric IPv4。
- 保持 IDNA lowercase、mixed DNS fail-closed、去重后 IPv4 preference、fake-IP DNS allow、IP literal `connect_url`、原 `Host` 与 HTTPS SNI。
- 继续同步调用 `socket.getaddrinfo()`；没有 timeout、retry 或 cooperative cancellation 参数。本 PR 不改 async DNS/thread offload/cache/multi-IP retry。
- `souwen.web.fetch` 的三个旧符号与 canonical symbols object identity 相同。
- Fetch helpers 仍通过 legacy module global 调用 `validate_fetch_url`，既有 `souwen.web.fetch.validate_fetch_url` monkeypatch contract 保持。
- `BaseScraper` 改用 canonical import，消除 Core → Web resolver reverse edge。
- local fixture harness 只对精确 fixture origin 同时 patch/restore canonical resolver 与已绑定 consumer，不扩大 production allowlist。

## 验证

Head：`389f16c8c5884026cdfe5200097cb2d473068876`

- SSRF/全部 Web/fetch handler/article/MCP/server fetch 定向回归：`565 passed, 2 skipped`。
- 全量：`2362 passed, 3 skipped`。
- Phase 2 skeleton + canonical SSRF：`111 passed`。
- 15 个 moved definitions 的 normalized semantic AST 与 parent implementation 完全一致。
- `python3 scripts/ci/check_architecture_dependencies.py`：通过。
- `uvx ruff==0.15.22 check src tests scripts tools`：通过。
- `uvx ruff==0.15.22 format --check src tests scripts tools`：`492 files already formatted`。
- generated docs、legacy-term gate、private-path/secret scan、`git diff --check`：通过。
- wheel build 成功，包含 canonical `common_runtime/security/fetch_target.py` 与 legacy `web/fetch.py`、`core/scraper/base.py`。
- `basic-cli` profile 全部通过。
- 本机 `full-cli` profile 因同一全局环境同时安装 `crawl4ai` 与 `scrapling`，触发既有互斥断言而失败；这不是本 diff 引入的 import/assertion。以本 PR 精确 head 的 clean CI/V2 profile 作为远端证据。

## Review focus

1. Security primitive 是否保持纯 stdlib、无 Fetch DTO/Provider/config/Delivery 依赖。
2. direct IP 与 DNS fake-IP 的不同 block-net policy 是否原样保留。
3. mixed DNS fail-closed、Host/SNI/IP pinning 与同步 DNS limitation 是否被测试充分冻结。
4. legacy object identity 和 monkeypatch compatibility 是否足以支持后续逐消费者迁移。

## 精确 head 远端验证

验证 head：`389f16c8c5884026cdfe5200097cb2d473068876`。

- CI run [#30062425349 attempt 2](https://github.com/BlueSkyXN/SouWen/actions/runs/30062425349/attempts/2)：29 successful，0 skipped，0 failing，0 pending；`CI / aggregate` success。
- 首次 attempt 唯一失败是 Crawl4AI 依赖安装从 `codeload.github.com` 下载 `SuperWeb2PDF` 时发生 `ReadTimeoutError`；尚未执行本 PR 代码或测试。failed-only rerun 在同一 head 上通过，未修改代码或放宽 gate。
- V2 CI run [#30062427301](https://github.com/BlueSkyXN/SouWen/actions/runs/30062427301)：12 successful，0 skipped，0 failing，0 pending；`V2 CI / v2 release readiness summary` success。
- 这是 base=`codex/phase3-request-context` 的 stacked Draft PR；未单独触发 pull-request CodeQL/HFS gates。依赖链合并并 retarget `main` 后必须重新运行自动 required checks，当前手动 dispatch 不替代最终门禁。