### PR TITLE
refactor: extract canonical OAuth transport

### DIFF
--- a/docs/internal/spec-06-common-runtime-lld.md
+++ b/docs/internal/spec-06-common-runtime-lld.md
@@ -45,7 +45,7 @@ Common Runtime 只接收同时满足以下条件的组件：
 | generic secret text/URL/payload redaction | CLI、Server、MCP、plugin manager、LLM/fetch errors | CONDITIONAL-04 | 先拆 generic primitive；Pydantic adapter 与 LLM gateway topology policy 不进入 Security primitive |
 | `SouWenHttpClient` | OpenAlex、HAL 等 Provider | CONDITIONAL-05 | 先冻结 native cancellation、无 stream v1、trusted auto-redirect 与 config adapter 边界 |
 | token/sliding-window limiter | OpenAlex、The Lens 等 Provider | CONDITIONAL-06 | 先补 acquire cancellation/state fixture；Provider 负责把 headers 转成通用数值 |
-| `OAuthClient` | EPO OPS、CNIPA | DEFER | 基础 Transport 之后独立决定 Transport/Security owner、token timeout 与 refresh cancellation |
+| `OAuthClient` | EPO OPS、CNIPA | **ACCEPT-07** | client-credentials acquisition/cache/bearer 属于 Transport；legacy config adapter 保持，先冻结 refresh cancellation 与 secret boundary |
 | `core.concurrency` 原 API | Search、Web aggregation | REJECT-AS-IS | `"search"` / `"web"` channel 是领域名称；不能原样成为 runtime API |
 | retry presets / `poll_retry` | 当前只有一个 production consumer 或无 consumer | REJECT | 不满足两个消费者；scraper/CAPTCHA exception set 含领域策略且缺独立测试 |
 | `BaseScraper` / browser pool / fingerprint | scraper/browser Provider | REJECT | 混合 anti-bot、SSRF、Provider backend、browser optional runtime；不是中立 transport |
@@ -284,7 +284,8 @@ end-user export。legacy `souwen.core.http_client.SouWenHttpClient` 继承 `Http
 
 当前 `self.max_retries` 只保存值，实际 tenacity stop 固定为三次；CR-05 是同行为搬移，不能顺手让该
 字段改变 attempt count。source timeout/backend、credential 和 Provider response body policy 不进入
-Transport core。`OAuthClient` 继续继承 legacy adapter，不迁入 canonical module。
+Transport core。`OAuthClient` 继续继承 legacy adapter；token acquisition/cache/bearer methods 由后续
+CR-07 canonical OAuth Transport 提供。
 
 #### 6.4.3 Retry、status、cancellation 与生命周期
 
@@ -344,6 +345,45 @@ response、config、registry 或具体 Provider。`souwen.core.rate_limiter` obj
 OpenAlex 与 The Lens 作为 token/sliding 两个 representative canonical consumers。Rollback 只恢复旧定义
 与 consumer imports，无数据或 persisted state migration。
 
+### 6.6 OAuth Client-Credentials Transport
+
+OAuth client-credentials acquisition、in-memory token cache、refresh lock 和 Bearer injection 属于
+Transport；它不定义 Provider credential source、secret persistence、Admin permission 或 config schema。
+Canonical repository-internal interface 为：
+
+```python
+class OAuthTransport(HttpTransport):
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        headers: dict[str, str],
+        timeout: int | float,
+        max_retries: int,
+        proxy: str | None,
+        follow_redirects: bool,
+        token_url: str,
+        client_id: str,
+        client_secret: str,
+    ) -> None: ...
+```
+
+token endpoint 继续直接使用同一个 `httpx.AsyncClient.post()`、相同 timeout/proxy/redirect options，
+不新增 token-specific retry。非 200、JSON parse failure、缺少 `access_token` 分别映射为现有
+`AuthError`；HTTPX network error 与 `expires_in` 类型/算术错误仍按现状原样传播。默认 `expires_in=1200`
+且在 expiry 前 60 秒刷新；恰好位于 refresh boundary 时必须刷新。
+
+每个实例 lazy 创建一个 `asyncio.Lock`，double-check 后只允许一个 refresh 请求。request cancellation
+或 lock-waiter cancellation 原样传播；`async with` 释放 lock，未完成 refresh 不写 token/expiry，其他
+waiter 或后续调用可以继续。接口不 shield cancellation、不跨 event loop 共享实例、不持久化 token，
+也不记录 `client_id`、`client_secret`、access token 或 response body。
+
+Bearer header 先由 cached token 构造，再按现有行为由 caller headers 覆盖；本切片不改变该 precedence。
+legacy `OAuthClient` 同时保持 `OAuthTransport` 与 `SouWenHttpClient` 子类关系，构造参数、source config
+resolution、User-Agent 和 lifecycle 不变；四个 operational methods 与 canonical method object 相同。
+EPO OPS 与 CNIPA 继续通过 legacy adapter 使用 canonical implementation。Rollback 恢复 legacy methods
+和单继承，不需要配置、credential 或 persisted token migration。
+
 ## 7. 验证计划
 
 ### ACCEPT-01 required evidence
@@ -377,6 +417,13 @@ OpenAlex 与 The Lens 作为 token/sliding 两个 representative canonical consu
 | VAL-CR-025 | retry pause/window wait cancellation 释放 lock，保留 pause/timestamp 并可由后续 acquire 恢复 |
 | VAL-CR-026 | OpenAlex token + The Lens sliding consumers canonicalized；Provider 继续解析 headers |
 | VAL-CR-027 | legacy limiter regression、Provider tests、wheel、全量 pytest、Ruff、CI/V2 通过 |
+| VAL-CR-028 | OAuth 四个 operational methods semantic AST parity；legacy MRO/API 与 canonical method identity |
+| VAL-CR-029 | canonical OAuth 无 config/Core/registry/Provider dependency；explicit options construction |
+| VAL-CR-030 | cache hit、60s boundary、default expiry、single refresh 与 token error mapping parity |
+| VAL-CR-031 | token-request/lock-wait cancellation 原样传播、释放 lock、不写 partial cache 且可恢复 |
+| VAL-CR-032 | Bearer injection/caller override、invalid retry policy 与 HTTP execution parity |
+| VAL-CR-033 | EPO OPS/CNIPA 使用 canonical methods；logs/wheel 不暴露 credential/token values |
+| VAL-CR-034 | OAuth/Provider regression、全量 pytest、Ruff、architecture、wheel、CI/V2 通过 |
 
 未来 conditional slice 必须各自增加 old/new parity、negative dependency、cancellation 和资源清理
 证据；不能仅以 import 成功作为退出门槛。
@@ -393,10 +440,9 @@ OpenAlex 与 The Lens 作为 token/sliding 两个 representative canonical consu
 
 需要后续关闭的技术项：
 
-1. OAuth 属于 Transport 还是 Security，以及 token refresh cancellation；
-2. neutral concurrency namespace，替代 legacy `search` / `web` channel；
-3. SSRF 同步 DNS 的 timeout/cancellation 演进；
-4. stable transport port 出现后再定义 fake transport/clock/testing harness。
+1. neutral concurrency namespace，替代 legacy `search` / `web` channel；
+2. SSRF 同步 DNS 的 timeout/cancellation 演进；
+3. stable transport port 出现后再定义 fake transport/clock/testing harness。
 
 ## 9. 实施任务
 
@@ -409,5 +455,6 @@ OpenAlex 与 The Lens 作为 token/sliding 两个 representative canonical consu
 | CR-05a | shared/transport error identity prerequisite | VAL-CR-015–017；legacy identity 与 inheritance parity |
 | CR-05b | trusted Provider HTTP execution core | VAL-CR-018–021；explicit cancellation/redirect/config contract and parity |
 | CR-06 | generic outbound rate limiter | VAL-CR-022–027；cancellation/state conformance；Provider header parsing outside runtime |
+| CR-07 | OAuth client-credentials transport | VAL-CR-028–034；refresh/cache/cancellation/secret boundary parity |
 
-CR-02–CR-06 不能因 CR-01 完成而自动视为批准；每个切片都重新执行 admission test。
+CR-02–CR-07 不能因前一切片完成而自动视为批准；每个切片都重新执行 admission test。

--- a/src/souwen/common_runtime/transport/__init__.py
+++ b/src/souwen/common_runtime/transport/__init__.py
@@ -4,10 +4,12 @@ from souwen.common_runtime.errors import SouWenError
 
 from .errors import AuthError, RateLimitError, SourceUnavailableError
 from .http_client import HttpTransport, RequestRetryPolicy
+from .oauth_client import OAuthTransport
 
 __all__ = [
     "AuthError",
     "HttpTransport",
+    "OAuthTransport",
     "RateLimitError",
     "RequestRetryPolicy",
     "SourceUnavailableError",

--- a/src/souwen/common_runtime/transport/oauth_client.py
+++ b/src/souwen/common_runtime/transport/oauth_client.py
@@ -1,0 +1,155 @@
+"""OAuth 2.0 client-credentials transport over explicit HTTP options."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any
+
+import httpx
+
+from .errors import AuthError
+from .http_client import HttpTransport, RequestRetryPolicy
+
+logger = logging.getLogger("souwen.http")
+
+
+class OAuthTransport(HttpTransport):
+    """Explicit-options OAuth 2.0 client-credentials transport."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        headers: dict[str, str],
+        timeout: int | float,
+        max_retries: int,
+        proxy: str | None,
+        follow_redirects: bool,
+        token_url: str,
+        client_id: str,
+        client_secret: str,
+    ) -> None:
+        super().__init__(
+            base_url=base_url,
+            headers=headers,
+            timeout=timeout,
+            max_retries=max_retries,
+            proxy=proxy,
+            follow_redirects=follow_redirects,
+        )
+        self._initialize_oauth(
+            token_url=token_url,
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+
+    def _initialize_oauth(
+        self,
+        *,
+        token_url: str,
+        client_id: str,
+        client_secret: str,
+    ) -> None:
+        self.token_url = token_url
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self._access_token: str | None = None
+        self._token_expires_at: float = 0
+        self._token_lock: asyncio.Lock | None = None
+
+    def _get_token_lock(self) -> asyncio.Lock:
+        """获取或创建令牌锁（懒加载）"""
+        if self._token_lock is None:
+            self._token_lock = asyncio.Lock()
+        return self._token_lock
+
+    async def _ensure_token(self) -> str:
+        """确保有有效的 access token，过期则自动刷新
+
+        刷新策略：
+        - 检查缓存的 token 是否仍有效（还有 60+ 秒）
+        - 若无效，获取令牌锁并向 token 端点发起请求
+        - 使用二次检查锁模式，避免并发调用重复刷新
+        - 提前 60 秒刷新，避免 token 在请求途中过期导致 401
+
+        Returns:
+            有效的 access token 字符串
+
+        Raises:
+            AuthError: token 获取失败或响应解析失败
+        """
+        if self._access_token and time.monotonic() < self._token_expires_at - 60:
+            return self._access_token
+
+        async with self._get_token_lock():
+            if self._access_token and time.monotonic() < self._token_expires_at - 60:
+                return self._access_token
+
+            logger.debug("正在获取 OAuth token")
+            resp = await self._client.post(
+                self.token_url,
+                data={"grant_type": "client_credentials"},
+                auth=(self.client_id, self.client_secret),
+            )
+            if resp.status_code != 200:
+                raise AuthError(f"OAuth token 获取失败: HTTP {resp.status_code}")
+
+            try:
+                token_data = resp.json()
+            except Exception as e:
+                raise AuthError("OAuth token 响应解析失败") from e
+
+            access_token = token_data.get("access_token")
+            if not access_token:
+                raise AuthError("OAuth 响应缺少 access_token")
+
+            self._access_token = access_token
+            expires_in = token_data.get("expires_in", 1200)
+            self._token_expires_at = time.monotonic() + expires_in
+
+            logger.debug("OAuth token 获取成功，有效期 %ds", expires_in)
+            return self._access_token
+
+    async def get(
+        self,
+        url: str,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        retry_policy: RequestRetryPolicy = "default",
+    ) -> httpx.Response:
+        """带 OAuth token 的 GET 请求"""
+        self._validate_retry_policy(retry_policy)
+        token = await self._ensure_token()
+        auth_headers = {"Authorization": f"Bearer {token}"}
+        if headers:
+            auth_headers.update(headers)
+        return await super().get(
+            url,
+            params=params,
+            headers=auth_headers,
+            retry_policy=retry_policy,
+        )
+
+    async def post(
+        self,
+        url: str,
+        json: dict[str, Any] | None = None,
+        data: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        retry_policy: RequestRetryPolicy = "default",
+    ) -> httpx.Response:
+        """带 OAuth token 的 POST 请求"""
+        self._validate_retry_policy(retry_policy)
+        token = await self._ensure_token()
+        auth_headers = {"Authorization": f"Bearer {token}"}
+        if headers:
+            auth_headers.update(headers)
+        return await super().post(
+            url,
+            json=json,
+            data=data,
+            headers=auth_headers,
+            retry_policy=retry_policy,
+        )

--- a/src/souwen/core/http_client.py
+++ b/src/souwen/core/http_client.py
@@ -48,25 +48,19 @@
 
 from __future__ import annotations
 
-import asyncio
-import logging
-import time
 from typing import Any
-
-import httpx
 
 from souwen import __version__
 from souwen.common_runtime.transport import (
-    AuthError,
+    AuthError as AuthError,
     HttpTransport,
+    OAuthTransport,
     RateLimitError as RateLimitError,
-    RequestRetryPolicy,
+    RequestRetryPolicy as RequestRetryPolicy,
     SourceUnavailableError as SourceUnavailableError,
     SouWenError as SouWenError,
 )
 from souwen.config import get_config
-
-logger = logging.getLogger("souwen.http")
 
 DEFAULT_USER_AGENT = (
     f"SouWen/{__version__} (Academic & Patent Search Tool; https://github.com/BlueSkyXN/SouWen)"
@@ -131,7 +125,7 @@ class SouWenHttpClient(HttpTransport):
         )
 
 
-class OAuthClient(SouWenHttpClient):
+class OAuthClient(OAuthTransport, SouWenHttpClient):
     """OAuth 2.0 Token 自动管理的 HTTP 客户端
 
     适用于 EPO OPS、CNIPA 等需要 OAuth 2.0 认证的数据源。
@@ -159,105 +153,9 @@ class OAuthClient(SouWenHttpClient):
         client_secret: str,
         **kwargs: Any,
     ):
-        super().__init__(base_url=base_url, **kwargs)
-        self.token_url = token_url
-        self.client_id = client_id
-        self.client_secret = client_secret
-        self._access_token: str | None = None
-        self._token_expires_at: float = 0
-        self._token_lock: asyncio.Lock | None = None
-
-    def _get_token_lock(self) -> asyncio.Lock:
-        """获取或创建令牌锁（懒加载）"""
-        if self._token_lock is None:
-            self._token_lock = asyncio.Lock()
-        return self._token_lock
-
-    async def _ensure_token(self) -> str:
-        """确保有有效的 access token，过期则自动刷新
-
-        刷新策略：
-        - 检查缓存的 token 是否仍有效（还有 60+ 秒）
-        - 若无效，获取令牌锁并向 token 端点发起请求
-        - 使用二次检查锁模式，避免并发调用重复刷新
-        - 提前 60 秒刷新，避免 token 在请求途中过期导致 401
-
-        Returns:
-            有效的 access token 字符串
-
-        Raises:
-            AuthError: token 获取失败或响应解析失败
-        """
-        if self._access_token and time.monotonic() < self._token_expires_at - 60:
-            return self._access_token
-
-        async with self._get_token_lock():
-            if self._access_token and time.monotonic() < self._token_expires_at - 60:
-                return self._access_token
-
-            logger.debug("正在获取 OAuth token")
-            resp = await self._client.post(
-                self.token_url,
-                data={"grant_type": "client_credentials"},
-                auth=(self.client_id, self.client_secret),
-            )
-            if resp.status_code != 200:
-                raise AuthError(f"OAuth token 获取失败: HTTP {resp.status_code}")
-
-            try:
-                token_data = resp.json()
-            except Exception as e:
-                raise AuthError("OAuth token 响应解析失败") from e
-
-            access_token = token_data.get("access_token")
-            if not access_token:
-                raise AuthError("OAuth 响应缺少 access_token")
-
-            self._access_token = access_token
-            expires_in = token_data.get("expires_in", 1200)
-            self._token_expires_at = time.monotonic() + expires_in
-
-            logger.debug("OAuth token 获取成功，有效期 %ds", expires_in)
-            return self._access_token
-
-    async def get(
-        self,
-        url: str,
-        params: dict[str, Any] | None = None,
-        headers: dict[str, str] | None = None,
-        retry_policy: RequestRetryPolicy = "default",
-    ) -> httpx.Response:
-        """带 OAuth token 的 GET 请求"""
-        self._validate_retry_policy(retry_policy)
-        token = await self._ensure_token()
-        auth_headers = {"Authorization": f"Bearer {token}"}
-        if headers:
-            auth_headers.update(headers)
-        return await super().get(
-            url,
-            params=params,
-            headers=auth_headers,
-            retry_policy=retry_policy,
-        )
-
-    async def post(
-        self,
-        url: str,
-        json: dict[str, Any] | None = None,
-        data: dict[str, Any] | None = None,
-        headers: dict[str, str] | None = None,
-        retry_policy: RequestRetryPolicy = "default",
-    ) -> httpx.Response:
-        """带 OAuth token 的 POST 请求"""
-        self._validate_retry_policy(retry_policy)
-        token = await self._ensure_token()
-        auth_headers = {"Authorization": f"Bearer {token}"}
-        if headers:
-            auth_headers.update(headers)
-        return await super().post(
-            url,
-            json=json,
-            data=data,
-            headers=auth_headers,
-            retry_policy=retry_policy,
+        SouWenHttpClient.__init__(self, base_url=base_url, **kwargs)
+        self._initialize_oauth(
+            token_url=token_url,
+            client_id=client_id,
+            client_secret=client_secret,
         )

--- a/tests/test_common_runtime_oauth_transport.py
+++ b/tests/test_common_runtime_oauth_transport.py
@@ -1,0 +1,353 @@
+"""Canonical OAuth transport identity, compatibility, and cancellation tests."""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import souwen.common_runtime.transport.oauth_client as canonical_module
+from souwen.common_runtime.transport import HttpTransport, OAuthTransport
+from souwen.core.exceptions import AuthError
+from souwen.core.http_client import OAuthClient, SouWenHttpClient
+from souwen.patent import cnipa, epo_ops
+
+
+def _response(
+    *,
+    status_code: int = 200,
+    payload: object = None,
+    json_error: Exception | None = None,
+) -> MagicMock:
+    response = MagicMock(status_code=status_code)
+    if json_error is not None:
+        response.json.side_effect = json_error
+    else:
+        response.json.return_value = payload
+    return response
+
+
+def _client_double(*, post: AsyncMock | None = None) -> SimpleNamespace:
+    return SimpleNamespace(
+        post=post or AsyncMock(),
+        request=AsyncMock(),
+        aclose=AsyncMock(),
+    )
+
+
+def _explicit_oauth_transport(client: object | None = None) -> OAuthTransport:
+    with patch(
+        "souwen.common_runtime.transport.http_client.httpx.AsyncClient",
+        return_value=client or _client_double(),
+    ):
+        return OAuthTransport(
+            base_url="https://api.example",
+            headers={"X-Test": "value"},
+            timeout=7,
+            max_retries=3,
+            proxy=None,
+            follow_redirects=True,
+            token_url="https://auth.example/oauth/token",
+            client_id="client-id",
+            client_secret="client-secret",
+        )
+
+
+def test_legacy_oauth_client_preserves_mro_and_uses_canonical_methods() -> None:
+    assert issubclass(OAuthTransport, HttpTransport)
+    assert issubclass(OAuthClient, OAuthTransport)
+    assert issubclass(OAuthClient, SouWenHttpClient)
+    assert OAuthClient.__mro__[:4] == (
+        OAuthClient,
+        OAuthTransport,
+        SouWenHttpClient,
+        HttpTransport,
+    )
+    assert OAuthClient._get_token_lock is OAuthTransport._get_token_lock
+    assert OAuthClient._ensure_token is OAuthTransport._ensure_token
+    assert OAuthClient.get is OAuthTransport.get
+    assert OAuthClient.post is OAuthTransport.post
+    assert epo_ops.OAuthClient is OAuthClient
+    assert cnipa.OAuthClient is OAuthClient
+
+
+def test_canonical_oauth_module_has_no_legacy_or_domain_dependencies() -> None:
+    path = Path(canonical_module.__file__)
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imported = {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module is not None
+    }
+    imported.update(
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    )
+    assert imported == {
+        "__future__",
+        "asyncio",
+        "errors",
+        "http_client",
+        "httpx",
+        "logging",
+        "time",
+        "typing",
+    }
+    source = path.read_text(encoding="utf-8")
+    for forbidden in (
+        "souwen.config",
+        "souwen.core",
+        "souwen.delivery",
+        "souwen.modules",
+        "souwen.providers",
+        "souwen.registry",
+        "souwen.server",
+        "get_config",
+        "source_name",
+        "os.environ",
+    ):
+        assert forbidden not in source
+
+
+def test_explicit_oauth_transport_constructs_without_config_resolution() -> None:
+    with patch("souwen.common_runtime.transport.http_client.httpx.AsyncClient") as client_factory:
+        client = OAuthTransport(
+            base_url="https://api.example",
+            headers={"X-Test": "value"},
+            timeout=12.5,
+            max_retries=9,
+            proxy="http://proxy.example:8080",
+            follow_redirects=False,
+            token_url="https://auth.example/oauth/token",
+            client_id="client-id",
+            client_secret="client-secret",
+        )
+
+    options = client_factory.call_args.kwargs
+    assert options["base_url"] == "https://api.example"
+    assert options["headers"] == {"X-Test": "value"}
+    assert options["timeout"].connect == 12.5
+    assert options["proxy"] == "http://proxy.example:8080"
+    assert options["follow_redirects"] is False
+    assert client.max_retries == 9
+    assert client.token_url == "https://auth.example/oauth/token"
+    assert client.client_id == "client-id"
+    assert client.client_secret == "client-secret"
+    assert client._access_token is None
+    assert client._token_expires_at == 0
+    assert client._token_lock is None
+
+
+def test_legacy_oauth_adapter_preserves_source_config_resolution() -> None:
+    config = MagicMock(timeout=30, max_retries=3)
+    config.resolve_base_url.return_value = "https://resolved.example"
+    config.resolve_proxy.return_value = "http://source-proxy.example:8080"
+    config.resolve_headers.return_value = {"X-Source": "source-value"}
+    with (
+        patch("souwen.core.http_client.get_config", return_value=config),
+        patch("souwen.common_runtime.transport.http_client.httpx.AsyncClient") as client_factory,
+    ):
+        client = OAuthClient(
+            base_url="https://default.example",
+            token_url="https://auth.example/oauth/token",
+            client_id="client-id",
+            client_secret="client-secret",
+            headers={"X-Caller": "caller-value"},
+            timeout=8,
+            source_name="oauth_source",
+        )
+
+    config.resolve_base_url.assert_called_once_with(
+        "oauth_source", default="https://default.example"
+    )
+    config.resolve_proxy.assert_called_once_with("oauth_source")
+    config.resolve_headers.assert_called_once_with("oauth_source")
+    options = client_factory.call_args.kwargs
+    assert options["base_url"] == "https://resolved.example"
+    assert options["headers"]["X-Source"] == "source-value"
+    assert options["headers"]["X-Caller"] == "caller-value"
+    assert options["timeout"].connect == 8
+    assert options["proxy"] == "http://source-proxy.example:8080"
+    assert client.token_url == "https://auth.example/oauth/token"
+
+
+def test_epo_and_cnipa_construct_with_canonical_oauth_operations() -> None:
+    config = MagicMock(
+        timeout=30,
+        max_retries=3,
+        epo_consumer_secret="epo-secret",
+        cnipa_client_secret="cnipa-secret",
+    )
+    config.resolve_api_key.side_effect = lambda source, _field: {
+        "epo_ops": "epo-client",
+        "cnipa": "cnipa-client",
+    }[source]
+    config.resolve_base_url.side_effect = lambda _source, default: default
+    config.resolve_proxy.return_value = None
+    config.resolve_headers.return_value = {}
+    with (
+        patch("souwen.patent.epo_ops.get_config", return_value=config),
+        patch("souwen.patent.cnipa.get_config", return_value=config),
+        patch("souwen.core.http_client.get_config", return_value=config),
+        patch("souwen.common_runtime.transport.http_client.httpx.AsyncClient"),
+    ):
+        epo = epo_ops.EpoOpsClient()
+        chinese = cnipa.CnipaClient()
+
+    assert isinstance(epo._http, OAuthTransport)
+    assert isinstance(epo._http, SouWenHttpClient)
+    assert isinstance(chinese._http, OAuthTransport)
+    assert isinstance(chinese._http, SouWenHttpClient)
+    assert epo._http._ensure_token.__func__ is OAuthTransport._ensure_token
+    assert chinese._http._ensure_token.__func__ is OAuthTransport._ensure_token
+
+
+@pytest.mark.asyncio
+async def test_token_request_cancellation_releases_lock_and_preserves_empty_cache() -> None:
+    started = asyncio.Event()
+
+    async def blocking_post(*_args: object, **_kwargs: object) -> None:
+        started.set()
+        await asyncio.Event().wait()
+
+    post = AsyncMock(side_effect=blocking_post)
+    client = _explicit_oauth_transport(_client_double(post=post))
+    task = asyncio.create_task(client._ensure_token())
+    await started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert not client._get_token_lock().locked()
+    assert client._access_token is None
+    assert client._token_expires_at == 0
+    assert post.await_count == 1
+
+    client._client.post = AsyncMock(
+        return_value=_response(payload={"access_token": "recovered", "expires_in": 1200})
+    )
+    with patch("souwen.common_runtime.transport.oauth_client.time.monotonic", return_value=100):
+        assert await client._ensure_token() == "recovered"
+    assert client._access_token == "recovered"
+    assert client._token_expires_at == 1300
+
+
+@pytest.mark.asyncio
+async def test_cancelled_lock_waiter_does_not_cancel_single_refresh() -> None:
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def blocking_post(*_args: object, **_kwargs: object) -> MagicMock:
+        started.set()
+        await release.wait()
+        return _response(payload={"access_token": "shared", "expires_in": 1200})
+
+    post = AsyncMock(side_effect=blocking_post)
+    client = _explicit_oauth_transport(_client_double(post=post))
+    first = asyncio.create_task(client._ensure_token())
+    await started.wait()
+    waiter = asyncio.create_task(client._ensure_token())
+    await asyncio.sleep(0)
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+
+    release.set()
+    assert await first == "shared"
+    assert post.await_count == 1
+    assert not client._get_token_lock().locked()
+
+
+@pytest.mark.asyncio
+async def test_cache_boundary_and_default_expiry_are_preserved() -> None:
+    post = AsyncMock(return_value=_response(payload={"access_token": "fresh"}))
+    client = _explicit_oauth_transport(_client_double(post=post))
+    client._access_token = "cached"
+    client._token_expires_at = 200
+
+    with patch("souwen.common_runtime.transport.oauth_client.time.monotonic", return_value=139):
+        assert await client._ensure_token() == "cached"
+    post.assert_not_awaited()
+
+    with patch("souwen.common_runtime.transport.oauth_client.time.monotonic", return_value=140):
+        assert await client._ensure_token() == "fresh"
+    post.assert_awaited_once_with(
+        "https://auth.example/oauth/token",
+        data={"grant_type": "client_credentials"},
+        auth=("client-id", "client-secret"),
+    )
+    assert client._token_expires_at == 1340
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("response", "message"),
+    [
+        (_response(status_code=401), "OAuth token 获取失败: HTTP 401"),
+        (_response(json_error=ValueError("bad json")), "OAuth token 响应解析失败"),
+        (_response(payload={}), "OAuth 响应缺少 access_token"),
+    ],
+)
+async def test_token_error_mapping_is_preserved(response: MagicMock, message: str) -> None:
+    client = _explicit_oauth_transport(_client_double(post=AsyncMock(return_value=response)))
+    with pytest.raises(AuthError, match=message):
+        await client._ensure_token()
+    assert client._access_token is None
+    assert client._token_expires_at == 0
+
+
+@pytest.mark.asyncio
+async def test_bearer_injection_and_caller_header_precedence_are_preserved() -> None:
+    response = MagicMock(status_code=200)
+    transport = _client_double()
+    transport.request.return_value = response
+    client = _explicit_oauth_transport(transport)
+    client._access_token = "cached-token"
+    client._token_expires_at = 1000
+
+    with patch("souwen.common_runtime.transport.oauth_client.time.monotonic", return_value=0):
+        assert (
+            await client.get(
+                "/records",
+                headers={"Authorization": "Caller override", "X-Request": "value"},
+                retry_policy="single_attempt",
+            )
+            is response
+        )
+
+    transport.request.assert_awaited_once_with(
+        "GET",
+        "/records",
+        params=None,
+        headers={"Authorization": "Caller override", "X-Request": "value"},
+    )
+    transport.post.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_oauth_logs_do_not_include_credentials_or_token(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    client = _explicit_oauth_transport(
+        _client_double(
+            post=AsyncMock(
+                return_value=_response(
+                    payload={"access_token": "returned-secret-token", "expires_in": 1200}
+                )
+            )
+        )
+    )
+    with caplog.at_level(logging.DEBUG, logger="souwen.http"):
+        assert await client._ensure_token() == "returned-secret-token"
+
+    rendered = caplog.text
+    assert "client-secret" not in rendered
+    assert "client-id" not in rendered
+    assert "returned-secret-token" not in rendered


### PR DESCRIPTION
## Summary

- add explicit-options `OAuthTransport` for OAuth 2.0 client-credentials acquisition, cache, refresh locking, and Bearer injection
- preserve legacy `OAuthClient` construction/config behavior and its `SouWenHttpClient` subtype relationship
- keep EPO OPS and CNIPA on the legacy adapter while executing the same canonical OAuth method objects
- freeze cache boundary, cancellation, error, header precedence, and secret-handling behavior in SPEC-06

## Stacked dependency

This Draft PR is stacked on #200 and intentionally targets `codex/phase3-rate-limiter`. It must not be retargeted to `main` before its dependency chain is merged. Main-only pull-request gates must be rerun after final retargeting.

## Behavior-preservation evidence

- `_get_token_lock`, `_ensure_token`, `get`, and `post` pass exact semantic AST parity against the parent implementation
- legacy `OAuthClient` remains both an `OAuthTransport` and `SouWenHttpClient`
- legacy source config, base URL, proxy, merged headers, timeout, User-Agent, and lifecycle remain in the compatibility adapter
- token endpoint still uses the same HTTPX client directly and adds no token-specific retry
- default `expires_in=1200` and the strict 60-second refresh boundary are unchanged
- non-200, malformed JSON, and missing access token retain existing `AuthError` mapping
- token-request and lock-waiter cancellation propagate natively, release the lock, and do not write a partial cache
- caller headers continue to override the generated Bearer header
- no credential, token, or response-body values are logged or persisted
- EPO OPS and CNIPA construct successfully with canonical OAuth operations

## Local validation

- focused OAuth/HTTP/infra/common-runtime suite: 89 passed
- OAuth/HTTP/infra suite after consumer construction coverage: 67 passed
- patent/doctor/catalog/server regression: 262 passed, 1 skipped
- full deterministic suite: 2406 passed, 3 skipped
- `uvx ruff==0.15.22 check src tests scripts tools`: passed
- `uvx ruff==0.15.22 format --check src tests scripts tools`: passed
- architecture dependency checker: passed
- generated docs and legacy wording gates: passed
- Markdown parse/fence and `git diff --check`: passed
- `basic-cli` profile: passed
- wheel path/MRO/method-identity and synthetic-secret absence checks: passed

## Out of scope

- Provider credential-source or config-schema changes
- token persistence, token-specific retry, or cross-event-loop sharing
- OAuth authorization-code/device flows
- neutral concurrency namespace
- synchronous DNS cancellation evolution
- Ready, merge, release, or deployment

## Exact-head remote validation

- exact head: `3323068a1286447515b1c1be8fb140d04082bcc0`
- CI run [#30066275066](https://github.com/BlueSkyXN/SouWen/actions/runs/30066275066): 29 successful, 0 failing/pending
- V2 run [#30066275007](https://github.com/BlueSkyXN/SouWen/actions/runs/30066275007): 12 successful, 0 failing/pending
- both runs were manually dispatched against the exact head
- because this PR is stacked on a non-`main` base, CodeQL/HFS pull-request gates did not run; all automatic required checks must run again after the dependency chain is merged and this PR is retargeted to `main`
