### PR TITLE
refactor: extract loop-local semaphore pool

### DIFF
--- a/docs/internal/spec-06-common-runtime-lld.md
+++ b/docs/internal/spec-06-common-runtime-lld.md
@@ -46,7 +46,7 @@ Common Runtime 只接收同时满足以下条件的组件：
 | `SouWenHttpClient` | OpenAlex、HAL 等 Provider | CONDITIONAL-05 | 先冻结 native cancellation、无 stream v1、trusted auto-redirect 与 config adapter 边界 |
 | token/sliding-window limiter | OpenAlex、The Lens 等 Provider | CONDITIONAL-06 | 先补 acquire cancellation/state fixture；Provider 负责把 headers 转成通用数值 |
 | `OAuthClient` | EPO OPS、CNIPA | **ACCEPT-07** | client-credentials acquisition/cache/bearer 属于 Transport；legacy config adapter 保持，先冻结 refresh cancellation 与 secret boundary |
-| `core.concurrency` 原 API | Search、Web aggregation | REJECT-AS-IS | `"search"` / `"web"` channel 是领域名称；不能原样成为 runtime API |
+| `core.concurrency` 原 API | Search、Web aggregation | **ACCEPT-08，neutral primitive only** | runtime 只接收 explicit-size loop-local pool；`"search"` / `"web"` 与 env policy 留在 legacy adapter |
 | retry presets / `poll_retry` | 当前只有一个 production consumer 或无 consumer | REJECT | 不满足两个消费者；scraper/CAPTCHA exception set 含领域策略且缺独立测试 |
 | `BaseScraper` / browser pool / fingerprint | scraper/browser Provider | REJECT | 混合 anti-bot、SSRF、Provider backend、browser optional runtime；不是中立 transport |
 | `SessionCache` | 当前仅 Server shutdown lifecycle | REJECT | 单一消费者、持久化 secret/state owner 未决，且 Fetch cache 归属另由 Fetch LLD 决定 |
@@ -384,6 +384,29 @@ resolution、User-Agent 和 lifecycle 不变；四个 operational methods 与 ca
 EPO OPS 与 CNIPA 继续通过 legacy adapter 使用 canonical implementation。Rollback 恢复 legacy methods
 和单继承，不需要配置、credential 或 persisted token migration。
 
+### 6.7 Loop-Local Semaphore Pool
+
+Common Runtime 只拥有中立的 per-event-loop semaphore state；不拥有 Search/Web channel、环境变量或
+产品并发默认值。Canonical repository-internal interface 为：
+
+```python
+class LoopLocalSemaphorePool:
+    def get(self, size: int) -> asyncio.Semaphore: ...
+    def clear(self) -> None: ...
+```
+
+每个 pool 用 `WeakKeyDictionary[AbstractEventLoop, Semaphore]` 保存当前 running loop 的实例。同一 pool、
+同一 loop 重复调用返回同一 object，首次 `size` 生效；不同 loop 或不同 pool 必须隔离。`size=0` 与负数
+分别保持 `asyncio.Semaphore` 的既有允许/拒绝语义，不新增校验。协程外调用继续由
+`asyncio.get_running_loop()` 抛出 `RuntimeError`。loop 无其他强引用时 weak entry 可被回收；`clear()`
+丢弃该 pool 的所有 entries，不关闭 loop、不取消 task，也不修改既有 semaphore object。
+
+`souwen.core.concurrency` 保留 `SOUWEN_MAX_CONCURRENCY`、默认值 10、非法值 fallback、`search` / `web`
+channel validation、exact error 与 `clear_semaphore()` compatibility。legacy adapter 为两个 channel 各持有
+一个 canonical pool，Search 和 Web aggregation 继续通过旧函数使用 canonical state，因此不改变公开
+或测试 patch surface。接口无 I/O、timeout、retry 或 cancellation point；不跨 process/thread 共享。
+Rollback 恢复 legacy maps；无数据、配置或 persisted state migration。
+
 ## 7. 验证计划
 
 ### ACCEPT-01 required evidence
@@ -424,6 +447,11 @@ EPO OPS 与 CNIPA 继续通过 legacy adapter 使用 canonical implementation。
 | VAL-CR-032 | Bearer injection/caller override、invalid retry policy 与 HTTP execution parity |
 | VAL-CR-033 | EPO OPS/CNIPA 使用 canonical methods；logs/wheel 不暴露 credential/token values |
 | VAL-CR-034 | OAuth/Provider regression、全量 pytest、Ruff、architecture、wheel、CI/V2 通过 |
+| VAL-CR-035 | same-loop identity、first-size-wins、different-loop 与 different-pool isolation |
+| VAL-CR-036 | explicit zero/negative size、no-running-loop、clear 与 weakref cleanup 语义保持 |
+| VAL-CR-037 | canonical concurrency stdlib-only；无 env、Search/Web、config、registry 或 Provider policy |
+| VAL-CR-038 | legacy env/default/channel/exact-error/clear contract 与 Search/Web consumers 保持 |
+| VAL-CR-039 | architecture、import、Search/Web regression、wheel、全量 pytest 与 Ruff 通过 |
 
 未来 conditional slice 必须各自增加 old/new parity、negative dependency、cancellation 和资源清理
 证据；不能仅以 import 成功作为退出门槛。
@@ -440,9 +468,8 @@ EPO OPS 与 CNIPA 继续通过 legacy adapter 使用 canonical implementation。
 
 需要后续关闭的技术项：
 
-1. neutral concurrency namespace，替代 legacy `search` / `web` channel；
-2. SSRF 同步 DNS 的 timeout/cancellation 演进；
-3. stable transport port 出现后再定义 fake transport/clock/testing harness。
+1. SSRF 同步 DNS 的 timeout/cancellation 演进；
+2. stable transport port 出现后再定义 fake transport/clock/testing harness。
 
 ## 9. 实施任务
 
@@ -456,5 +483,6 @@ EPO OPS 与 CNIPA 继续通过 legacy adapter 使用 canonical implementation。
 | CR-05b | trusted Provider HTTP execution core | VAL-CR-018–021；explicit cancellation/redirect/config contract and parity |
 | CR-06 | generic outbound rate limiter | VAL-CR-022–027；cancellation/state conformance；Provider header parsing outside runtime |
 | CR-07 | OAuth client-credentials transport | VAL-CR-028–034；refresh/cache/cancellation/secret boundary parity |
+| CR-08 | neutral loop-local semaphore pool | VAL-CR-035–039；domain/env policy stays in legacy adapter |
 
-CR-02–CR-07 不能因前一切片完成而自动视为批准；每个切片都重新执行 admission test。
+CR-02–CR-08 不能因前一切片完成而自动视为批准；每个切片都重新执行 admission test。

--- a/src/souwen/common_runtime/resilience/__init__.py
+++ b/src/souwen/common_runtime/resilience/__init__.py
@@ -1,5 +1,11 @@
 """Resilience runtime boundary. Owner: Common Runtime. Allowed dependencies: standard library and common runtime."""
 
+from .concurrency import LoopLocalSemaphorePool
 from .rate_limiter import RateLimiterBase, SlidingWindowLimiter, TokenBucketLimiter
 
-__all__ = ["RateLimiterBase", "SlidingWindowLimiter", "TokenBucketLimiter"]
+__all__ = [
+    "LoopLocalSemaphorePool",
+    "RateLimiterBase",
+    "SlidingWindowLimiter",
+    "TokenBucketLimiter",
+]

--- a/src/souwen/common_runtime/resilience/concurrency.py
+++ b/src/souwen/common_runtime/resilience/concurrency.py
@@ -1,0 +1,28 @@
+"""Event-loop-local concurrency primitives without product policy."""
+
+from __future__ import annotations
+
+import asyncio
+import weakref
+
+
+class LoopLocalSemaphorePool:
+    """Return one semaphore per running event loop for this pool."""
+
+    def __init__(self) -> None:
+        self._semaphores: weakref.WeakKeyDictionary[
+            asyncio.AbstractEventLoop, asyncio.Semaphore
+        ] = weakref.WeakKeyDictionary()
+
+    def get(self, size: int) -> asyncio.Semaphore:
+        """Return the current loop's semaphore, creating it with ``size`` once."""
+        loop = asyncio.get_running_loop()
+        semaphore = self._semaphores.get(loop)
+        if semaphore is None:
+            semaphore = asyncio.Semaphore(size)
+            self._semaphores[loop] = semaphore
+        return semaphore
+
+    def clear(self) -> None:
+        """Discard all loop-local semaphores owned by this pool."""
+        self._semaphores = weakref.WeakKeyDictionary()

--- a/src/souwen/core/concurrency.py
+++ b/src/souwen/core/concurrency.py
@@ -16,16 +16,16 @@ from __future__ import annotations
 
 import asyncio
 import os
-import weakref
+
+from souwen.common_runtime.resilience import LoopLocalSemaphorePool
 
 # 默认全局并发度上限；通过 SOUWEN_MAX_CONCURRENCY 环境变量覆盖
 _DEFAULT_MAX_CONCURRENCY = 10
 
-#: 按 channel 分开存储的 per-loop Semaphore 映射。
-#: WeakKeyDictionary 会在 loop 被 GC 时自动清理对应 Semaphore。
-_sem_maps: dict[str, "weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Semaphore]"] = {
-    "search": weakref.WeakKeyDictionary(),
-    "web": weakref.WeakKeyDictionary(),
+#: legacy channel policy stays here; the canonical pool has no product channel names.
+_sem_pools: dict[str, LoopLocalSemaphorePool] = {
+    "search": LoopLocalSemaphorePool(),
+    "web": LoopLocalSemaphorePool(),
 }
 
 
@@ -67,15 +67,9 @@ def get_semaphore(
     Raises:
         RuntimeError: 没有 running event loop（在协程外调用）。
     """
-    if channel not in _sem_maps:
+    if channel not in _sem_pools:
         raise ValueError(f"unknown channel {channel!r}; expected 'search' or 'web'")
-    loop = asyncio.get_running_loop()
-    sem_map = _sem_maps[channel]
-    sem = sem_map.get(loop)
-    if sem is None:
-        sem = asyncio.Semaphore(size if size is not None else get_max_concurrency())
-        sem_map[loop] = sem
-    return sem
+    return _sem_pools[channel].get(size if size is not None else get_max_concurrency())
 
 
 def clear_semaphore(channel: str | None = None) -> None:
@@ -84,7 +78,7 @@ def clear_semaphore(channel: str | None = None) -> None:
     Args:
         channel: 指定要清除的 channel；None 表示清除所有 channel。
     """
-    targets = [channel] if channel else list(_sem_maps.keys())
+    targets = [channel] if channel else list(_sem_pools.keys())
     for ch in targets:
-        if ch in _sem_maps:
-            _sem_maps[ch] = weakref.WeakKeyDictionary()
+        if ch in _sem_pools:
+            _sem_pools[ch].clear()

--- a/tests/test_common_runtime_concurrency.py
+++ b/tests/test_common_runtime_concurrency.py
@@ -1,0 +1,312 @@
+"""Canonical loop-local semaphore and legacy concurrency-policy conformance."""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import gc
+import importlib
+import weakref
+from pathlib import Path
+
+import pytest
+
+import souwen.common_runtime.resilience.concurrency as canonical_module
+from souwen.common_runtime.resilience import LoopLocalSemaphorePool
+from souwen.core import concurrency as legacy_module
+
+
+def _run_in_new_loop(factory):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop, loop.run_until_complete(factory())
+    except BaseException:
+        loop.close()
+        raise
+
+
+def test_canonical_pool_is_stdlib_only_and_product_neutral() -> None:
+    path = Path(canonical_module.__file__)
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(path))
+    imported = {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module is not None
+    }
+    imported.update(
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    )
+
+    assert imported == {"__future__", "asyncio", "weakref"}
+    assert '"search"' not in source
+    assert '"web"' not in source
+    assert "SOUWEN_MAX_CONCURRENCY" not in source
+
+
+def test_same_loop_identity_and_first_size_wins() -> None:
+    pool = LoopLocalSemaphorePool()
+
+    async def exercise() -> tuple[asyncio.Semaphore, asyncio.Semaphore]:
+        return pool.get(2), pool.get(7)
+
+    semaphore, same_semaphore = asyncio.run(exercise())
+
+    assert semaphore is same_semaphore
+    assert semaphore._value == 2
+
+
+def test_different_loops_and_pools_are_isolated() -> None:
+    first_pool = LoopLocalSemaphorePool()
+    second_pool = LoopLocalSemaphorePool()
+
+    async def get_from_first() -> asyncio.Semaphore:
+        return first_pool.get(2)
+
+    async def get_from_both() -> tuple[asyncio.Semaphore, asyncio.Semaphore]:
+        return first_pool.get(3), second_pool.get(4)
+
+    loop_one, semaphore_one = _run_in_new_loop(get_from_first)
+    loop_one.close()
+    loop_two, (semaphore_two, other_pool_semaphore) = _run_in_new_loop(get_from_both)
+    loop_two.close()
+
+    assert semaphore_one is not semaphore_two
+    assert semaphore_two is not other_pool_semaphore
+    assert semaphore_one._value == 2
+    assert semaphore_two._value == 3
+    assert other_pool_semaphore._value == 4
+
+
+def test_clear_replaces_current_loop_semaphore() -> None:
+    pool = LoopLocalSemaphorePool()
+
+    async def exercise() -> tuple[asyncio.Semaphore, asyncio.Semaphore]:
+        before = pool.get(2)
+        pool.clear()
+        after = pool.get(5)
+        return before, after
+
+    before, after = asyncio.run(exercise())
+
+    assert before is not after
+    assert before._value == 2
+    assert after._value == 5
+
+
+def test_clear_discards_entries_for_all_live_loops() -> None:
+    pool = LoopLocalSemaphorePool()
+
+    async def get(size: int) -> asyncio.Semaphore:
+        return pool.get(size)
+
+    loop_one, semaphore_one = _run_in_new_loop(lambda: get(2))
+    loop_two, semaphore_two = _run_in_new_loop(lambda: get(3))
+    try:
+        pool.clear()
+        next_one = loop_one.run_until_complete(get(5))
+        next_two = loop_two.run_until_complete(get(7))
+    finally:
+        loop_one.close()
+        loop_two.close()
+
+    assert next_one is not semaphore_one
+    assert next_two is not semaphore_two
+    assert next_one._value == 5
+    assert next_two._value == 7
+
+
+def test_size_semantics_and_running_loop_error_match_asyncio() -> None:
+    pool = LoopLocalSemaphorePool()
+
+    with pytest.raises(RuntimeError, match="no running event loop"):
+        pool.get(1)
+
+    async def zero_size() -> asyncio.Semaphore:
+        return pool.get(0)
+
+    assert asyncio.run(zero_size())._value == 0
+
+    pool.clear()
+
+    async def negative_size() -> None:
+        pool.get(-1)
+
+    with pytest.raises(ValueError, match="Semaphore initial value must be >= 0"):
+        asyncio.run(negative_size())
+
+
+def test_closed_loop_entry_is_removed_after_garbage_collection() -> None:
+    pool = LoopLocalSemaphorePool()
+
+    async def get_semaphore() -> asyncio.Semaphore:
+        return pool.get(1)
+
+    loop, semaphore = _run_in_new_loop(get_semaphore)
+    loop_ref = weakref.ref(loop)
+    assert len(pool._semaphores) == 1
+
+    loop.close()
+    del loop
+    del semaphore
+    gc.collect()
+
+    assert loop_ref() is None
+    assert len(pool._semaphores) == 0
+
+
+@pytest.fixture(autouse=True)
+def _clear_legacy_pools() -> None:
+    legacy_module.clear_semaphore()
+    yield
+    legacy_module.clear_semaphore()
+
+
+def test_legacy_channels_use_independent_canonical_pools() -> None:
+    assert set(legacy_module._sem_pools) == {"search", "web"}
+    assert all(
+        isinstance(pool, LoopLocalSemaphorePool) for pool in legacy_module._sem_pools.values()
+    )
+
+    async def exercise() -> tuple[asyncio.Semaphore, asyncio.Semaphore, asyncio.Semaphore]:
+        search = legacy_module.get_semaphore("search", 2)
+        search_again = legacy_module.get_semaphore("search", 9)
+        web = legacy_module.get_semaphore("web", 3)
+        return search, search_again, web
+
+    search, search_again, web = asyncio.run(exercise())
+
+    assert search is search_again
+    assert search is not web
+    assert search._value == 2
+    assert web._value == 3
+
+
+def test_legacy_environment_policy_and_exact_unknown_channel_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SOUWEN_MAX_CONCURRENCY", "6")
+
+    async def get_default() -> asyncio.Semaphore:
+        return legacy_module.get_semaphore("search")
+
+    assert asyncio.run(get_default())._value == 6
+
+    with pytest.raises(ValueError) as exc_info:
+        legacy_module.get_semaphore("provider")
+    assert str(exc_info.value) == "unknown channel 'provider'; expected 'search' or 'web'"
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, 10),
+        ("", 10),
+        ("0", 10),
+        ("-3", 10),
+        ("invalid", 10),
+        ("6", 6),
+    ],
+)
+def test_legacy_max_concurrency_environment_matrix(
+    monkeypatch: pytest.MonkeyPatch,
+    raw: str | None,
+    expected: int,
+) -> None:
+    if raw is None:
+        monkeypatch.delenv("SOUWEN_MAX_CONCURRENCY", raising=False)
+    else:
+        monkeypatch.setenv("SOUWEN_MAX_CONCURRENCY", raw)
+
+    assert legacy_module.get_max_concurrency() == expected
+
+
+def test_legacy_valid_channel_requires_running_loop_and_unknown_clear_is_noop() -> None:
+    with pytest.raises(RuntimeError, match="no running event loop"):
+        legacy_module.get_semaphore("search", 1)
+
+    legacy_module.clear_semaphore("unknown")
+    assert set(legacy_module._sem_pools) == {"search", "web"}
+
+
+def test_search_and_web_helpers_use_isolated_canonical_pools() -> None:
+    search_module = importlib.import_module("souwen.search")
+    web_search_module = importlib.import_module("souwen.web.search")
+
+    async def exercise() -> tuple[asyncio.Semaphore, asyncio.Semaphore, asyncio.AbstractEventLoop]:
+        return (
+            search_module._get_semaphore(),
+            web_search_module._get_web_semaphore(),
+            asyncio.get_running_loop(),
+        )
+
+    search, web, loop = asyncio.run(exercise())
+
+    assert search is not web
+    assert search is legacy_module._sem_pools["search"]._semaphores.get(loop)
+    assert web is legacy_module._sem_pools["web"]._semaphores.get(loop)
+
+
+def test_legacy_clear_one_channel_or_all() -> None:
+    async def populate() -> tuple[asyncio.Semaphore, asyncio.Semaphore]:
+        return (
+            legacy_module.get_semaphore("search", 1),
+            legacy_module.get_semaphore("web", 2),
+        )
+
+    async def read_again() -> tuple[asyncio.Semaphore, asyncio.Semaphore]:
+        return (
+            legacy_module.get_semaphore("search", 3),
+            legacy_module.get_semaphore("web", 4),
+        )
+
+    async def exercise() -> tuple[
+        asyncio.Semaphore,
+        asyncio.Semaphore,
+        asyncio.Semaphore,
+        asyncio.Semaphore,
+        asyncio.Semaphore,
+        asyncio.Semaphore,
+    ]:
+        original_search, original_web = await populate()
+        legacy_module.clear_semaphore("search")
+        next_search, same_web = await read_again()
+        legacy_module.clear_semaphore()
+        final_search, final_web = await read_again()
+        return original_search, original_web, next_search, same_web, final_search, final_web
+
+    original_search, original_web, next_search, same_web, final_search, final_web = asyncio.run(
+        exercise()
+    )
+
+    assert next_search is not original_search
+    assert same_web is original_web
+    assert final_search is not next_search
+    assert final_web is not same_web
+    assert next_search._value == 3
+    assert same_web._value == 2
+    assert final_search._value == 3
+    assert final_web._value == 4
+
+
+def test_legacy_channel_clear_discards_entries_for_all_live_loops() -> None:
+    async def get_search(size: int) -> asyncio.Semaphore:
+        return legacy_module.get_semaphore("search", size)
+
+    loop_one, semaphore_one = _run_in_new_loop(lambda: get_search(2))
+    loop_two, semaphore_two = _run_in_new_loop(lambda: get_search(3))
+    try:
+        legacy_module.clear_semaphore("search")
+        next_one = loop_one.run_until_complete(get_search(5))
+        next_two = loop_two.run_until_complete(get_search(7))
+    finally:
+        loop_one.close()
+        loop_two.close()
+
+    assert next_one is not semaphore_one
+    assert next_two is not semaphore_two
+    assert next_one._value == 5
+    assert next_two._value == 7


### PR DESCRIPTION
## Summary

- add a product-neutral `LoopLocalSemaphorePool` to Common Runtime Resilience
- preserve the legacy `SOUWEN_MAX_CONCURRENCY`, default/fallback, `search`/`web` channel, exact error, and clear policy in `souwen.core.concurrency`
- keep Search and Web aggregation on their existing legacy helper surface while both use canonical per-loop state
- close the SPEC-06 neutral-concurrency technical item as CR-08 with deterministic conformance evidence

## Stacked dependency

This Draft PR is stacked on #201 and intentionally targets `codex/phase3-oauth-transport`. It must not be retargeted to `main` before its dependency chain is merged. Main-only pull-request gates must be rerun after final retargeting.

## Behavior-preservation evidence

- same pool + same running loop returns the same semaphore; first size wins
- different loops, pools, and legacy `search`/`web` channels remain isolated
- `clear()` and legacy channel/all clear discard entries across all live loops without mutating returned semaphores
- zero/negative size behavior delegates unchanged to `asyncio.Semaphore`
- no-running-loop and unknown-channel behavior, including exact legacy error text, remain unchanged
- weak-key cleanup is covered for an unreferenced closed loop
- unset, empty, zero, negative, invalid, and positive `SOUWEN_MAX_CONCURRENCY` inputs retain the current fallback/value matrix
- canonical code contains no env, config, registry, Provider, Search, or Web policy
- real Search and Web helpers resolve through independent canonical pools

## Local validation

- focused Common Runtime/Search/Web suite: 87 passed
- full deterministic suite: 2425 passed, 3 skipped
- `uvx ruff==0.15.22 check src tests scripts tools`: passed
- `uvx ruff==0.15.22 format --check src tests scripts tools`: passed
- architecture dependency checker: passed
- generated docs and legacy wording gates: passed
- Markdown fence and `git diff --check`: passed
- `basic-cli` profile: passed
- isolated wheel build, path presence, canonical/legacy import and identity behavior: passed
- independent read-only review: implementation accepted after adding cross-loop clear, env fallback matrix, and real Web consumer coverage

## Out of scope

- changing concurrency defaults, channel names, or environment policy
- global/thread/process semaphore sharing
- moving individual Provider batch semaphores into Common Runtime
- SSRF synchronous DNS cancellation evolution
- Ready, merge, release, or deployment

## Exact-head remote validation

- exact head: `efd0a81c3ca418523babd50827680e1201ca4dad`
- CI run [#30067118887](https://github.com/BlueSkyXN/SouWen/actions/runs/30067118887): 29 successful, 0 skipped/failing/pending
- V2 run [#30067121001](https://github.com/BlueSkyXN/SouWen/actions/runs/30067121001): 12 successful, 0 skipped/failing/pending
- both runs were manually dispatched against the exact head
- because this PR is stacked on a non-`main` base, CodeQL/HFS pull-request gates did not run; all automatic required checks must run again after the dependency chain is merged and this PR is retargeted to `main`
