### PR TITLE
feat(v2): 落地 P4-01 canonical provider platform

### DIFF
--- a/scripts/ci/check_architecture_dependencies.py
+++ b/scripts/ci/check_architecture_dependencies.py
@@ -224,7 +224,10 @@ def _rule_for(edge: ImportEdge) -> str | None:
     if imported == "<dynamic>":
         return DYNAMIC_RULE_ID
     if _is_module(importer, "souwen.modules"):
-        if _is_module(imported, "souwen.providers"):
+        if _is_module(imported, "souwen.providers") or (
+            _is_module(imported, "souwen.platform")
+            and not _is_module(imported, "souwen.platform.provider_spi")
+        ):
             return "DEP-001"
         if (
             _is_module(imported, "fastapi")

--- a/src/souwen/modules/fetch/api/__init__.py
+++ b/src/souwen/modules/fetch/api/__init__.py
@@ -1,3 +1,19 @@
-"""Fetch Core API. Owner: Fetch Core. Allowed dependencies: Fetch application and domain contracts."""
+"""Fetch public API. Owner: Fetch Core. Allowed dependencies: Provider SPI only."""
 
-__all__: list[str] = []
+from __future__ import annotations
+
+from typing import Protocol
+
+from souwen.platform.provider_spi import ExecutionContext, FetchBatch, FetchRequest, RequestContext
+
+
+class FetchModule(Protocol):
+    """Public asynchronous entry port for the canonical Fetch use case."""
+
+    async def fetch(
+        self, request: FetchRequest, context: RequestContext, execution: ExecutionContext
+    ) -> FetchBatch:
+        """Execute Fetch without exposing a concrete provider."""
+
+
+__all__ = ["FetchBatch", "FetchModule", "FetchRequest"]

--- a/src/souwen/modules/llm_search/api/__init__.py
+++ b/src/souwen/modules/llm_search/api/__init__.py
@@ -1,3 +1,24 @@
-"""LLM Search Core API. Owner: LLM Search Core. Allowed dependencies: LLM Search application and domain contracts."""
+"""LLM Search public API. Owner: LLM Search Core. Allowed dependencies: Provider SPI only."""
 
-__all__: list[str] = []
+from __future__ import annotations
+
+from typing import Protocol
+
+from souwen.platform.provider_spi import (
+    ExecutionContext,
+    LLMSearchRequest,
+    LLMSearchResult,
+    RequestContext,
+)
+
+
+class LLMSearchModule(Protocol):
+    """Public asynchronous entry port for canonical LLM Search."""
+
+    async def search(
+        self, request: LLMSearchRequest, context: RequestContext, execution: ExecutionContext
+    ) -> LLMSearchResult:
+        """Execute LLM Search without exposing a concrete provider."""
+
+
+__all__ = ["LLMSearchModule", "LLMSearchRequest", "LLMSearchResult"]

--- a/src/souwen/modules/search/api/__init__.py
+++ b/src/souwen/modules/search/api/__init__.py
@@ -1,3 +1,19 @@
-"""Search Core API. Owner: Search Core. Allowed dependencies: Search application and domain contracts."""
+"""Search public API. Owner: Search Core. Allowed dependencies: Provider SPI only."""
 
-__all__: list[str] = []
+from __future__ import annotations
+
+from typing import Protocol
+
+from souwen.platform.provider_spi import ExecutionContext, RequestContext, SearchPage, SearchRequest
+
+
+class SearchModule(Protocol):
+    """Public asynchronous entry port for the canonical Search use case."""
+
+    async def search(
+        self, request: SearchRequest, context: RequestContext, execution: ExecutionContext
+    ) -> SearchPage:
+        """Execute Search without exposing a concrete provider."""
+
+
+__all__ = ["SearchModule", "SearchPage", "SearchRequest"]

--- a/src/souwen/platform/manifest_registry/__init__.py
+++ b/src/souwen/platform/manifest_registry/__init__.py
@@ -1,3 +1,12 @@
 """Manifest registry boundary. Owner: Platform. Allowed dependencies: contracts and Platform metadata only."""
 
-__all__: list[str] = []
+from .models import AdapterDeclaration, ProviderManifest
+from .registry import ManifestDiagnostic, ManifestRegistration, ManifestRegistry
+
+__all__ = [
+    "AdapterDeclaration",
+    "ManifestDiagnostic",
+    "ManifestRegistration",
+    "ManifestRegistry",
+    "ProviderManifest",
+]

--- a/src/souwen/platform/manifest_registry/models.py
+++ b/src/souwen/platform/manifest_registry/models.py
@@ -1,0 +1,159 @@
+"""Strict, static Provider v2 manifest declarations.
+
+This module validates package metadata only.  It deliberately has no provider
+imports, resolver calls, or executable loading hooks.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Annotated, Literal
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StrictBool,
+    StrictStr,
+    StringConstraints,
+    model_validator,
+)
+
+
+_ID = re.compile(r"^[a-z][a-z0-9_-]{0,127}$")
+_SCHEMA_ID = re.compile(r"^[a-z][a-z0-9-]{0,127}$")
+_SECRET_REFERENCE = re.compile(r"^[A-Z][A-Z0-9_]{0,127}$")
+_HOST = re.compile(r"^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)(?:\.[a-z0-9-]+)+$")
+_VERSION = re.compile(r"^\d+\.\d+\.\d+(?:(?:a|b|rc)\d+|[-+][0-9A-Za-z.-]+)?$")
+
+StableId = Annotated[StrictStr, StringConstraints(pattern=_ID.pattern)]
+SchemaId = Annotated[StrictStr, StringConstraints(pattern=_SCHEMA_ID.pattern)]
+SecretReference = Annotated[StrictStr, StringConstraints(pattern=_SECRET_REFERENCE.pattern)]
+Host = Annotated[StrictStr, StringConstraints(pattern=_HOST.pattern)]
+Version = Annotated[StrictStr, StringConstraints(pattern=_VERSION.pattern)]
+CapabilityName = Literal["search", "llm_search", "fetch"]
+
+
+class _StrictManifestModel(BaseModel):
+    """Base model that rejects unreviewed manifest topology and metadata."""
+
+    # JSON arrays must remain valid manifest input; scalar fields are strict by
+    # annotation while `extra="forbid"` keeps declaration topology closed.
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class AdapterDeclaration(_StrictManifestModel):
+    """One exported adapter and exactly one target SPI capability."""
+
+    id: StableId
+    capability: CapabilityName
+    export: Annotated[StrictStr, StringConstraints(pattern=r"^[A-Z][A-Za-z0-9_]{0,127}$")]
+    availability: Literal["always", "configured"]
+
+
+class ConfigurationDeclaration(_StrictManifestModel):
+    """Non-secret configuration shape declared by a provider package."""
+
+    schema_reference: SchemaId
+    unknown_key_policy: Literal["reject"]
+    non_secret_keys: tuple[StableId, ...] = ()
+
+    @model_validator(mode="after")
+    def _no_duplicate_or_secret_like_keys(self) -> "ConfigurationDeclaration":
+        if len(set(self.non_secret_keys)) != len(self.non_secret_keys):
+            raise ValueError("duplicate non-secret configuration key")
+        secret_words = {"auth", "cookie", "credential", "key", "password", "secret", "token"}
+        if any(secret_words.intersection(re.split(r"[-_]", key)) for key in self.non_secret_keys):
+            raise ValueError("secret-like configuration key")
+        return self
+
+
+class SecretsDeclaration(_StrictManifestModel):
+    """Reference names only; this type intentionally has no value field."""
+
+    references: tuple[SecretReference, ...] = ()
+
+    @model_validator(mode="after")
+    def _no_duplicate_references(self) -> "SecretsDeclaration":
+        if len(set(self.references)) != len(self.references):
+            raise ValueError("duplicate secret reference")
+        return self
+
+
+class NetworkDeclaration(_StrictManifestModel):
+    """Reviewed network metadata, never a credential-bearing URL."""
+
+    egress_hosts: tuple[Host, ...] = ()
+    proxy_supported: StrictBool
+    browser_required: StrictBool
+
+    @model_validator(mode="after")
+    def _no_duplicate_hosts(self) -> "NetworkDeclaration":
+        if len(set(self.egress_hosts)) != len(self.egress_hosts):
+            raise ValueError("duplicate egress host")
+        return self
+
+
+class RiskDeclaration(_StrictManifestModel):
+    authenticated: StrictBool
+    costed: StrictBool
+
+
+class ObservabilityDeclaration(_StrictManifestModel):
+    dimensions: tuple[StableId, ...]
+
+    @model_validator(mode="after")
+    def _dimensions_are_unique_and_bounded(self) -> "ObservabilityDeclaration":
+        if not self.dimensions or len(set(self.dimensions)) != len(self.dimensions):
+            raise ValueError("invalid observability dimensions")
+        return self
+
+
+class CompatibilityDeclaration(_StrictManifestModel):
+    contract_versions: tuple[Literal["provider-v2"], ...]
+    config_schema_versions: tuple[SchemaId, ...]
+
+    @model_validator(mode="after")
+    def _ranges_are_nonempty_and_unique(self) -> "CompatibilityDeclaration":
+        if not self.contract_versions or not self.config_schema_versions:
+            raise ValueError("empty compatibility declaration")
+        if len(set(self.contract_versions)) != len(self.contract_versions):
+            raise ValueError("duplicate contract compatibility")
+        if len(set(self.config_schema_versions)) != len(self.config_schema_versions):
+            raise ValueError("duplicate config schema compatibility")
+        return self
+
+
+class ProviderManifest(_StrictManifestModel):
+    """Validated, non-executable Provider Extension v2 declaration."""
+
+    schema_version: Literal[2]
+    id: StableId
+    version: Version
+    contract_version: Literal["provider-v2"]
+    capabilities: tuple[CapabilityName, ...] = Field(min_length=1)
+    adapters: tuple[AdapterDeclaration, ...] = Field(min_length=1)
+    configuration: ConfigurationDeclaration
+    secrets: SecretsDeclaration
+    network: NetworkDeclaration
+    risk: RiskDeclaration
+    observability: ObservabilityDeclaration
+    compatibility: CompatibilityDeclaration
+
+    @model_validator(mode="after")
+    def _validate_topology_and_compatibility(self) -> "ProviderManifest":
+        if len(set(self.capabilities)) != len(self.capabilities):
+            raise ValueError("duplicate capability")
+        adapter_ids = tuple(adapter.id for adapter in self.adapters)
+        if len(set(adapter_ids)) != len(adapter_ids):
+            raise ValueError("duplicate adapter")
+        adapter_capabilities = tuple(adapter.capability for adapter in self.adapters)
+        if len(set(adapter_capabilities)) != len(adapter_capabilities):
+            raise ValueError("duplicate adapter capability")
+        if set(adapter_capabilities) != set(self.capabilities):
+            raise ValueError("capability and adapter parity mismatch")
+        if self.contract_version not in self.compatibility.contract_versions:
+            raise ValueError("incompatible contract version")
+        if self.configuration.schema_reference not in self.compatibility.config_schema_versions:
+            raise ValueError("incompatible configuration schema")
+        return self

--- a/src/souwen/platform/manifest_registry/registry.py
+++ b/src/souwen/platform/manifest_registry/registry.py
@@ -1,0 +1,134 @@
+"""Transactional in-memory registry for validated static manifest declarations."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import ValidationError
+
+from .models import AdapterDeclaration, ProviderManifest
+
+
+SAFE_REASON_CODES = frozenset(
+    {
+        "manifest_invalid",
+        "duplicate_package",
+        "duplicate_adapter",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ManifestDiagnostic:
+    """A bounded diagnostic that deliberately excludes validation details."""
+
+    reason_code: str
+    package_id: str | None = None
+    adapter_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ManifestRegistration:
+    """The result of a static declaration registration attempt."""
+
+    manifest: ProviderManifest | None
+    diagnostic: ManifestDiagnostic | None
+
+    @property
+    def accepted(self) -> bool:
+        return self.manifest is not None
+
+
+class ManifestRegistry:
+    """Store validated metadata without importing or constructing providers."""
+
+    def __init__(self) -> None:
+        self._packages: dict[str, ProviderManifest] = {}
+        self._adapters: dict[str, tuple[str, AdapterDeclaration]] = {}
+        self._diagnostics: list[ManifestDiagnostic] = []
+
+    def register(self, declaration: ProviderManifest | Mapping[str, Any]) -> ManifestRegistration:
+        """Validate then atomically add one package, quarantining only a new failure."""
+        raw_package_id = _safe_package_id(declaration)
+        try:
+            manifest = (
+                declaration
+                if isinstance(declaration, ProviderManifest)
+                else ProviderManifest.model_validate(declaration)
+            )
+        except (TypeError, ValidationError):
+            return self._quarantine("manifest_invalid", package_id=raw_package_id)
+
+        if manifest.id in self._packages:
+            return self._quarantine("duplicate_package", package_id=manifest.id)
+
+        duplicate = next(
+            (adapter for adapter in manifest.adapters if adapter.id in self._adapters), None
+        )
+        if duplicate is not None:
+            return self._quarantine(
+                "duplicate_adapter",
+                package_id=manifest.id,
+                adapter_id=duplicate.id,
+            )
+
+        # Every duplicate check ran before either index is mutated.
+        self._packages[manifest.id] = manifest
+        for adapter in manifest.adapters:
+            self._adapters[adapter.id] = (manifest.id, adapter)
+        return ManifestRegistration(manifest=manifest, diagnostic=None)
+
+    def discover(
+        self, declarations: Iterable[ProviderManifest | Mapping[str, Any]]
+    ) -> tuple[ManifestRegistration, ...]:
+        """Register each supplied declaration independently and without loading code."""
+        return tuple(self.register(declaration) for declaration in declarations)
+
+    def package(self, package_id: str) -> ProviderManifest | None:
+        """Return a registered package declaration by stable package ID."""
+        return self._packages.get(package_id)
+
+    def adapter(self, adapter_id: str) -> tuple[ProviderManifest, AdapterDeclaration] | None:
+        """Return a static adapter declaration and its owning package."""
+        item = self._adapters.get(adapter_id)
+        if item is None:
+            return None
+        package_id, adapter = item
+        return self._packages[package_id], adapter
+
+    @property
+    def packages(self) -> tuple[ProviderManifest, ...]:
+        return tuple(self._packages.values())
+
+    @property
+    def diagnostics(self) -> tuple[ManifestDiagnostic, ...]:
+        return tuple(self._diagnostics)
+
+    def _quarantine(
+        self,
+        reason_code: str,
+        *,
+        package_id: str | None = None,
+        adapter_id: str | None = None,
+    ) -> ManifestRegistration:
+        if reason_code not in SAFE_REASON_CODES:
+            raise ValueError("unsupported manifest diagnostic code")
+        diagnostic = ManifestDiagnostic(reason_code, package_id, adapter_id)
+        self._diagnostics.append(diagnostic)
+        return ManifestRegistration(manifest=None, diagnostic=diagnostic)
+
+
+def _safe_package_id(declaration: ProviderManifest | Mapping[str, Any]) -> str | None:
+    """Retain only an identifier that already satisfies the manifest ID shape."""
+    candidate = (
+        declaration.id if isinstance(declaration, ProviderManifest) else declaration.get("id")
+    )
+    if isinstance(candidate, str) and 0 < len(candidate) <= 128:
+        alphabet = "abcdefghijklmnopqrstuvwxyz0123456789_-"
+        if candidate[0] in "abcdefghijklmnopqrstuvwxyz" and all(
+            char in alphabet for char in candidate
+        ):
+            return candidate
+    return None

--- a/src/souwen/platform/provider_manager/__init__.py
+++ b/src/souwen/platform/provider_manager/__init__.py
@@ -1,3 +1,10 @@
 """Provider assembly boundary. Owner: Platform. Allowed dependencies: SPI, manifest registry, and provider factories."""
 
-__all__: list[str] = []
+from .manager import FactoryRegistration, ProviderDiagnostic, ProviderManager, ProviderManagerError
+
+__all__ = [
+    "FactoryRegistration",
+    "ProviderDiagnostic",
+    "ProviderManager",
+    "ProviderManagerError",
+]

--- a/src/souwen/platform/provider_manager/manager.py
+++ b/src/souwen/platform/provider_manager/manager.py
@@ -1,0 +1,537 @@
+"""Explicit, lazy assembly for already-declared Provider v2 adapters.
+
+The manager never imports provider modules by name.  A composition root must
+register a factory and its concrete provider type explicitly before discovery.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import time
+from collections.abc import Awaitable, Callable, Iterable, Mapping
+from contextlib import suppress
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from souwen.common_runtime.resilience.concurrency import LoopLocalSemaphorePool
+from souwen.platform.manifest_registry.models import AdapterDeclaration, ProviderManifest
+from souwen.platform.manifest_registry.registry import ManifestRegistration, ManifestRegistry
+from souwen.platform.provider_spi import (
+    Capability,
+    ExecutionContext,
+    FetchResult,
+    FetchTargetRequest,
+    LLMSearchRequest,
+    LLMSearchResult,
+    ProviderError,
+    ProviderErrorCode,
+    ProviderProbe,
+    RequestContext,
+    SearchPage,
+    SearchRequest,
+)
+
+
+class ProviderFactory(Protocol):
+    """Construct one adapter from its already-resolved local inputs."""
+
+    def __call__(self, configuration: Mapping[str, Any], secrets: Mapping[str, str]) -> Any: ...
+
+
+ConfigResolver = Callable[[ProviderManifest], Mapping[str, Any]]
+SecretResolver = Callable[[ProviderManifest, tuple[str, ...]], Mapping[str, str]]
+SchemaValidator = Callable[[ProviderManifest, Mapping[str, Any]], Mapping[str, Any]]
+
+_SAFE_MANAGER_CODES = frozenset(
+    {
+        "adapter_not_registered",
+        "adapter_not_eligible",
+        "adapter_quarantined",
+        "config_invalid",
+        "secret_unavailable",
+        "factory_missing",
+        "factory_export_mismatch",
+        "factory_capability_mismatch",
+        "factory_spi_mismatch",
+        "factory_failed",
+        "execution_context_required",
+        "invalid_request_context",
+        "invalid_execution_context",
+        "invalid_request",
+        "invalid_provider_result",
+        "invalid_probe_result",
+        "provider_failed",
+        "probe_failed",
+        "close_failed",
+    }
+)
+
+
+class ProviderManagerError(RuntimeError):
+    """Bounded runtime error that intentionally has no upstream exception text."""
+
+    def __init__(self, code: str) -> None:
+        if code not in _SAFE_MANAGER_CODES:
+            raise ValueError("unsupported provider manager error code")
+        self.code = code
+        super().__init__(code)
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderDiagnostic:
+    """Safe, bounded lifecycle diagnostic without config, secret, or exception data."""
+
+    reason_code: str
+    package_id: str
+    adapter_id: str
+    capability: str
+
+
+@dataclass(frozen=True, slots=True)
+class FactoryRegistration:
+    """An explicit factory declaration; provider_type enables static preflight."""
+
+    package_id: str
+    export: str
+    factory: ProviderFactory
+    provider_type: type[Any] | None = None
+
+
+@dataclass(slots=True)
+class _AdapterRuntime:
+    manifest: ProviderManifest
+    adapter: AdapterDeclaration
+    configuration: Mapping[str, Any]
+    secrets: Mapping[str, str]
+    factory: ProviderFactory
+    provider_type: type[Any]
+    semaphore_pool: LoopLocalSemaphorePool = field(default_factory=LoopLocalSemaphorePool)
+    instance: Any | None = None
+    closed: bool = False
+    quarantined: bool = False
+
+
+class ProviderManager:
+    """Manage v2 provider eligibility, lazy instances, and provider-local faults."""
+
+    def __init__(
+        self,
+        registry: ManifestRegistry | None = None,
+        *,
+        config_resolver: ConfigResolver | None = None,
+        secret_resolver: SecretResolver | None = None,
+        schema_validator: SchemaValidator | None = None,
+    ) -> None:
+        self.registry = registry or ManifestRegistry()
+        self._config_resolver = config_resolver or _default_config_resolver
+        self._secret_resolver = secret_resolver or _default_secret_resolver
+        self._schema_validator = schema_validator or _default_schema_validator
+        self._factories: dict[tuple[str, str], FactoryRegistration] = {}
+        self._runtimes: dict[str, _AdapterRuntime] = {}
+        self._diagnostics: list[ProviderDiagnostic] = []
+
+    def register_factory(
+        self,
+        *,
+        package_id: str,
+        export: str,
+        factory: ProviderFactory,
+        provider_type: type[Any] | None = None,
+    ) -> None:
+        """Add a factory explicitly; this intentionally accepts no module path."""
+        if not callable(factory):
+            raise TypeError("factory must be callable")
+        self._factories[(package_id, export)] = FactoryRegistration(
+            package_id=package_id,
+            export=export,
+            factory=factory,
+            provider_type=provider_type,
+        )
+
+    def discover(
+        self, declarations: Iterable[ProviderManifest | Mapping[str, Any]]
+    ) -> tuple[ManifestRegistration, ...]:
+        """Statically register then preflight eligibility without creating an instance."""
+        registrations = self.registry.discover(declarations)
+        for registration in registrations:
+            if registration.manifest is not None:
+                self._preflight_manifest(registration.manifest)
+        return registrations
+
+    def preflight_registered(self) -> None:
+        """Re-evaluate static packages after an explicit factory registration change."""
+        for manifest in self.registry.packages:
+            self._preflight_manifest(manifest)
+
+    async def execute(
+        self,
+        adapter_id: str,
+        request: Any,
+        request_context: Any,
+        execution: Any,
+        *,
+        timeout: float | None = None,
+    ) -> Any:
+        """Lazily create and execute a declared adapter under its loop-local limit."""
+        runtime = self._runtime_for(adapter_id)
+        _validate_execution_inputs(runtime.adapter.capability, request, request_context, execution)
+        self._raise_if_cancelled(execution)
+        provider = self._instance_for(runtime)
+        timeout = _execution_timeout(execution, timeout)
+        try:
+            async with runtime.semaphore_pool.get(10):
+                self._raise_if_cancelled(execution)
+                call = _provider_call(
+                    provider,
+                    runtime.adapter.capability,
+                    request,
+                    request_context,
+                    execution,
+                )
+                result = await _await_with_execution(call, execution, timeout)
+                if not _provider_result_matches(
+                    runtime.adapter.capability, request, request_context, result
+                ):
+                    await self._quarantine(runtime, "invalid_provider_result")
+                    raise ProviderManagerError("invalid_provider_result")
+                return result
+        except asyncio.CancelledError:
+            raise
+        except ProviderError:
+            raise
+        except TimeoutError as exc:
+            raise ProviderError(ProviderErrorCode.DEADLINE_EXCEEDED) from exc
+        except ProviderManagerError:
+            raise
+        except Exception as exc:
+            await self._quarantine(runtime, "provider_failed")
+            raise ProviderManagerError("provider_failed") from exc
+
+    async def probe(self, adapter_id: str, execution: Any, *, timeout: float | None = None) -> Any:
+        """Explicitly probe one eligible adapter without changing its eligibility."""
+        runtime = self._runtime_for(adapter_id)
+        if not isinstance(execution, ExecutionContext):
+            raise ProviderManagerError("invalid_execution_context")
+        self._raise_if_cancelled(execution)
+        provider = self._instance_for(runtime)
+        timeout = _execution_timeout(execution, timeout)
+        try:
+            async with runtime.semaphore_pool.get(10):
+                result = await _await_with_execution(provider.probe(execution), execution, timeout)
+                if (
+                    not isinstance(result, ProviderProbe)
+                    or result.capability != runtime.adapter.capability
+                ):
+                    await self._quarantine(runtime, "invalid_probe_result")
+                    raise ProviderManagerError("invalid_probe_result")
+                return result
+        except asyncio.CancelledError:
+            raise
+        except ProviderError:
+            raise
+        except TimeoutError as exc:
+            raise ProviderError(ProviderErrorCode.DEADLINE_EXCEEDED) from exc
+        except ProviderManagerError:
+            raise
+        except Exception as exc:
+            await self._quarantine(runtime, "probe_failed")
+            raise ProviderManagerError("probe_failed") from exc
+
+    async def close(self, adapter_id: str) -> None:
+        """Close one owned adapter at most once; unrelated adapters remain active."""
+        runtime = self._runtimes.get(adapter_id)
+        if runtime is None or runtime.closed:
+            return
+        runtime.closed = True
+        if runtime.instance is None:
+            return
+        try:
+            result = runtime.instance.close()
+            if inspect.isawaitable(result):
+                await result
+        except asyncio.CancelledError:
+            runtime.closed = False
+            raise
+        except Exception as exc:
+            self._diagnose(runtime, "close_failed")
+            raise ProviderManagerError("close_failed") from exc
+
+    async def close_all(self) -> None:
+        """Close every created adapter, preserving the first safe failure."""
+        failure: ProviderManagerError | None = None
+        for adapter_id in tuple(self._runtimes):
+            try:
+                await self.close(adapter_id)
+            except ProviderManagerError as exc:
+                if failure is None:
+                    failure = exc
+        if failure is not None:
+            raise failure
+
+    @property
+    def diagnostics(self) -> tuple[ProviderDiagnostic, ...]:
+        return tuple(self._diagnostics)
+
+    @property
+    def eligible_adapter_ids(self) -> tuple[str, ...]:
+        return tuple(self._runtimes)
+
+    def _preflight_manifest(self, manifest: ProviderManifest) -> None:
+        """Resolve local inputs and inspect exports, but do not call provider factories."""
+        for adapter in manifest.adapters:
+            runtime = self._preflight_adapter(manifest, adapter)
+            if runtime is not None:
+                self._runtimes[adapter.id] = runtime
+
+    def _preflight_adapter(
+        self, manifest: ProviderManifest, adapter: AdapterDeclaration
+    ) -> _AdapterRuntime | None:
+        factory_registration = self._factories.get((manifest.id, adapter.export))
+        if factory_registration is None:
+            self._diagnose_declaration(manifest, adapter, "factory_missing")
+            return None
+        provider_type = _provider_type(factory_registration)
+        if provider_type is None or provider_type.__name__ != adapter.export:
+            self._diagnose_declaration(manifest, adapter, "factory_export_mismatch")
+            return None
+        capability = _capability_name(getattr(provider_type, "capability", None))
+        if capability != adapter.capability:
+            self._diagnose_declaration(manifest, adapter, "factory_capability_mismatch")
+            return None
+        capability_method = "fetch" if adapter.capability == "fetch" else "search"
+        if not all(
+            callable(getattr(provider_type, name, None))
+            for name in (capability_method, "probe", "close")
+        ):
+            self._diagnose_declaration(manifest, adapter, "factory_spi_mismatch")
+            return None
+        try:
+            configuration = self._schema_validator(manifest, self._config_resolver(manifest))
+        except Exception:
+            self._diagnose_declaration(manifest, adapter, "config_invalid")
+            return None
+        try:
+            secrets = self._secret_resolver(manifest, manifest.secrets.references)
+        except Exception:
+            self._diagnose_declaration(manifest, adapter, "secret_unavailable")
+            return None
+        if not isinstance(configuration, Mapping):
+            self._diagnose_declaration(manifest, adapter, "config_invalid")
+            return None
+        if not isinstance(secrets, Mapping) or not _has_declared_secrets(manifest, secrets):
+            self._diagnose_declaration(manifest, adapter, "secret_unavailable")
+            return None
+        return _AdapterRuntime(
+            manifest=manifest,
+            adapter=adapter,
+            configuration=dict(configuration),
+            secrets=dict(secrets),
+            factory=factory_registration.factory,
+            provider_type=provider_type,
+        )
+
+    def _runtime_for(self, adapter_id: str) -> _AdapterRuntime:
+        static = self.registry.adapter(adapter_id)
+        if static is None:
+            raise ProviderManagerError("adapter_not_registered")
+        runtime = self._runtimes.get(adapter_id)
+        if runtime is None:
+            raise ProviderManagerError("adapter_not_eligible")
+        if runtime.quarantined:
+            raise ProviderManagerError("adapter_quarantined")
+        if runtime.closed:
+            raise ProviderManagerError("adapter_quarantined")
+        return runtime
+
+    def _instance_for(self, runtime: _AdapterRuntime) -> Any:
+        if runtime.instance is not None:
+            return runtime.instance
+        try:
+            instance = runtime.factory(runtime.configuration, runtime.secrets)
+        except Exception as exc:
+            runtime.quarantined = True
+            self._diagnose(runtime, "factory_failed")
+            raise ProviderManagerError("factory_failed") from exc
+        if not isinstance(instance, runtime.provider_type):
+            runtime.quarantined = True
+            self._diagnose(runtime, "factory_spi_mismatch")
+            raise ProviderManagerError("factory_spi_mismatch")
+        runtime.instance = instance
+        return instance
+
+    async def _quarantine(self, runtime: _AdapterRuntime, reason_code: str) -> None:
+        runtime.quarantined = True
+        self._diagnose(runtime, reason_code)
+        try:
+            await self.close(runtime.adapter.id)
+        except ProviderManagerError:
+            pass
+
+    def _diagnose(self, runtime: _AdapterRuntime, reason_code: str) -> None:
+        self._diagnose_declaration(runtime.manifest, runtime.adapter, reason_code)
+
+    def _diagnose_declaration(
+        self, manifest: ProviderManifest, adapter: AdapterDeclaration, reason_code: str
+    ) -> None:
+        if reason_code not in _SAFE_MANAGER_CODES:
+            raise ValueError("unsupported provider manager diagnostic code")
+        self._diagnostics.append(
+            ProviderDiagnostic(reason_code, manifest.id, adapter.id, adapter.capability)
+        )
+
+    @staticmethod
+    def _raise_if_cancelled(context: Any) -> None:
+        raise_if_cancelled = getattr(context, "raise_if_cancelled_or_expired", None)
+        if callable(raise_if_cancelled):
+            raise_if_cancelled()
+        if _is_cancelled(context):
+            raise ProviderError(ProviderErrorCode.CANCELLED)
+
+
+def _provider_type(registration: FactoryRegistration) -> type[Any] | None:
+    if registration.provider_type is not None:
+        return registration.provider_type
+    if isinstance(registration.factory, type):
+        return registration.factory
+    candidate = getattr(registration.factory, "provider_type", None)
+    return candidate if isinstance(candidate, type) else None
+
+
+def _capability_name(value: Any) -> Capability | None:
+    candidate = getattr(value, "value", value)
+    return candidate if candidate in {"search", "llm_search", "fetch"} else None
+
+
+def _default_config_resolver(_manifest: ProviderManifest) -> Mapping[str, Any]:
+    return {}
+
+
+def _default_secret_resolver(
+    _manifest: ProviderManifest, _references: tuple[str, ...]
+) -> Mapping[str, str]:
+    return {}
+
+
+def _default_schema_validator(
+    manifest: ProviderManifest, configuration: Mapping[str, Any]
+) -> Mapping[str, Any]:
+    if not isinstance(configuration, Mapping):
+        raise TypeError("provider configuration must be a mapping")
+    if manifest.configuration.unknown_key_policy == "reject":
+        unknown = set(configuration).difference(manifest.configuration.non_secret_keys)
+        if unknown:
+            raise ValueError("unknown provider configuration key")
+    return configuration
+
+
+def _has_declared_secrets(manifest: ProviderManifest, secrets: Mapping[str, str]) -> bool:
+    """Require each declared reference to resolve to a non-empty string value."""
+    return all(
+        isinstance(secrets.get(reference), str) and bool(secrets[reference])
+        for reference in manifest.secrets.references
+    )
+
+
+def _validate_execution_inputs(
+    capability: Capability,
+    request: Any,
+    request_context: Any,
+    execution: Any,
+) -> None:
+    """Reject non-canonical call inputs before provider construction or invocation."""
+    if not isinstance(request_context, RequestContext):
+        raise ProviderManagerError("invalid_request_context")
+    if not isinstance(execution, ExecutionContext):
+        raise ProviderManagerError("invalid_execution_context")
+    expected_type = (
+        FetchTargetRequest
+        if capability == "fetch"
+        else (LLMSearchRequest if capability == "llm_search" else SearchRequest)
+    )
+    if not isinstance(request, expected_type):
+        raise ProviderManagerError("invalid_request")
+
+
+def _is_cancelled(context: Any) -> bool:
+    value = getattr(context, "cancelled", False)
+    if callable(value):
+        value = value()
+    if hasattr(value, "is_set"):
+        value = value.is_set()
+    return bool(value)
+
+
+def _execution_timeout(context: Any, explicit_timeout: float | None) -> float | None:
+    """Use the shortest explicit or monotonic deadline without exposing it in diagnostics."""
+    candidates = [timeout for timeout in (explicit_timeout,) if timeout is not None]
+    deadline = getattr(context, "deadline_monotonic", getattr(context, "deadline", None))
+    if isinstance(deadline, (int, float)) and not isinstance(deadline, bool):
+        candidates.append(max(0.0, float(deadline) - time.monotonic()))
+    if not candidates:
+        return None
+    timeout = min(candidates)
+    if timeout < 0:
+        raise ProviderError(ProviderErrorCode.DEADLINE_EXCEEDED)
+    return timeout
+
+
+async def _await_with_execution(
+    value: Awaitable[Any], execution: ExecutionContext, timeout: float | None
+) -> Any:
+    """Bound a provider awaitable by both deadline and live cancellation signal."""
+    provider_task = asyncio.ensure_future(value)
+    cancellation_task = asyncio.create_task(execution.cancel_event.wait())
+    try:
+        done, _pending = await asyncio.wait(
+            {provider_task, cancellation_task},
+            timeout=timeout,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if provider_task in done:
+            return await provider_task
+
+        provider_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await provider_task
+        code = (
+            ProviderErrorCode.CANCELLED
+            if cancellation_task in done
+            else ProviderErrorCode.DEADLINE_EXCEEDED
+        )
+        raise ProviderError(code)
+    finally:
+        cancellation_task.cancel()
+        if not provider_task.done():
+            provider_task.cancel()
+        await asyncio.gather(provider_task, cancellation_task, return_exceptions=True)
+
+
+def _provider_call(
+    provider: Any,
+    capability: str,
+    request: Any,
+    request_context: Any,
+    execution: Any,
+) -> Awaitable[Any]:
+    """Dispatch exactly one declared SPI capability; no provider cross-call is possible."""
+    method = provider.fetch if capability == "fetch" else provider.search
+    return method(request, request_context, execution)
+
+
+def _provider_result_matches(
+    capability: Capability,
+    request: SearchRequest | LLMSearchRequest | FetchTargetRequest,
+    request_context: RequestContext,
+    result: Any,
+) -> bool:
+    """Reject raw or capability-mismatched provider output at the assembly boundary."""
+    if capability == "fetch":
+        return (
+            isinstance(request, FetchTargetRequest)
+            and isinstance(result, FetchResult)
+            and str(result.target) == str(request.target)
+        )
+    if capability == "llm_search":
+        return isinstance(result, LLMSearchResult) and result.context == request_context
+    return isinstance(result, SearchPage) and result.context == request_context

--- a/src/souwen/platform/provider_spi/contracts.py
+++ b/src/souwen/platform/provider_spi/contracts.py
@@ -1,4 +1,8 @@
-"""Provider SPI boundary. Owner: Platform. Allowed dependencies: contracts and common runtime only."""
+"""Public canonical DTO binding for the Provider SPI.
+
+The implementation lives in :mod:`dto`; this stable import module names the
+contract boundary without coupling callers to any provider implementation.
+"""
 
 from souwen.platform.provider_spi.dto import (
     Capability,
@@ -41,9 +45,6 @@ from souwen.platform.provider_spi.dto import (
     Usage,
     UsageMetadata,
 )
-from souwen.platform.provider_spi.errors import ProviderError, ProviderErrorCode
-from souwen.platform.provider_spi.execution import ExecutionContext, MAX_EXECUTION_SECONDS
-from souwen.platform.provider_spi.protocols import FetchProvider, LLMSearchProvider, SearchProvider
 
 __all__ = [
     "Capability",
@@ -54,26 +55,20 @@ __all__ = [
     "ErrorDetail",
     "ErrorResponse",
     "EvidenceItem",
-    "ExecutionContext",
     "FetchBatch",
     "FetchContentOptions",
     "FetchMeta",
     "FetchPolicyOptions",
-    "FetchProvider",
     "FetchRequest",
     "FetchResult",
     "FetchStrategy",
     "FetchTargetRequest",
     "LLMFetchOptions",
     "LLMSearchBudget",
-    "LLMSearchProvider",
     "LLMSearchRequest",
     "LLMSearchResult",
     "LLMSearchStrategy",
-    "MAX_EXECUTION_SECONDS",
     "PageInfo",
-    "ProviderError",
-    "ProviderErrorCode",
     "ProviderFailure",
     "ProviderProbe",
     "ProviderProvenance",
@@ -88,7 +83,6 @@ __all__ = [
     "SearchMeta",
     "SearchPage",
     "SearchPageRequest",
-    "SearchProvider",
     "SearchRequest",
     "Usage",
     "UsageMetadata",

--- a/src/souwen/platform/provider_spi/dto.py
+++ b/src/souwen/platform/provider_spi/dto.py
@@ -1,0 +1,495 @@
+"""Canonical provider-facing DTOs for the target External Data API.
+
+These bindings are transport-neutral. They are shared by Core modules and
+provider adapters, but do not import concrete providers or delivery frameworks.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+import re
+from typing import Literal, TypeAlias
+
+from pydantic import AnyHttpUrl, BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+class CanonicalModel(BaseModel):
+    """Immutable, strict base for target canonical DTOs."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, hide_input_in_errors=True)
+
+
+class RequestContext(CanonicalModel):
+    """Correlation data carried by every canonical response."""
+
+    request_id: str = Field(min_length=1, max_length=128)
+    api_major: Literal[2] = 2
+    trace_id: str | None = Field(default=None, min_length=1, max_length=128)
+
+
+class ProviderRef(CanonicalModel):
+    """A public, stable provider identity; never a model, URL, or secret reference."""
+
+    id: str = Field(min_length=1, max_length=128, pattern=r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+    kind: Capability
+    display_name: str | None = Field(default=None, min_length=1, max_length=256)
+
+
+class Provenance(CanonicalModel):
+    """Safe public provenance for one canonical result."""
+
+    provider: str = Field(min_length=1, max_length=128)
+    attempt: int | None = Field(default=None, ge=1)
+    outcome: Literal["success", "empty", "failed"]
+    retrieved_at: datetime | None = None
+
+
+ProviderProvenance = Provenance
+
+
+class PageInfo(CanonicalModel):
+    """Opaque continuation information for a canonical page."""
+
+    limit: int = Field(ge=1, le=100)
+    next_cursor: str | None = Field(default=None, min_length=1, max_length=2048)
+    total: int | None = Field(default=None, ge=0)
+
+
+class Usage(CanonicalModel):
+    """Provider-reported usage only; unknown values are represented by ``None``."""
+
+    input_tokens: int | None = Field(default=None, ge=0)
+    output_tokens: int | None = Field(default=None, ge=0)
+    cost: float | None = Field(default=None, ge=0)
+    currency: str | None = Field(default=None, min_length=1, max_length=16)
+
+    @model_validator(mode="after")
+    def _cost_and_currency_are_reported_together(self) -> Usage:
+        if (self.cost is None) != (self.currency is None):
+            raise ValueError("cost and currency must both be present or both be null")
+        return self
+
+
+UsageMetadata = Usage
+
+
+CanonicalErrorCode: TypeAlias = Literal[
+    "invalid_request",
+    "unauthenticated",
+    "forbidden",
+    "not_found",
+    "conflict",
+    "api_major_mismatch",
+    "rate_limited",
+    "provider_timeout",
+    "provider_unavailable",
+    "policy_blocked",
+    "internal_error",
+]
+
+Capability: TypeAlias = Literal["search", "llm_search", "fetch"]
+
+
+class ErrorDetail(CanonicalModel):
+    """Public error details with no upstream payload or diagnostic fields."""
+
+    code: CanonicalErrorCode
+    message: str = Field(min_length=1, max_length=512)
+    retryable: bool
+    request_id: str = Field(min_length=1, max_length=128)
+    provider: str | None = Field(default=None, min_length=1, max_length=128)
+
+
+class ErrorResponse(CanonicalModel):
+    """Target External Data API error envelope."""
+
+    error: ErrorDetail
+    context: RequestContext
+
+    @model_validator(mode="after")
+    def _matches_request_context(self) -> ErrorResponse:
+        if self.error.request_id != self.context.request_id:
+            raise ValueError("error.request_id must match context.request_id")
+        return self
+
+
+class ProviderProbe(CanonicalModel):
+    """Safe bounded result of an explicitly requested provider probe."""
+
+    provider: str = Field(min_length=1, max_length=128)
+    capability: Capability
+    status: Literal["available", "unavailable"]
+
+
+SearchDomain: TypeAlias = Literal[
+    "paper",
+    "book",
+    "research_output",
+    "patent",
+    "web",
+    "news",
+    "images",
+    "videos",
+]
+
+
+class SearchPageRequest(CanonicalModel):
+    """Client paging input; the cursor remains opaque to the client."""
+
+    limit: int = Field(ge=1, le=100)
+    cursor: str | None = Field(default=None, min_length=1, max_length=2048)
+
+
+class ClientRequestContext(CanonicalModel):
+    """Client-supplied correlation subset without server-owned API state."""
+
+    request_id: str | None = Field(default=None, min_length=1, max_length=128)
+    trace_id: str | None = Field(default=None, min_length=1, max_length=128)
+
+
+class SearchFilters(CanonicalModel):
+    """Schema-listed filters for the initial canonical Search surface."""
+
+    year_from: int | None = Field(default=None, ge=0, le=9999)
+    year_to: int | None = Field(default=None, ge=0, le=9999)
+    language: str | None = Field(default=None, min_length=2, max_length=35)
+    open_access: bool | None = None
+    resource_type: str | None = Field(default=None, min_length=1, max_length=64)
+
+    @model_validator(mode="after")
+    def _year_range_is_ordered(self) -> SearchFilters:
+        if (
+            self.year_from is not None
+            and self.year_to is not None
+            and self.year_from > self.year_to
+        ):
+            raise ValueError("year_from must not exceed year_to")
+        return self
+
+
+class SearchRequest(CanonicalModel):
+    """Canonical Search use-case input."""
+
+    query: str = Field(min_length=1, max_length=4096)
+    domains: tuple[SearchDomain, ...] = Field(min_length=1)
+    providers: tuple[ProviderRef, ...] | None = None
+    page: SearchPageRequest | None = None
+    filters: SearchFilters | None = None
+    request_context: ClientRequestContext | None = None
+
+    @field_validator("query")
+    @classmethod
+    def _normalise_query(cls, value: str) -> str:
+        normalised = value.strip()
+        if not normalised:
+            raise ValueError("query must not be blank")
+        return normalised
+
+    @model_validator(mode="after")
+    def _unique_provider_ids(self) -> SearchRequest:
+        if self.providers is not None and len({provider.id for provider in self.providers}) != len(
+            self.providers
+        ):
+            raise ValueError("providers must not contain duplicate ids")
+        return self
+
+
+class SearchIdentifier(CanonicalModel):
+    """A stable domain identifier such as DOI or OpenAlex ID."""
+
+    scheme: str = Field(min_length=1, max_length=32, pattern=r"^[a-z][a-z0-9_.-]*$")
+    value: str = Field(min_length=1, max_length=512)
+
+
+class SearchAttributes(CanonicalModel):
+    """Explicit additive metadata shared by the first Provider v2 slices."""
+
+    year: int | None = Field(default=None, ge=0, le=9999)
+    authors: tuple[str, ...] = ()
+    identifiers: tuple[SearchIdentifier, ...] = ()
+    resource_type: str | None = Field(default=None, min_length=1, max_length=64)
+    language: str | None = Field(default=None, min_length=2, max_length=35)
+    open_access: bool | None = None
+    citation_count: int | None = Field(default=None, ge=0)
+
+    @field_validator("authors")
+    @classmethod
+    def _authors_are_nonblank_and_unique(cls, values: tuple[str, ...]) -> tuple[str, ...]:
+        normalized = tuple(value.strip() for value in values)
+        if any(not value for value in normalized) or len(set(normalized)) != len(normalized):
+            raise ValueError("authors must be nonblank and unique")
+        return normalized
+
+
+class SearchItem(CanonicalModel):
+    """One normalized Search result without provider-private payloads."""
+
+    id: str = Field(min_length=1, max_length=512)
+    title: str = Field(min_length=1, max_length=2048)
+    url: AnyHttpUrl | None = None
+    snippet: str | None = Field(default=None, max_length=20_000)
+    rank: int | None = Field(default=None, ge=1)
+    provenance: tuple[Provenance, ...] = Field(min_length=1)
+    attributes: SearchAttributes | None = None
+
+
+class ProviderFailure(CanonicalModel):
+    """A machine-readable provider failure retained in partial results."""
+
+    provider: str = Field(min_length=1, max_length=128)
+    code: CanonicalErrorCode
+
+
+class SearchMeta(CanonicalModel):
+    """Provider outcome summary for Search and LLM Search results."""
+
+    partial: bool = False
+    requested: tuple[str, ...] = ()
+    succeeded: tuple[str, ...] = ()
+    failed: tuple[ProviderFailure, ...] = ()
+
+    @model_validator(mode="after")
+    def _provider_outcomes_are_consistent(self) -> SearchMeta:
+        requested = set(self.requested)
+        succeeded = set(self.succeeded)
+        failed = {item.provider for item in self.failed}
+        if any(len(values) != len(set(values)) for values in (self.requested, self.succeeded)):
+            raise ValueError("provider outcome IDs must be unique")
+        if len(failed) != len(self.failed) or succeeded.intersection(failed):
+            raise ValueError("provider outcomes must be unique and disjoint")
+        if requested and not succeeded.union(failed).issubset(requested):
+            raise ValueError("provider outcomes must belong to requested providers")
+        if self.partial != bool(failed):
+            raise ValueError("partial must reflect failed provider outcomes")
+        return self
+
+
+class SearchPage(CanonicalModel):
+    """Canonical Search page emitted by a Search provider or Core module."""
+
+    items: tuple[SearchItem, ...]
+    page: PageInfo
+    meta: SearchMeta
+    context: RequestContext
+
+
+LLMSearchStrategy: TypeAlias = Literal["single", "fanout", "first_success"]
+
+
+class LLMFetchOptions(CanonicalModel):
+    """Bounded request to enable a separately secured downstream Fetch step."""
+
+    enabled: bool = True
+
+
+class LLMSearchBudget(CanonicalModel):
+    """Execution limits, not a billing promise."""
+
+    timeout_seconds: float | None = Field(default=None, gt=0, le=120)
+    max_attempts: int | None = Field(default=None, ge=1)
+
+
+class LLMSearchRequest(CanonicalModel):
+    """Canonical single-operation LLM Search input."""
+
+    query: str = Field(min_length=1, max_length=4096)
+    providers: tuple[ProviderRef, ...] = Field(min_length=1)
+    strategy: LLMSearchStrategy
+    max_results_per_provider: int | None = Field(default=None, ge=1)
+    fetch: LLMFetchOptions | None = None
+    budget: LLMSearchBudget | None = None
+    synthesis_profile: str | None = Field(default=None, min_length=1, max_length=128)
+
+    @field_validator("query")
+    @classmethod
+    def _normalise_query(cls, value: str) -> str:
+        normalised = value.strip()
+        if not normalised:
+            raise ValueError("query must not be blank")
+        return normalised
+
+    @model_validator(mode="after")
+    def _unique_provider_ids(self) -> LLMSearchRequest:
+        if len({provider.id for provider in self.providers}) != len(self.providers):
+            raise ValueError("providers must not contain duplicate ids")
+        return self
+
+
+class EvidenceItem(CanonicalModel):
+    """Verifiable public evidence attached to an LLM Search item."""
+
+    id: str = Field(min_length=1, max_length=512)
+    item_id: str = Field(min_length=1, max_length=512)
+    provider: str = Field(min_length=1, max_length=128)
+    public_url: AnyHttpUrl
+    title_or_snippet: str = Field(min_length=1, max_length=20_000)
+    retrieved_at: datetime
+
+
+class LLMSearchResult(CanonicalModel):
+    """Canonical LLM Search result with evidence and always-present usage."""
+
+    query: str = Field(min_length=1, max_length=4096)
+    items: tuple[SearchItem, ...]
+    evidence: tuple[EvidenceItem, ...]
+    answer: str | None = Field(default=None, max_length=100_000)
+    meta: SearchMeta
+    usage: Usage
+    context: RequestContext
+
+    @model_validator(mode="after")
+    def _evidence_and_answer_are_traceable(self) -> LLMSearchResult:
+        item_ids = {item.id for item in self.items}
+        evidence_ids = {item.id for item in self.evidence}
+        if len(item_ids) != len(self.items) or len(evidence_ids) != len(self.evidence):
+            raise ValueError("item and evidence IDs must be unique")
+        evidenced_item_ids = {item.item_id for item in self.evidence}
+        if not item_ids.issubset(evidenced_item_ids) or not evidenced_item_ids.issubset(item_ids):
+            raise ValueError("every item must have evidence and every evidence item must resolve")
+        if self.answer:
+            paragraphs = tuple(
+                part.strip() for part in re.split(r"\n\s*\n", self.answer) if part.strip()
+            )
+            for paragraph in paragraphs:
+                if not any(f"[{evidence_id}]" in paragraph for evidence_id in evidence_ids):
+                    raise ValueError("each answer paragraph must cite a stable evidence ID")
+        return self
+
+
+FetchStrategy: TypeAlias = Literal["fallback", "fanout"]
+
+
+class FetchContentOptions(CanonicalModel):
+    """Bounded normalized-content extraction options."""
+
+    max_code_points: int | None = Field(default=None, ge=1, le=1_000_000)
+
+
+class FetchPolicyOptions(CanonicalModel):
+    """Policy options that cannot disable server-side Fetch protections."""
+
+    respect_robots: Literal[True] | None = None
+
+
+class FetchRequest(CanonicalModel):
+    """Canonical Fetch input; target validation does not replace SSRF controls."""
+
+    targets: tuple[AnyHttpUrl, ...] = Field(min_length=1, max_length=20)
+    providers: tuple[ProviderRef, ...] | None = None
+    strategy: FetchStrategy | None = None
+    content: FetchContentOptions | None = None
+    policy: FetchPolicyOptions | None = None
+
+    @model_validator(mode="after")
+    def _unique_provider_ids(self) -> FetchRequest:
+        if self.providers is not None and len({provider.id for provider in self.providers}) != len(
+            self.providers
+        ):
+            raise ValueError("providers must not contain duplicate ids")
+        return self
+
+
+class FetchTargetRequest(CanonicalModel):
+    """One policy-bounded target dispatched to a single FetchProvider."""
+
+    target: AnyHttpUrl
+    content: FetchContentOptions | None = None
+    policy: FetchPolicyOptions | None = None
+
+
+class ContentMetadata(CanonicalModel):
+    """Safe normalized-content metadata for one Fetch result."""
+
+    media_type: str = Field(min_length=1, max_length=128)
+    charset: str | None = Field(default=None, min_length=1, max_length=64)
+    retrieved_at: datetime | None = None
+    truncated: bool
+    content_length: int | None = Field(default=None, ge=0)
+    quality: Literal["high", "low"] | None = None
+
+
+class FetchResult(CanonicalModel):
+    """One per-target Fetch outcome, including its own provenance or safe error."""
+
+    target: AnyHttpUrl
+    final_url: AnyHttpUrl | None = None
+    status: Literal["success", "failed", "blocked"]
+    title: str | None = Field(default=None, max_length=2048)
+    content: str | None = Field(default=None, max_length=1_000_000)
+    content_metadata: ContentMetadata | None = None
+    provenance: tuple[Provenance, ...] = Field(min_length=1)
+    error: ErrorDetail | None = None
+
+    @model_validator(mode="after")
+    def _outcome_is_internally_consistent(self) -> FetchResult:
+        if self.status == "success":
+            if self.content is None or not self.content.strip() or self.content_metadata is None:
+                raise ValueError("successful fetch requires non-empty content and metadata")
+            if self.error is not None:
+                raise ValueError("successful fetch cannot include an error")
+            expected_quality = "low" if len(self.content.strip()) <= 63 else "high"
+            if self.content_metadata.quality != expected_quality:
+                raise ValueError("content quality must match normalized content length")
+        else:
+            if self.error is None:
+                raise ValueError("failed or blocked fetch requires an item error")
+            if self.content is not None or self.content_metadata is not None:
+                raise ValueError("failed or blocked fetch cannot include normalized content")
+        return self
+
+
+class FetchMeta(CanonicalModel):
+    """Batch-level Fetch outcome summary."""
+
+    partial: bool = False
+
+
+class FetchBatch(CanonicalModel):
+    """Canonical Fetch batch emitted by a Fetch provider or Core module."""
+
+    items: tuple[FetchResult, ...]
+    meta: FetchMeta
+    context: RequestContext
+
+
+__all__ = [
+    "Capability",
+    "CanonicalErrorCode",
+    "CanonicalModel",
+    "ClientRequestContext",
+    "ContentMetadata",
+    "ErrorDetail",
+    "ErrorResponse",
+    "EvidenceItem",
+    "FetchBatch",
+    "FetchContentOptions",
+    "FetchMeta",
+    "FetchPolicyOptions",
+    "FetchRequest",
+    "FetchResult",
+    "FetchStrategy",
+    "FetchTargetRequest",
+    "LLMFetchOptions",
+    "LLMSearchBudget",
+    "LLMSearchRequest",
+    "LLMSearchResult",
+    "LLMSearchStrategy",
+    "PageInfo",
+    "ProviderFailure",
+    "ProviderProbe",
+    "ProviderProvenance",
+    "ProviderRef",
+    "Provenance",
+    "RequestContext",
+    "SearchDomain",
+    "SearchAttributes",
+    "SearchFilters",
+    "SearchIdentifier",
+    "SearchItem",
+    "SearchMeta",
+    "SearchPage",
+    "SearchPageRequest",
+    "SearchRequest",
+    "Usage",
+    "UsageMetadata",
+]

--- a/src/souwen/platform/provider_spi/errors.py
+++ b/src/souwen/platform/provider_spi/errors.py
@@ -1,0 +1,56 @@
+"""Safe provider-side error taxonomy for target SPI implementations."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class ProviderErrorCode(str, Enum):
+    """The only provider error classes allowed across the Core/SPI boundary."""
+
+    INVALID_REQUEST = "invalid_request"
+    INVALID_CONFIG = "invalid_config"
+    CANCELLED = "cancelled"
+    DEADLINE_EXCEEDED = "deadline_exceeded"
+    RATE_LIMITED = "rate_limited"
+    PROVIDER_UNAVAILABLE = "provider_unavailable"
+    INVALID_UPSTREAM_RESPONSE = "invalid_upstream_response"
+    POLICY_BLOCKED = "policy_blocked"
+
+
+_SAFE_MESSAGES: dict[ProviderErrorCode, str] = {
+    ProviderErrorCode.INVALID_REQUEST: "Provider request is invalid",
+    ProviderErrorCode.INVALID_CONFIG: "Provider configuration is invalid",
+    ProviderErrorCode.CANCELLED: "Provider execution was cancelled",
+    ProviderErrorCode.DEADLINE_EXCEEDED: "Provider execution exceeded its deadline",
+    ProviderErrorCode.RATE_LIMITED: "Provider rate limit was reached",
+    ProviderErrorCode.PROVIDER_UNAVAILABLE: "Provider is unavailable",
+    ProviderErrorCode.INVALID_UPSTREAM_RESPONSE: "Provider returned an invalid response",
+    ProviderErrorCode.POLICY_BLOCKED: "Provider operation was blocked by policy",
+}
+
+
+class ProviderError(Exception):
+    """A typed provider failure that deliberately accepts no raw upstream detail."""
+
+    def __init__(
+        self,
+        code: ProviderErrorCode,
+        *,
+        provider_id: str | None = None,
+        retry_after_seconds: float | None = None,
+    ) -> None:
+        if retry_after_seconds is not None and retry_after_seconds < 0:
+            raise ValueError("retry_after_seconds must be non-negative")
+        self.code = code
+        self.provider_id = provider_id
+        self.retry_after_seconds = retry_after_seconds
+        self.retryable = code in {
+            ProviderErrorCode.DEADLINE_EXCEEDED,
+            ProviderErrorCode.RATE_LIMITED,
+            ProviderErrorCode.PROVIDER_UNAVAILABLE,
+        }
+        super().__init__(_SAFE_MESSAGES[code])
+
+
+__all__ = ["ProviderError", "ProviderErrorCode"]

--- a/src/souwen/platform/provider_spi/execution.py
+++ b/src/souwen/platform/provider_spi/execution.py
@@ -1,0 +1,77 @@
+"""Execution deadline and cancellation context passed from Core to providers."""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import time
+from dataclasses import dataclass, field
+
+from souwen.platform.provider_spi.errors import ProviderError, ProviderErrorCode
+
+
+MAX_EXECUTION_SECONDS = 120.0
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionContext:
+    """A provider-call budget using an absolute monotonic deadline."""
+
+    deadline_monotonic: float
+    cancel_event: asyncio.Event = field(default_factory=asyncio.Event)
+    max_remaining_seconds: float = MAX_EXECUTION_SECONDS
+
+    def __post_init__(self) -> None:
+        if not math.isfinite(self.deadline_monotonic):
+            raise ValueError("deadline_monotonic must be finite")
+        if not 0 < self.max_remaining_seconds <= MAX_EXECUTION_SECONDS:
+            raise ValueError(f"max_remaining_seconds must be in (0, {MAX_EXECUTION_SECONDS}]")
+
+    @classmethod
+    def with_timeout(
+        cls,
+        timeout_seconds: float,
+        *,
+        cancel_event: asyncio.Event | None = None,
+    ) -> ExecutionContext:
+        """Create an absolute deadline within the target hard maximum."""
+
+        if not math.isfinite(timeout_seconds) or not 0 < timeout_seconds <= MAX_EXECUTION_SECONDS:
+            raise ValueError(f"timeout_seconds must be in (0, {MAX_EXECUTION_SECONDS}]")
+        return cls(
+            deadline_monotonic=time.monotonic() + timeout_seconds,
+            cancel_event=cancel_event if cancel_event is not None else asyncio.Event(),
+            max_remaining_seconds=timeout_seconds,
+        )
+
+    @property
+    def cancelled(self) -> bool:
+        """Whether the caller has signalled cancellation."""
+
+        return self.cancel_event.is_set()
+
+    @property
+    def remaining_seconds(self) -> float:
+        """Return the non-negative, bounded time available for the call."""
+
+        return max(0.0, min(self.deadline_monotonic - time.monotonic(), self.max_remaining_seconds))
+
+    @property
+    def expired(self) -> bool:
+        """Whether no provider-call time remains."""
+
+        return self.remaining_seconds <= 0
+
+    def raise_if_cancelled_or_expired(self) -> None:
+        """Raise a safe canonical provider error before starting more work."""
+
+        if self.cancelled or self.expired:
+            code = (
+                ProviderErrorCode.CANCELLED
+                if self.cancelled
+                else ProviderErrorCode.DEADLINE_EXCEEDED
+            )
+            raise ProviderError(code)
+
+
+__all__ = ["ExecutionContext", "MAX_EXECUTION_SECONDS"]

--- a/src/souwen/platform/provider_spi/protocols.py
+++ b/src/souwen/platform/provider_spi/protocols.py
@@ -1,0 +1,74 @@
+"""Single-capability asynchronous provider ports."""
+
+from __future__ import annotations
+
+from typing import Literal, Protocol, runtime_checkable
+
+from souwen.platform.provider_spi.dto import (
+    FetchResult,
+    FetchTargetRequest,
+    LLMSearchRequest,
+    LLMSearchResult,
+    ProviderProbe,
+    RequestContext,
+    SearchPage,
+    SearchRequest,
+)
+from souwen.platform.provider_spi.execution import ExecutionContext
+
+
+@runtime_checkable
+class SearchProvider(Protocol):
+    """An adapter that implements only the ``search`` capability."""
+
+    capability: Literal["search"]
+
+    async def search(
+        self, request: SearchRequest, context: RequestContext, execution: ExecutionContext
+    ) -> SearchPage:
+        """Return a canonical page or raise a typed ``ProviderError``."""
+
+    async def probe(self, execution: ExecutionContext) -> ProviderProbe:
+        """Perform one bounded, safe, explicitly requested probe."""
+
+    async def close(self) -> None:
+        """Release only owned resources; implementations must be idempotent."""
+
+
+@runtime_checkable
+class LLMSearchProvider(Protocol):
+    """An adapter that implements only the ``llm_search`` capability."""
+
+    capability: Literal["llm_search"]
+
+    async def search(
+        self, request: LLMSearchRequest, context: RequestContext, execution: ExecutionContext
+    ) -> LLMSearchResult:
+        """Return a canonical result or raise a typed ``ProviderError``."""
+
+    async def probe(self, execution: ExecutionContext) -> ProviderProbe:
+        """Perform one bounded, safe, explicitly requested probe."""
+
+    async def close(self) -> None:
+        """Release only owned resources; implementations must be idempotent."""
+
+
+@runtime_checkable
+class FetchProvider(Protocol):
+    """An adapter that implements only the ``fetch`` capability."""
+
+    capability: Literal["fetch"]
+
+    async def fetch(
+        self, request: FetchTargetRequest, context: RequestContext, execution: ExecutionContext
+    ) -> FetchResult:
+        """Return one canonical target result or raise a typed ``ProviderError``."""
+
+    async def probe(self, execution: ExecutionContext) -> ProviderProbe:
+        """Perform one bounded, safe, explicitly requested probe."""
+
+    async def close(self) -> None:
+        """Release only owned resources; implementations must be idempotent."""
+
+
+__all__ = ["FetchProvider", "LLMSearchProvider", "SearchProvider"]

--- a/tests/contracts/fixtures/target_api_contract_v2.json
+++ b/tests/contracts/fixtures/target_api_contract_v2.json
@@ -135,13 +135,16 @@
     "search_partial_success": {
       "context": {"request_id": "fixture-request-001", "api_major": 2},
       "items": [{"id": "doi:10.1000/fixture", "title": "Fixture result", "rank": 1, "provenance": [{"provider": "openalex", "outcome": "success"}]}],
+      "page": {"limit": 10, "next_cursor": null, "total": null},
       "meta": {"partial": true, "requested": ["openalex", "other"], "succeeded": ["openalex"], "failed": [{"provider": "other", "code": "provider_timeout"}]}
     },
     "llm_search_evidence": {
+      "query": "fixture query",
       "context": {"request_id": "fixture-request-002", "api_major": 2},
       "items": [{"id": "fixture-item-001", "title": "Fixture item", "provenance": [{"provider": "fixture-llm", "outcome": "success"}]}],
       "evidence": [{"id": "evidence-001", "item_id": "fixture-item-001", "provider": "fixture-llm", "public_url": "https://example.com/evidence", "title_or_snippet": "Fixture evidence", "retrieved_at": "2026-07-24T00:00:00Z"}],
       "answer": "Fixture factual answer [evidence-001]",
+      "meta": {"partial": false, "requested": ["fixture-llm"], "succeeded": ["fixture-llm"], "failed": []},
       "usage": {"input_tokens": null, "output_tokens": null, "cost": null, "currency": null}
     },
     "fetch_low_quality_partial": {

--- a/tests/test_architecture_dependencies.py
+++ b/tests/test_architecture_dependencies.py
@@ -63,6 +63,27 @@ def test_allowed_target_edges_pass(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     "imported",
     [
+        "souwen.platform.manifest_registry",
+        "souwen.platform.provider_manager",
+    ],
+)
+def test_modules_may_depend_on_provider_spi_but_not_platform_assembly(
+    tmp_path: Path, imported: str
+) -> None:
+    root, exceptions = _repository(tmp_path)
+    relative_path = "src/souwen/modules/search/application/service.py"
+    _write(root, relative_path, f"import {imported}\n")
+
+    violations = _violations(root, exceptions)
+
+    assert [(violation.rule_id, violation.imported) for violation in violations] == [
+        ("DEP-001", imported)
+    ]
+
+
+@pytest.mark.parametrize(
+    "imported",
+    [
         "souwen",
         "souwen.core",
         "souwen.delivery",

--- a/tests/test_manifest_registry_v2.py
+++ b/tests/test_manifest_registry_v2.py
@@ -1,0 +1,124 @@
+"""Deterministic static conformance for the Provider v2 manifest registry."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from souwen.platform.manifest_registry.models import ProviderManifest
+from souwen.platform.manifest_registry.registry import ManifestRegistry
+
+
+_FIXTURE = Path(__file__).parent / "contracts" / "fixtures" / "target_provider_manifest_v2.json"
+
+
+def _manifest() -> dict[str, object]:
+    return copy.deepcopy(json.loads(_FIXTURE.read_text(encoding="utf-8"))["manifest"])
+
+
+def test_target_fixture_is_a_valid_static_manifest_declaration() -> None:
+    registry = ManifestRegistry()
+
+    result = registry.register(_manifest())
+
+    assert result.accepted is True
+    assert result.manifest is not None
+    assert registry.package("fixture-provider-package") == result.manifest
+    resolved = registry.adapter("fixture-search")
+    assert resolved is not None
+    assert resolved[0].id == "fixture-provider-package"
+    assert resolved[1].capability == "search"
+
+
+def test_manifest_accepts_stable_underscore_adapter_ids_and_pep440_release_candidates() -> None:
+    declaration = _manifest()
+    declaration["id"] = "uniapi_provider_package"
+    declaration["version"] = "2.0.0rc2"
+    declaration["adapters"][0]["id"] = "uniapi_ark_annotations_deepseek_v3_2_251201"
+
+    registry = ManifestRegistry()
+    result = registry.register(declaration)
+
+    assert result.accepted is True
+    assert registry.package("uniapi_provider_package") is not None
+    assert registry.adapter("uniapi_ark_annotations_deepseek_v3_2_251201") is not None
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda declaration: declaration.pop("id"),
+        lambda declaration: declaration.update(unexpected="value"),
+        lambda declaration: declaration.update(capabilities=[]),
+        lambda declaration: declaration["secrets"].update(values=["not-allowed"]),
+        lambda declaration: declaration["secrets"].update(references=["https://secret.example"]),
+        lambda declaration: declaration["configuration"].update(
+            non_secret_keys=["enabled", "api_key"]
+        ),
+        lambda declaration: declaration["compatibility"].update(contract_versions=[]),
+    ],
+)
+def test_manifest_model_rejects_missing_extra_secret_or_incompatible_declarations(mutate) -> None:
+    declaration = _manifest()
+
+    mutate(declaration)
+
+    with pytest.raises(ValidationError):
+        ProviderManifest.model_validate(declaration)
+
+
+def test_registry_quarantines_only_new_duplicate_package_without_mutating_healthy_package() -> None:
+    registry = ManifestRegistry()
+    healthy = registry.register(_manifest())
+    duplicate = _manifest()
+    duplicate["version"] = "2.1.0"
+
+    result = registry.register(duplicate)
+
+    assert healthy.accepted is True
+    assert result.accepted is False
+    assert result.diagnostic is not None
+    assert result.diagnostic.reason_code == "duplicate_package"
+    assert registry.package("fixture-provider-package") == healthy.manifest
+    assert len(registry.packages) == 1
+
+
+def test_registry_transactionally_quarantines_new_package_with_duplicate_adapter() -> None:
+    registry = ManifestRegistry()
+    first = registry.register(_manifest())
+    conflicting = _manifest()
+    conflicting["id"] = "second-provider-package"
+    conflicting["adapters"][0]["export"] = "SecondSearchProvider"
+
+    result = registry.register(conflicting)
+
+    assert first.accepted is True
+    assert result.accepted is False
+    assert result.diagnostic is not None
+    assert result.diagnostic.reason_code == "duplicate_adapter"
+    assert registry.package("second-provider-package") is None
+    assert registry.adapter("fixture-search") is not None
+    assert len(registry.packages) == 1
+
+
+def test_discovery_keeps_valid_packages_when_another_declaration_is_invalid() -> None:
+    invalid = _manifest()
+    invalid["id"] = "not-a-secret"
+    invalid["secrets"]["references"] = ["literal-secret-value"]
+    healthy = _manifest()
+    healthy["id"] = "healthy-provider-package"
+    healthy["adapters"][0]["id"] = "healthy-search"
+    healthy["adapters"][0]["export"] = "HealthySearchProvider"
+
+    registry = ManifestRegistry()
+    results = registry.discover((invalid, healthy))
+
+    assert [result.accepted for result in results] == [False, True]
+    assert registry.package("healthy-provider-package") is not None
+    diagnostic = registry.diagnostics[0]
+    assert diagnostic.reason_code == "manifest_invalid"
+    assert "literal-secret-value" not in repr(diagnostic)

--- a/tests/test_phase2_module_skeleton.py
+++ b/tests/test_phase2_module_skeleton.py
@@ -49,6 +49,23 @@ SKELETON_PACKAGES = (
     "souwen.providers.fetch_sources",
 )
 
+# P4-01 intentionally promotes these Phase-2 placeholders into real internal
+# interfaces. Their strict contracts and import boundaries have dedicated tests;
+# the remaining packages must stay inert until their owning migration slice.
+IMPLEMENTED_PACKAGES = frozenset(
+    {
+        "souwen.modules.search.api",
+        "souwen.modules.llm_search.api",
+        "souwen.modules.fetch.api",
+        "souwen.platform.provider_spi",
+        "souwen.platform.manifest_registry",
+        "souwen.platform.provider_manager",
+    }
+)
+INERT_SKELETON_PACKAGES = tuple(
+    package_name for package_name in SKELETON_PACKAGES if package_name not in IMPLEMENTED_PACKAGES
+)
+
 
 def _package_path(package_name: str) -> Path:
     return SOURCE_ROOT.joinpath(*package_name.split(".")[1:], "__init__.py")
@@ -61,10 +78,9 @@ def test_phase2_packages_import_from_souwen_distribution(package_name: str) -> N
     package_file = Path(package.__file__).resolve()
 
     assert package_file.is_relative_to(SOURCE_ROOT.resolve())
-    assert package.__all__ == []
 
 
-@pytest.mark.parametrize("package_name", SKELETON_PACKAGES)
+@pytest.mark.parametrize("package_name", INERT_SKELETON_PACKAGES)
 def test_phase2_packages_declare_an_empty_internal_interface(package_name: str) -> None:
     """Skeletons state ownership/boundaries without adding an end-user API."""
     tree = ast.parse(_package_path(package_name).read_text(encoding="utf-8"))
@@ -83,7 +99,7 @@ def test_phase2_packages_declare_an_empty_internal_interface(package_name: str) 
     )
 
 
-@pytest.mark.parametrize("package_name", SKELETON_PACKAGES)
+@pytest.mark.parametrize("package_name", INERT_SKELETON_PACKAGES)
 def test_phase2_packages_have_no_legacy_or_optional_imports(package_name: str) -> None:
     """Skeletons must be inert until a later migration intentionally adds a dependency."""
     tree = ast.parse(_package_path(package_name).read_text(encoding="utf-8"))
@@ -97,8 +113,8 @@ def test_phase2_packages_have_no_legacy_or_optional_imports(package_name: str) -
     )
 
 
-def test_phase2_package_imports_add_no_runtime_modules() -> None:
-    """Package imports add only the requested skeleton packages after ``souwen`` is loaded."""
+def test_inert_phase2_package_imports_add_no_runtime_modules() -> None:
+    """Still-inert package imports add no modules outside the skeleton set."""
     script = f"""
 import importlib
 import json
@@ -107,7 +123,7 @@ import sys
 import souwen
 
 before = set(sys.modules)
-for package_name in {SKELETON_PACKAGES!r}:
+for package_name in {INERT_SKELETON_PACKAGES!r}:
     importlib.import_module(package_name)
 print(json.dumps(sorted(set(sys.modules) - before)))
 """
@@ -126,4 +142,4 @@ print(json.dumps(sorted(set(sys.modules) - before)))
         text=True,
     )
     added_modules = set(json.loads(result.stdout))
-    assert added_modules <= set(SKELETON_PACKAGES)
+    assert added_modules <= set(INERT_SKELETON_PACKAGES)

--- a/tests/test_provider_manager_v2.py
+++ b/tests/test_provider_manager_v2.py
@@ -1,0 +1,463 @@
+"""Deterministic lifecycle conformance for the Provider v2 manager."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from souwen.platform.provider_manager.manager import ProviderManager, ProviderManagerError
+from souwen.platform.provider_spi import (
+    ContentMetadata,
+    ExecutionContext,
+    FetchResult,
+    FetchTargetRequest,
+    PageInfo,
+    ProviderError,
+    ProviderErrorCode,
+    ProviderProbe,
+    Provenance,
+    RequestContext,
+    SearchItem,
+    SearchMeta,
+    SearchPage,
+    SearchRequest,
+)
+
+
+_FIXTURE = Path(__file__).parent / "contracts" / "fixtures" / "target_provider_manifest_v2.json"
+
+
+def _manifest(
+    *,
+    package_id: str = "fixture-provider-package",
+    adapter_id: str = "fixture-search",
+    export: str = "FixtureSearchProvider",
+):
+    declaration = copy.deepcopy(json.loads(_FIXTURE.read_text(encoding="utf-8"))["manifest"])
+    declaration["id"] = package_id
+    declaration["adapters"][0]["id"] = adapter_id
+    declaration["adapters"][0]["export"] = export
+    return declaration
+
+
+class FixtureSearchProvider:
+    capability = "search"
+
+    def __init__(self, configuration, secrets) -> None:
+        self.configuration = configuration
+        self.secrets = secrets
+        self.close_count = 0
+
+    async def search(self, request, context, execution):
+        return _page(context, request.query)
+
+    async def probe(self, execution):
+        return ProviderProbe(provider="fixture-provider", capability="search", status="available")
+
+    async def close(self):
+        self.close_count += 1
+
+
+def _manager() -> ProviderManager:
+    return ProviderManager(
+        config_resolver=lambda _manifest: {"enabled": True},
+        secret_resolver=lambda _manifest, _references: {"FIXTURE_PROVIDER_API_KEY": "test-only"},
+    )
+
+
+def _execution() -> ExecutionContext:
+    return ExecutionContext.with_timeout(5)
+
+
+def _request(query: str = "query") -> SearchRequest:
+    return SearchRequest(query=query, domains=("paper",))
+
+
+def _request_context() -> RequestContext:
+    return RequestContext(request_id="provider-manager-test")
+
+
+def _page(context: RequestContext, title: str = "query") -> SearchPage:
+    return SearchPage(
+        items=(
+            SearchItem(
+                id=f"fixture:{title}",
+                title=title,
+                rank=1,
+                provenance=(Provenance(provider="fixture-search", outcome="success"),),
+            ),
+        ),
+        page=PageInfo(limit=1),
+        meta=SearchMeta(
+            requested=("fixture-search",),
+            succeeded=("fixture-search",),
+        ),
+        context=context,
+    )
+
+
+@pytest.mark.asyncio
+async def test_discovery_preflights_factory_without_constructing_until_execution() -> None:
+    manager = _manager()
+    constructed = 0
+
+    def factory(configuration, secrets):
+        nonlocal constructed
+        constructed += 1
+        return FixtureSearchProvider(configuration, secrets)
+
+    manager.register_factory(
+        package_id="fixture-provider-package",
+        export="FixtureSearchProvider",
+        factory=factory,
+        provider_type=FixtureSearchProvider,
+    )
+
+    result = manager.discover([_manifest()])
+
+    assert result[0].accepted is True
+    assert manager.eligible_adapter_ids == ("fixture-search",)
+    assert constructed == 0
+    page = await manager.execute("fixture-search", _request(), _request_context(), _execution())
+    assert page.items[0].title == "query"
+    assert constructed == 1
+    assert await manager.probe("fixture-search", _execution()) == ProviderProbe(
+        provider="fixture-provider", capability="search", status="available"
+    )
+
+
+@pytest.mark.asyncio
+async def test_config_or_secret_failure_is_provider_local_and_safe() -> None:
+    manager = ProviderManager(
+        config_resolver=lambda manifest: (
+            {"enabled": True}
+            if manifest.id == "healthy-provider-package"
+            else {"unexpected": "literal-secret-value"}
+        ),
+        secret_resolver=lambda _manifest, _references: {"FIXTURE_PROVIDER_API_KEY": "test-only"},
+    )
+    for package_id, adapter_id, export in (
+        ("fixture-provider-package", "fixture-search", "FixtureSearchProvider"),
+        ("healthy-provider-package", "healthy-search", "FixtureSearchProvider"),
+    ):
+        manager.register_factory(
+            package_id=package_id,
+            export=export,
+            factory=FixtureSearchProvider,
+            provider_type=FixtureSearchProvider,
+        )
+
+    manager.discover(
+        [
+            _manifest(),
+            _manifest(package_id="healthy-provider-package", adapter_id="healthy-search"),
+        ]
+    )
+
+    assert manager.eligible_adapter_ids == ("healthy-search",)
+    with pytest.raises(ProviderManagerError, match="adapter_not_eligible"):
+        await manager.execute("fixture-search", _request(), _request_context(), _execution())
+    page = await manager.execute("healthy-search", _request(), _request_context(), _execution())
+    assert page.items[0].title == "query"
+    assert all("literal-secret-value" not in repr(item) for item in manager.diagnostics)
+    assert manager.diagnostics[0].reason_code == "config_invalid"
+
+
+def test_declared_secret_references_must_resolve_to_nonempty_strings() -> None:
+    manager = ProviderManager(
+        config_resolver=lambda _manifest: {"enabled": True},
+        secret_resolver=lambda _manifest, _references: {},
+    )
+    manager.register_factory(
+        package_id="fixture-provider-package",
+        export="FixtureSearchProvider",
+        factory=FixtureSearchProvider,
+        provider_type=FixtureSearchProvider,
+    )
+
+    manager.discover([_manifest()])
+
+    assert manager.eligible_adapter_ids == ()
+    assert manager.diagnostics[-1].reason_code == "secret_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_execution_rejects_noncanonical_context_before_provider_construction() -> None:
+    manager = _manager()
+    constructions = 0
+
+    def factory(configuration, secrets):
+        nonlocal constructions
+        constructions += 1
+        return FixtureSearchProvider(configuration, secrets)
+
+    manager.register_factory(
+        package_id="fixture-provider-package",
+        export="FixtureSearchProvider",
+        factory=factory,
+        provider_type=FixtureSearchProvider,
+    )
+    manager.discover([_manifest()])
+
+    with pytest.raises(ProviderManagerError, match="invalid_request_context"):
+        await manager.execute("fixture-search", _request(), object(), _execution())
+    with pytest.raises(ProviderManagerError, match="invalid_execution_context"):
+        await manager.execute("fixture-search", _request(), _request_context(), object())
+    assert constructions == 0
+
+
+@pytest.mark.asyncio
+async def test_export_or_capability_mismatch_never_calls_factory() -> None:
+    manager = _manager()
+    calls = 0
+
+    def factory(configuration, secrets):
+        nonlocal calls
+        calls += 1
+        return FixtureSearchProvider(configuration, secrets)
+
+    class WrongCapabilityProvider(FixtureSearchProvider):
+        capability = "fetch"
+
+    manager.register_factory(
+        package_id="fixture-provider-package",
+        export="WrongCapabilityProvider",
+        factory=factory,
+        provider_type=WrongCapabilityProvider,
+    )
+    manager.discover([_manifest(export="WrongCapabilityProvider")])
+
+    assert manager.eligible_adapter_ids == ()
+    assert calls == 0
+    assert manager.diagnostics[-1].reason_code == "factory_capability_mismatch"
+
+
+@pytest.mark.asyncio
+async def test_execute_dispatches_fetch_capability_to_fetch_provider_method() -> None:
+    calls: list[str] = []
+
+    class FixtureFetchProvider:
+        capability = "fetch"
+
+        def __init__(self, configuration, secrets) -> None:
+            self.configuration = configuration
+            self.secrets = secrets
+
+        async def fetch(self, request, context, execution):
+            calls.append("fetch")
+            return FetchResult(
+                target=request.target,
+                status="success",
+                content="fixture article",
+                content_metadata=ContentMetadata(
+                    media_type="text/plain", truncated=False, quality="low"
+                ),
+                provenance=(Provenance(provider="fixture-search", outcome="success"),),
+            )
+
+        async def probe(self, execution):
+            return ProviderProbe(
+                provider="fixture-provider", capability="fetch", status="available"
+            )
+
+        async def close(self):
+            return None
+
+    declaration = _manifest(export="FixtureFetchProvider")
+    declaration["capabilities"] = ["fetch"]
+    declaration["adapters"][0]["capability"] = "fetch"
+    manager = _manager()
+    manager.register_factory(
+        package_id="fixture-provider-package",
+        export="FixtureFetchProvider",
+        factory=FixtureFetchProvider,
+        provider_type=FixtureFetchProvider,
+    )
+    manager.discover([declaration])
+
+    result = await manager.execute(
+        "fixture-search",
+        FetchTargetRequest(target="https://example.com/article"),
+        _request_context(),
+        _execution(),
+    )
+
+    assert str(result.target) == "https://example.com/article"
+    assert calls == ["fetch"]
+
+
+@pytest.mark.asyncio
+async def test_deadline_cancel_and_idempotent_close_do_not_leak_provider_details() -> None:
+    manager = _manager()
+    instance: FixtureSearchProvider | None = None
+
+    def factory(configuration, secrets):
+        nonlocal instance
+        instance = FixtureSearchProvider(configuration, secrets)
+        return instance
+
+    manager.register_factory(
+        package_id="fixture-provider-package",
+        export="FixtureSearchProvider",
+        factory=factory,
+        provider_type=FixtureSearchProvider,
+    )
+    manager.discover([_manifest()])
+
+    with pytest.raises(ProviderError) as exc_info:
+        cancel_event = asyncio.Event()
+        cancel_event.set()
+        await manager.execute(
+            "fixture-search",
+            _request(),
+            _request_context(),
+            ExecutionContext.with_timeout(5, cancel_event=cancel_event),
+        )
+    assert exc_info.value.code is ProviderErrorCode.CANCELLED
+    assert instance is None
+
+    await manager.execute("fixture-search", _request(), _request_context(), _execution())
+    await manager.close("fixture-search")
+    await manager.close("fixture-search")
+
+    assert instance is not None
+    assert instance.close_count == 1
+
+
+@pytest.mark.asyncio
+async def test_cancellation_signal_stops_an_in_flight_provider_call() -> None:
+    entered = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    class CancellableProvider(FixtureSearchProvider):
+        async def search(self, request, context, execution):
+            entered.set()
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+    manager = _manager()
+    manager.register_factory(
+        package_id="fixture-provider-package",
+        export="CancellableProvider",
+        factory=CancellableProvider,
+        provider_type=CancellableProvider,
+    )
+    manager.discover([_manifest(export="CancellableProvider")])
+    cancel_event = asyncio.Event()
+    task = asyncio.create_task(
+        manager.execute(
+            "fixture-search",
+            _request(),
+            _request_context(),
+            ExecutionContext.with_timeout(5, cancel_event=cancel_event),
+        )
+    )
+
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    cancel_event.set()
+
+    with pytest.raises(ProviderError) as exc_info:
+        await asyncio.wait_for(task, timeout=1)
+    assert exc_info.value.code is ProviderErrorCode.CANCELLED
+    assert cancelled.is_set()
+
+
+@pytest.mark.asyncio
+async def test_provider_failure_quarantines_only_the_failing_adapter() -> None:
+    class FailingProvider(FixtureSearchProvider):
+        async def search(self, request, context, execution):
+            raise RuntimeError("secret=literal-secret-value")
+
+    manager = _manager()
+    manager.register_factory(
+        package_id="fixture-provider-package",
+        export="FailingProvider",
+        factory=FailingProvider,
+        provider_type=FailingProvider,
+    )
+    manager.register_factory(
+        package_id="healthy-provider-package",
+        export="FixtureSearchProvider",
+        factory=FixtureSearchProvider,
+        provider_type=FixtureSearchProvider,
+    )
+    manager.discover(
+        [
+            _manifest(export="FailingProvider"),
+            _manifest(package_id="healthy-provider-package", adapter_id="healthy-search"),
+        ]
+    )
+
+    with pytest.raises(ProviderManagerError, match="provider_failed"):
+        await manager.execute("fixture-search", _request(), _request_context(), _execution())
+    page = await manager.execute("healthy-search", _request(), _request_context(), _execution())
+    assert page.items[0].title == "query"
+    assert manager.diagnostics[-1].reason_code == "provider_failed"
+    assert all("literal-secret-value" not in repr(item) for item in manager.diagnostics)
+
+
+@pytest.mark.asyncio
+async def test_each_adapter_uses_a_loop_local_concurrency_limit_of_ten() -> None:
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    calls = 0
+
+    class BlockingProvider(FixtureSearchProvider):
+        async def search(self, request, context, execution):
+            nonlocal calls
+            calls += 1
+            if calls == 10:
+                entered.set()
+            await release.wait()
+            return _page(context, request.query)
+
+    manager = _manager()
+    manager.register_factory(
+        package_id="fixture-provider-package",
+        export="BlockingProvider",
+        factory=BlockingProvider,
+        provider_type=BlockingProvider,
+    )
+    manager.discover([_manifest(export="BlockingProvider")])
+
+    tasks = [
+        asyncio.create_task(
+            manager.execute(
+                "fixture-search", _request(f"query-{index}"), _request_context(), _execution()
+            )
+        )
+        for index in range(11)
+    ]
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    assert calls == 10
+    release.set()
+    pages = await asyncio.gather(*tasks)
+    assert {page.items[0].title for page in pages} == {f"query-{index}" for index in range(11)}
+
+
+@pytest.mark.asyncio
+async def test_noncanonical_provider_output_quarantines_only_that_adapter() -> None:
+    class RawProvider(FixtureSearchProvider):
+        async def search(self, request, context, execution):
+            return {"raw": "upstream"}
+
+    manager = _manager()
+    manager.register_factory(
+        package_id="fixture-provider-package",
+        export="RawProvider",
+        factory=RawProvider,
+        provider_type=RawProvider,
+    )
+    manager.discover([_manifest(export="RawProvider")])
+
+    with pytest.raises(ProviderManagerError, match="invalid_provider_result"):
+        await manager.execute("fixture-search", _request(), _request_context(), _execution())
+
+    assert manager.diagnostics[-1].reason_code == "invalid_provider_result"

--- a/tests/test_provider_spi.py
+++ b/tests/test_provider_spi.py
@@ -1,0 +1,126 @@
+"""Deterministic Provider SPI port and execution-context conformance tests."""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import time
+from pathlib import Path
+
+import pytest
+
+from souwen.modules.fetch.api import FetchModule
+from souwen.modules.llm_search.api import LLMSearchModule
+from souwen.modules.search.api import SearchModule
+from souwen.platform.provider_spi import (
+    ExecutionContext,
+    FetchProvider,
+    LLMSearchProvider,
+    ProviderError,
+    ProviderErrorCode,
+    SearchProvider,
+)
+
+
+class _SearchAdapter:
+    capability = "search"
+
+    async def search(self, request, context, execution):  # noqa: ANN001
+        raise NotImplementedError
+
+    async def probe(self, execution):  # noqa: ANN001
+        raise NotImplementedError
+
+    async def close(self) -> None:
+        return None
+
+
+class _LLMSearchAdapter:
+    capability = "llm_search"
+
+    async def search(self, request, context, execution):  # noqa: ANN001
+        raise NotImplementedError
+
+    async def probe(self, execution):  # noqa: ANN001
+        raise NotImplementedError
+
+    async def close(self) -> None:
+        return None
+
+
+class _FetchAdapter:
+    capability = "fetch"
+
+    async def fetch(self, request, context, execution):  # noqa: ANN001
+        raise NotImplementedError
+
+    async def probe(self, execution):  # noqa: ANN001
+        raise NotImplementedError
+
+    async def close(self) -> None:
+        return None
+
+
+def test_each_adapter_protocol_has_one_capability() -> None:
+    assert isinstance(_SearchAdapter(), SearchProvider)
+    assert isinstance(_LLMSearchAdapter(), LLMSearchProvider)
+    assert isinstance(_FetchAdapter(), FetchProvider)
+    assert SearchProvider.__dict__["__annotations__"]["capability"] == "Literal['search']"
+    assert LLMSearchProvider.__dict__["__annotations__"]["capability"] == "Literal['llm_search']"
+    assert FetchProvider.__dict__["__annotations__"]["capability"] == "Literal['fetch']"
+
+
+def test_execution_context_uses_absolute_monotonic_deadline_and_cancellation() -> None:
+    cancel_event = asyncio.Event()
+    context = ExecutionContext.with_timeout(30, cancel_event=cancel_event)
+
+    assert context.deadline_monotonic > time.monotonic()
+    assert 0 < context.remaining_seconds <= 30
+    cancel_event.set()
+    assert context.cancelled is True
+    with pytest.raises(ProviderError) as exc_info:
+        context.raise_if_cancelled_or_expired()
+    assert exc_info.value.code is ProviderErrorCode.CANCELLED
+
+
+def test_execution_context_bounds_distant_deadlines_and_rejects_invalid_timeouts() -> None:
+    distant = ExecutionContext(deadline_monotonic=time.monotonic() + 1_000)
+    assert distant.remaining_seconds == 120
+    assert ExecutionContext(deadline_monotonic=time.monotonic() - 1).expired is True
+    with pytest.raises(ValueError):
+        ExecutionContext.with_timeout(121)
+    with pytest.raises(ProviderError) as exc_info:
+        ExecutionContext(deadline_monotonic=time.monotonic() - 1).raise_if_cancelled_or_expired()
+    assert exc_info.value.code is ProviderErrorCode.DEADLINE_EXCEEDED
+
+
+def test_provider_errors_expose_only_safe_taxonomy() -> None:
+    error = ProviderError(
+        ProviderErrorCode.RATE_LIMITED,
+        provider_id="fixture-provider",
+        retry_after_seconds=2,
+    )
+
+    assert error.retryable is True
+    assert str(error) == "Provider rate limit was reached"
+    assert error.provider_id == "fixture-provider"
+
+
+def test_module_public_api_imports_only_provider_spi() -> None:
+    assert SearchModule.__module__ == "souwen.modules.search.api"
+    assert LLMSearchModule.__module__ == "souwen.modules.llm_search.api"
+    assert FetchModule.__module__ == "souwen.modules.fetch.api"
+
+    root = Path(__file__).resolve().parents[1]
+    for path in (
+        root / "src/souwen/modules/search/api/__init__.py",
+        root / "src/souwen/modules/llm_search/api/__init__.py",
+        root / "src/souwen/modules/fetch/api/__init__.py",
+    ):
+        imports = [
+            node.module
+            for node in ast.walk(ast.parse(path.read_text(encoding="utf-8")))
+            if isinstance(node, ast.ImportFrom) and node.module
+        ]
+        assert "souwen.platform.provider_spi" in imports
+        assert not any(module.startswith("souwen.providers") for module in imports)

--- a/tests/test_target_canonical_dto.py
+++ b/tests/test_target_canonical_dto.py
@@ -1,0 +1,188 @@
+"""Deterministic conformance tests for the Phase 4 canonical DTO binding."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from souwen.platform.provider_spi import (
+    ContentMetadata,
+    EvidenceItem,
+    FetchBatch,
+    FetchMeta,
+    FetchRequest,
+    FetchResult,
+    LLMSearchRequest,
+    LLMSearchResult,
+    PageInfo,
+    ProviderFailure,
+    ProviderRef,
+    Provenance,
+    RequestContext,
+    SearchItem,
+    SearchFilters,
+    SearchMeta,
+    SearchPage,
+    SearchRequest,
+    Usage,
+)
+
+
+def _context(request_id: str = "fixture-request") -> RequestContext:
+    return RequestContext(request_id=request_id)
+
+
+def _provenance(provider: str = "fixture-provider") -> Provenance:
+    return Provenance(provider=provider, outcome="success")
+
+
+def _search_item(item_id: str = "fixture-item") -> SearchItem:
+    return SearchItem(
+        id=item_id,
+        title="Fixture result",
+        rank=1,
+        provenance=(_provenance(),),
+    )
+
+
+def test_python_binding_validates_the_language_neutral_golden_fixtures() -> None:
+    fixture_path = Path(__file__).parent / "contracts" / "fixtures" / "target_api_contract_v2.json"
+    goldens = json.loads(fixture_path.read_text(encoding="utf-8"))["goldens"]
+
+    assert SearchPage.model_validate(goldens["search_partial_success"]).meta.partial is True
+    assert LLMSearchResult.model_validate(goldens["llm_search_evidence"]).usage.cost is None
+    assert (
+        FetchBatch.model_validate(goldens["fetch_low_quality_partial"]).items[0].content == "short"
+    )
+
+
+def test_common_dtos_are_strict_frozen_and_use_api_major_two() -> None:
+    context = _context()
+    provider = ProviderRef(id="fixture-provider", kind="search")
+
+    assert context.api_major == 2
+    assert provider.model_config["extra"] == "forbid"
+    assert provider.model_config["frozen"] is True
+    assert provider.model_config["hide_input_in_errors"] is True
+
+    with pytest.raises(ValidationError):
+        RequestContext(request_id="fixture", unexpected="value")
+    with pytest.raises(ValidationError):
+        RequestContext(request_id="fixture", api_major=1)
+    with pytest.raises(ValidationError):
+        provider.id = "changed"  # type: ignore[misc]
+
+
+def test_search_dto_preserves_partial_provider_outcome() -> None:
+    page = SearchPage(
+        items=(_search_item("doi:10.1000/fixture"),),
+        page=PageInfo(limit=10),
+        meta=SearchMeta(
+            partial=True,
+            requested=("openalex", "other"),
+            succeeded=("openalex",),
+            failed=(ProviderFailure(provider="other", code="provider_timeout"),),
+        ),
+        context=_context("fixture-request-001"),
+    )
+
+    assert page.model_dump(mode="json")["meta"] == {
+        "partial": True,
+        "requested": ["openalex", "other"],
+        "succeeded": ["openalex"],
+        "failed": [{"provider": "other", "code": "provider_timeout"}],
+    }
+
+
+def test_search_and_llm_requests_reject_blank_and_duplicate_providers() -> None:
+    provider = ProviderRef(id="fixture-llm", kind="llm_search")
+
+    with pytest.raises(ValidationError):
+        SearchRequest(query="   ", domains=("paper",))
+    with pytest.raises(ValidationError):
+        LLMSearchRequest(query="query", providers=(provider, provider), strategy="single")
+    with pytest.raises(ValidationError):
+        SearchFilters(year_from=2026, year_to=2025)
+
+
+def test_llm_result_requires_evidence_and_always_serializes_nullable_usage() -> None:
+    result = LLMSearchResult(
+        query="fixture query",
+        items=(_search_item("fixture-item-001"),),
+        evidence=(
+            EvidenceItem(
+                id="evidence-001",
+                item_id="fixture-item-001",
+                provider="fixture-llm",
+                public_url="https://example.com/evidence",
+                title_or_snippet="Fixture evidence",
+                retrieved_at=datetime(2026, 7, 24, tzinfo=timezone.utc),
+            ),
+        ),
+        answer="Fixture factual answer [evidence-001]",
+        meta=SearchMeta(),
+        usage=Usage(),
+        context=_context("fixture-request-002"),
+    )
+
+    assert result.model_dump(mode="json")["usage"] == {
+        "input_tokens": None,
+        "output_tokens": None,
+        "cost": None,
+        "currency": None,
+    }
+    assert result.evidence[0].item_id == result.items[0].id
+    with pytest.raises(ValidationError):
+        result.model_copy(update={"evidence": ()}).model_validate(
+            result.model_copy(update={"evidence": ()}).model_dump()
+        )
+    with pytest.raises(ValidationError):
+        LLMSearchResult(
+            query="fixture query",
+            items=result.items,
+            evidence=result.evidence,
+            answer="Uncited factual paragraph",
+            meta=SearchMeta(),
+            usage=Usage(),
+            context=result.context,
+        )
+
+
+def test_fetch_dto_enforces_target_cardinality_and_low_quality_partial_item() -> None:
+    request = FetchRequest(targets=("https://example.com/short",))
+    batch = FetchBatch(
+        items=(
+            FetchResult(
+                target="https://example.com/short",
+                status="success",
+                content="short",
+                content_metadata=ContentMetadata(
+                    media_type="text/plain", quality="low", truncated=False
+                ),
+                provenance=(_provenance("builtin"),),
+            ),
+        ),
+        meta=FetchMeta(partial=True),
+        context=_context("fixture-request-003"),
+    )
+
+    assert str(request.targets[0]) == "https://example.com/short"
+    assert batch.model_dump(mode="json")["meta"] == {"partial": True}
+    with pytest.raises(ValidationError):
+        FetchRequest(targets=())
+    with pytest.raises(ValidationError):
+        FetchRequest(targets=tuple(f"https://example.com/{index}" for index in range(21)))
+    with pytest.raises(ValidationError):
+        FetchResult(
+            target="https://example.com/empty",
+            status="success",
+            content="",
+            content_metadata=ContentMetadata(
+                media_type="text/plain", quality="low", truncated=False
+            ),
+            provenance=(_provenance("builtin"),),
+        )


### PR DESCRIPTION
## 目标

交付 Souwen v2rc2 Phase 4 / P4-01：Canonical DTO、三个 Module public API、Provider SPI、静态 Manifest Registry 与 lazy Provider Manager。

本 PR 不包含具体 Provider、Delivery route、rollout 切换、HFS promotion 或版本升级。

## 实现

- 新增严格、不可变的 Search / LLM Search / Fetch canonical Python binding，并与 language-neutral target golden fixtures 对齐。
- 新增 `SearchProvider`、`LLMSearchProvider`、`FetchProvider` 单能力 async Protocol，包含 bounded deadline/cancellation、probe、idempotent close 和安全错误 taxonomy。
- 三个 Module API 仅依赖 Provider SPI，不 import concrete Provider。
- Manifest Registry 只做静态 fail-closed validation/registration；重复或非法 package 仅局部 quarantine，不 import 或构造 Provider。
- Provider Manager 使用显式 factory/config/secret resolver，执行 export/capability/SPI agreement，lazy create，per-adapter loop-local concurrency=10，canonical result validation、probe/close 和 provider-local quarantine。
- 运行中 cancellation 会取消 Provider task；deadline 与 cancellation 保持不同 typed outcome。
- architecture gate 进一步禁止 Module import Provider Manager / Manifest Registry，只允许 Provider SPI。
- legacy registry 仍是未迁移 Provider 的唯一 source/catalog 真源。

## 安全边界

- Manifest/config diagnostics 不返回 raw config、secret 或 exception。
- secret reference 必须全部解析为 non-empty string 才能 eligible。
- Manager 拒绝 raw/non-canonical Provider output。
- Fetch request/SPI 不提供 SSRF、redirect、robots 或 content-policy bypass。

## 验证

```text
python3 scripts/ci/check_architecture_dependencies.py
PASS

python3 -m ruff check src tests scripts tools
PASS

python3 -m ruff format --check src tests scripts tools
522 files already formatted

PYTHONPATH=src python3 tools/gen_docs.py --check
PASS

python3 scripts/ci/check_no_legacy_terms.py
PASS（仅已有 public docs wording warnings）

PYTHONPATH=src python3 -m pytest tests/ -q --tb=short
2507 passed, 3 skipped
```

## 合并约束

- 只在 exact-head CI、V2、CodeQL、HFS-local 适用 gates 全绿后使用 merge commit 合并。
- PR 验证不得执行 HFS promotion。
- 合并后立即删除本 worktree、local branch 和 remote branch，再开始 P4-02。
