### PR TITLE
ci: harden Common Runtime dependency gate

### DIFF
--- a/docs/internal/spec-06-common-runtime-lld.md
+++ b/docs/internal/spec-06-common-runtime-lld.md
@@ -83,7 +83,9 @@ common_runtime -> legacy core compatibility wrapper
 ```
 
 Legacy path 可以单向 re-export canonical implementation；canonical implementation 不得反向 import
-legacy path。Architecture dependency checker 持续执行 DEP-004 和 `DEP-DYNAMIC`。
+legacy path。Architecture dependency checker 持续执行 DEP-004 和 `DEP-DYNAMIC`：Common Runtime
+只能 import `souwen.common_runtime.*`，任何其他 `souwen.*` namespace 均按 DEP-004 拒绝；
+`importlib.import_module()` 与 builtin `__import__()`（含 alias）的 literal/non-literal 调用不得绕过门禁。
 
 ## 5. ACCEPT-01：Runtime source provenance
 
@@ -469,6 +471,10 @@ Rollback 恢复 legacy maps；无数据、配置或 persisted state migration。
 | VAL-CR-043 | BaseScraper 与 builtin 使用 async wrapper；取消后及 worker 返回后均无 stale request |
 | VAL-CR-044 | legacy sync exports/monkeypatch、fixture harness、IP-bound redirect security 保持 |
 | VAL-CR-045 | architecture、SSRF/Fetch regression、wheel、全量 pytest、Ruff 与 CI/V2 通过 |
+| VAL-CR-046 | Common Runtime 对 `core/delivery/server/config/registry/platform/modules/providers` 与具体 legacy client 的 direct import 全部报 DEP-004 |
+| VAL-CR-047 | `from souwen import ...` gateway alias 与 literal `importlib.import_module()` / `__import__()`（含 builtin alias）不能绕过 DEP-004 |
+| VAL-CR-048 | non-literal dynamic import 报 `DEP-DYNAMIC`；relative/self import、stdlib 与已准入第三方依赖继续允许 |
+| VAL-CR-049 | 当前 Common Runtime tree、checker fixtures、全量 pytest、Ruff、wheel 与 CI/V2 通过 |
 
 未来 conditional slice 必须各自增加 old/new parity、negative dependency、cancellation 和资源清理
 证据；不能仅以 import 成功作为退出门槛。
@@ -502,5 +508,6 @@ Rollback 恢复 legacy maps；无数据、配置或 persisted state migration。
 | CR-07 | OAuth client-credentials transport | VAL-CR-028–034；refresh/cache/cancellation/secret boundary parity |
 | CR-08 | neutral loop-local semaphore pool | VAL-CR-035–039；domain/env policy stays in legacy adapter |
 | CR-09 | async SSRF resolver wait | VAL-CR-040–045；sync truth preserved；no hard DNS cancellation claim |
+| CR-10 | Common Runtime architecture gate hardening | VAL-CR-046–049；all reverse edges and builtin dynamic import blocked |
 
-CR-02–CR-09 不能因前一切片完成而自动视为批准；每个切片都重新执行 admission test。
+CR-02–CR-10 不能因前一切片完成而自动视为批准；每个切片都重新执行 admission test。

--- a/scripts/ci/check_architecture_dependencies.py
+++ b/scripts/ci/check_architecture_dependencies.py
@@ -109,15 +109,21 @@ def _resolve_import_from(importer: str, path: Path, node: ast.ImportFrom) -> str
     return ".".join((*anchor, *([module] if module else [])))
 
 
-def _literal_import_call(node: ast.Call, importlib_names: set[str], direct_names: set[str]) -> bool:
-    function = node.func
-    if isinstance(function, ast.Name):
-        return function.id in direct_names
+def _dynamic_import_reference(
+    node: ast.expr,
+    importlib_names: set[str],
+    builtins_names: set[str],
+    direct_names: set[str],
+) -> bool:
+    if isinstance(node, ast.Name):
+        return node.id in direct_names
     return (
-        isinstance(function, ast.Attribute)
-        and function.attr == "import_module"
-        and isinstance(function.value, ast.Name)
-        and function.value.id in importlib_names
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and (
+            (node.attr == "import_module" and node.value.id in importlib_names)
+            or (node.attr == "__import__" and node.value.id in builtins_names)
+        )
     )
 
 
@@ -131,7 +137,9 @@ def _parse_imports(root: Path, path: Path) -> list[ImportEdge]:
     importer = _module_name(root, path)
     edges: list[ImportEdge] = []
     importlib_names: set[str] = set()
-    direct_import_names: set[str] = set()
+    builtins_names: set[str] = set()
+    direct_import_names: set[str] = {"__import__"}
+    import_alias_assignments: list[tuple[str, ast.expr]] = []
 
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
@@ -139,11 +147,16 @@ def _parse_imports(root: Path, path: Path) -> list[ImportEdge]:
                 edges.append(ImportEdge(relative_file, node.lineno, importer, alias.name))
                 if alias.name == "importlib" or alias.name.startswith("importlib."):
                     importlib_names.add(alias.asname or alias.name.split(".", maxsplit=1)[0])
+                if alias.name == "builtins":
+                    builtins_names.add(alias.asname or alias.name)
         elif isinstance(node, ast.ImportFrom):
             imported = _resolve_import_from(importer, path, node)
             if imported:
-                edges.append(ImportEdge(relative_file, node.lineno, importer, imported))
-                if imported in {"souwen", "souwen.server", "souwen.deploy"}:
+                gateway_aliases = imported in {"souwen", "souwen.server", "souwen.deploy"}
+                named_aliases = [alias for alias in node.names if alias.name != "*"]
+                if not gateway_aliases or not named_aliases:
+                    edges.append(ImportEdge(relative_file, node.lineno, importer, imported))
+                if gateway_aliases:
                     edges.extend(
                         ImportEdge(
                             relative_file,
@@ -151,17 +164,42 @@ def _parse_imports(root: Path, path: Path) -> list[ImportEdge]:
                             importer,
                             f"{imported}.{alias.name}",
                         )
-                        for alias in node.names
-                        if alias.name != "*"
+                        for alias in named_aliases
                     )
             if node.level == 0 and node.module == "importlib":
                 for alias in node.names:
                     if alias.name == "import_module":
                         direct_import_names.add(alias.asname or alias.name)
+            if node.level == 0 and node.module == "builtins":
+                for alias in node.names:
+                    if alias.name == "__import__":
+                        direct_import_names.add(alias.asname or alias.name)
+        elif isinstance(node, ast.Assign):
+            import_alias_assignments.extend(
+                (target.id, node.value) for target in node.targets if isinstance(target, ast.Name)
+            )
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name) and node.value:
+            import_alias_assignments.append((node.target.id, node.value))
+
+    unresolved_aliases = import_alias_assignments
+    while unresolved_aliases:
+        remaining: list[tuple[str, ast.expr]] = []
+        discovered = False
+        for target, value in unresolved_aliases:
+            if _dynamic_import_reference(
+                value, importlib_names, builtins_names, direct_import_names
+            ):
+                direct_import_names.add(target)
+                discovered = True
+            else:
+                remaining.append((target, value))
+        if not discovered:
+            break
+        unresolved_aliases = remaining
 
     for node in ast.walk(tree):
-        if not isinstance(node, ast.Call) or not _literal_import_call(
-            node, importlib_names, direct_import_names
+        if not isinstance(node, ast.Call) or not _dynamic_import_reference(
+            node.func, importlib_names, builtins_names, direct_import_names
         ):
             continue
         if (
@@ -205,8 +243,10 @@ def _rule_for(edge: ImportEdge) -> str | None:
             importer
         ) != _provider_identity(imported):
             return "DEP-003"
-    if _is_module(importer, "souwen.common_runtime") and (
-        _is_module(imported, "souwen.modules") or _is_module(imported, "souwen.providers")
+    if (
+        _is_module(importer, "souwen.common_runtime")
+        and _is_module(imported, "souwen")
+        and not _is_module(imported, "souwen.common_runtime")
     ):
         return "DEP-004"
     if _is_module(importer, "souwen.delivery.api") and _is_module(imported, "souwen.providers"):

--- a/tests/test_architecture_dependencies.py
+++ b/tests/test_architecture_dependencies.py
@@ -48,8 +48,45 @@ def test_allowed_target_edges_pass(tmp_path: Path) -> None:
         "src/souwen/providers/information_sources/openalex/adapter.py",
         "from souwen.common_runtime.transport import Client\n",
     )
+    _write(
+        root,
+        "src/souwen/common_runtime/transport/client.py",
+        "from ..security import policy\n"
+        "from souwen import common_runtime\n"
+        "import asyncio\n"
+        "import httpx\n",
+    )
 
     assert _violations(root, exceptions) == []
+
+
+@pytest.mark.parametrize(
+    "imported",
+    [
+        "souwen",
+        "souwen.core",
+        "souwen.delivery",
+        "souwen.server",
+        "souwen.config",
+        "souwen.registry",
+        "souwen.platform",
+        "souwen.modules.search",
+        "souwen.providers.information_sources.openalex",
+        "souwen.paper.openalex",
+        "souwen.web.builtin",
+    ],
+)
+def test_common_runtime_rejects_every_other_souwen_namespace(tmp_path: Path, imported: str) -> None:
+    root, exceptions = _repository(tmp_path)
+    relative_path = "src/souwen/common_runtime/transport/client.py"
+    _write(root, relative_path, f"import {imported}\n")
+
+    violations = _violations(root, exceptions)
+
+    assert [
+        (violation.rule_id, violation.file, violation.line, violation.imported)
+        for violation in violations
+    ] == [("DEP-004", relative_path, 1, imported)]
 
 
 @pytest.mark.parametrize(
@@ -168,6 +205,24 @@ def test_import_from_gateway_aliases_cannot_bypass_rules(
     ]
 
 
+def test_common_runtime_gateway_aliases_cannot_bypass_dep_004(tmp_path: Path) -> None:
+    root, exceptions = _repository(tmp_path)
+    relative_path = "src/souwen/common_runtime/transport/client.py"
+    _write(root, relative_path, "from souwen import core, config, registry, platform, server\n")
+
+    violations = _violations(root, exceptions)
+
+    assert [
+        (violation.rule_id, violation.line, violation.imported) for violation in violations
+    ] == [
+        ("DEP-004", 1, "souwen.config"),
+        ("DEP-004", 1, "souwen.core"),
+        ("DEP-004", 1, "souwen.platform"),
+        ("DEP-004", 1, "souwen.registry"),
+        ("DEP-004", 1, "souwen.server"),
+    ]
+
+
 def test_nonliteral_dynamic_import_fails_with_stable_rule_id(tmp_path: Path) -> None:
     root, exceptions = _repository(tmp_path)
     _write(
@@ -181,6 +236,62 @@ def test_nonliteral_dynamic_import_fails_with_stable_rule_id(tmp_path: Path) -> 
     assert [
         (violation.rule_id, violation.line, violation.imported) for violation in violations
     ] == [(checker.DYNAMIC_RULE_ID, 3, "<dynamic>")]
+
+
+@pytest.mark.parametrize(
+    ("source", "rule_id", "line", "imported"),
+    [
+        ('__import__("souwen.core.http_client")\n', "DEP-004", 1, "souwen.core.http_client"),
+        (
+            "module_name = 'souwen.core.http_client'\n__import__(module_name)\n",
+            "DEP-DYNAMIC",
+            2,
+            "<dynamic>",
+        ),
+        (
+            'load = __import__\nload("souwen.core.http_client")\n',
+            "DEP-004",
+            2,
+            "souwen.core.http_client",
+        ),
+        (
+            "load = __import__\nname = 'souwen.core.http_client'\nload(name)\n",
+            "DEP-DYNAMIC",
+            3,
+            "<dynamic>",
+        ),
+        (
+            'from builtins import __import__ as load\nload("souwen.core.http_client")\n',
+            "DEP-004",
+            2,
+            "souwen.core.http_client",
+        ),
+        (
+            'import builtins as runtime\nruntime.__import__("souwen.core.http_client")\n',
+            "DEP-004",
+            2,
+            "souwen.core.http_client",
+        ),
+        (
+            'load = __import__\nindirect = load\nindirect("souwen.core.http_client")\n',
+            "DEP-004",
+            3,
+            "souwen.core.http_client",
+        ),
+    ],
+)
+def test_builtin_import_cannot_bypass_architecture_rules(
+    tmp_path: Path, source: str, rule_id: str, line: int, imported: str
+) -> None:
+    root, exceptions = _repository(tmp_path)
+    relative_path = "src/souwen/common_runtime/transport/client.py"
+    _write(root, relative_path, source)
+
+    violations = _violations(root, exceptions)
+
+    assert [
+        (violation.rule_id, violation.line, violation.imported) for violation in violations
+    ] == [(rule_id, line, imported)]
 
 
 def test_platform_is_governed_for_dynamic_imports(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- enforce `DEP-004` for every `souwen.*` dependency from `souwen.common_runtime`, except `souwen.common_runtime.*` itself
- preserve relative/self, stdlib, and admitted third-party imports while expanding `from souwen import ...` gateway aliases without duplicate evidence
- detect literal and non-literal dynamic imports through `importlib.import_module`, builtin `__import__`, module aliases, direct aliases, and chained aliases
- add CR-10 and `VAL-CR-046`–`VAL-CR-049` to SPEC-06

## Validation

- exact head: `5b710ad7f085dba155340120ce9559a317a77746`
- `pytest tests/test_architecture_dependencies.py -q`: 41 passed
- `pytest tests/ -q --tb=short`: 2458 passed, 3 skipped
- `ruff check src tests scripts`: passed
- `ruff format --check src tests scripts`: 501 files already formatted
- `python3 scripts/ci/check_architecture_dependencies.py`: passed
- `python3 tools/gen_docs.py --check`: passed
- `python3 scripts/ci/check_no_legacy_terms.py`: passed with existing review warnings only
- `python3 scripts/ci/run_profile.py --profile basic-cli`: passed
- isolated wheel build, Common Runtime paths, import origin, and object identity: passed
- independent read-only review: accept
- CI run [#30069554347](https://github.com/BlueSkyXN/SouWen/actions/runs/30069554347): 29 successful jobs, aggregate successful
- V2 CI run [#30069556283](https://github.com/BlueSkyXN/SouWen/actions/runs/30069556283): 12 successful jobs, release readiness summary successful

## Stack and delivery boundary

- stacked on #203 (`codex/phase3-async-ssrf-resolver`)
- keep this PR Draft until the Phase 2/3 stack is reviewed
- stacked CI evidence does not replace required checks after eventual retarget to `main`
- no release or deployment action is included