### PR TITLE
feat(v2): 落地 P4-02 OpenAlex Search 垂直切片

### DIFF
--- a/src/souwen/modules/search/api/__init__.py
+++ b/src/souwen/modules/search/api/__init__.py
@@ -1,9 +1,10 @@
-"""Search public API. Owner: Search Core. Allowed dependencies: Provider SPI only."""
+"""Search public API. Owner: Search Core. Allowed dependencies: Search application and Provider SPI."""
 
 from __future__ import annotations
 
 from typing import Protocol
 
+from souwen.modules.search.application import SearchModuleService
 from souwen.platform.provider_spi import ExecutionContext, RequestContext, SearchPage, SearchRequest
 
 
@@ -16,4 +17,4 @@ class SearchModule(Protocol):
         """Execute Search without exposing a concrete provider."""
 
 
-__all__ = ["SearchModule", "SearchPage", "SearchRequest"]
+__all__ = ["SearchModule", "SearchModuleService", "SearchPage", "SearchRequest"]

--- a/src/souwen/modules/search/application/__init__.py
+++ b/src/souwen/modules/search/application/__init__.py
@@ -1,3 +1,19 @@
 """Search application layer. Owner: Search Core. Allowed dependencies: own domain, ports, and common runtime."""
 
-__all__: list[str] = []
+from souwen.modules.search.application.orchestration import (
+    OrderedSearchProviderSelector,
+    RRF_K,
+    SearchModuleService,
+    SearchProviderManager,
+    SearchProviderSelection,
+    SearchProviderSelector,
+)
+
+__all__ = [
+    "RRF_K",
+    "OrderedSearchProviderSelector",
+    "SearchModuleService",
+    "SearchProviderManager",
+    "SearchProviderSelection",
+    "SearchProviderSelector",
+]

--- a/src/souwen/modules/search/application/orchestration.py
+++ b/src/souwen/modules/search/application/orchestration.py
@@ -1,0 +1,378 @@
+"""Canonical Search orchestration through injected Provider v2 ports.
+
+Owner: Search Core. Inputs: canonical Search request/context/execution values.
+Outputs: one canonical SearchPage or a safe typed ProviderError. Dependencies:
+the Search Provider SPI only; concrete providers, legacy registry, and delivery
+frameworks are intentionally outside this module.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from souwen.platform.provider_spi import (
+    ExecutionContext,
+    ProviderError,
+    ProviderErrorCode,
+    ProviderFailure,
+    ProviderRef,
+    Provenance,
+    RequestContext,
+    SearchItem,
+    SearchMeta,
+    SearchPage,
+    SearchRequest,
+)
+
+
+RRF_K = 60
+
+
+@dataclass(frozen=True, slots=True)
+class SearchProviderSelection:
+    """One selected search adapter and its YAML ordering priority."""
+
+    provider: ProviderRef
+    adapter_id: str
+    yaml_priority: int
+
+    def __post_init__(self) -> None:
+        if self.provider.kind != "search":
+            raise ValueError("Search provider selection must use kind='search'")
+        if not self.adapter_id:
+            raise ValueError("adapter_id must not be blank")
+
+
+class SearchProviderSelector(Protocol):
+    """Resolve public provider refs to eligible adapter selections.
+
+    The selector is the single boundary for the YAML domain/capability ordered
+    default. It must return exactly one selection for ``select_default``.
+    """
+
+    def select_default(self, request: SearchRequest) -> tuple[SearchProviderSelection, ...]:
+        """Return the one primary selected by YAML domain/capability ordering."""
+
+    def select_explicit(
+        self, providers: tuple[ProviderRef, ...]
+    ) -> tuple[SearchProviderSelection, ...]:
+        """Resolve only the caller's explicitly requested provider IDs."""
+
+
+class OrderedSearchProviderSelector:
+    """Immutable projection of YAML domain/capability provider priority."""
+
+    def __init__(
+        self, selections_by_domain: Mapping[str, tuple[SearchProviderSelection, ...]]
+    ) -> None:
+        ordered: dict[str, tuple[SearchProviderSelection, ...]] = {}
+        by_provider: dict[str, SearchProviderSelection] = {}
+        for domain, selections in selections_by_domain.items():
+            if not domain or not selections:
+                raise ValueError("each Search domain must have at least one provider selection")
+            ranked = tuple(
+                selection
+                for _index, selection in sorted(
+                    enumerate(selections),
+                    key=lambda item: (item[1].yaml_priority, item[0]),
+                )
+            )
+            provider_ids = tuple(selection.provider.id for selection in ranked)
+            if len(provider_ids) != len(set(provider_ids)):
+                raise ValueError("provider selection IDs must be unique within a domain")
+            ordered[domain] = ranked
+            for selection in ranked:
+                existing = by_provider.get(selection.provider.id)
+                if existing is not None and existing != selection:
+                    raise ValueError(
+                        "a provider ID must resolve to one immutable adapter selection"
+                    )
+                by_provider[selection.provider.id] = selection
+        self._by_domain = ordered
+        self._by_provider = by_provider
+
+    def select_default(self, request: SearchRequest) -> tuple[SearchProviderSelection, ...]:
+        if len(request.domains) != 1:
+            raise ProviderError(ProviderErrorCode.INVALID_REQUEST)
+        selections = self._by_domain.get(request.domains[0], ())
+        if not selections:
+            raise ProviderError(ProviderErrorCode.PROVIDER_UNAVAILABLE)
+        return (selections[0],)
+
+    def select_explicit(
+        self, providers: tuple[ProviderRef, ...]
+    ) -> tuple[SearchProviderSelection, ...]:
+        selections: list[SearchProviderSelection] = []
+        for provider in providers:
+            selection = self._by_provider.get(provider.id)
+            if selection is None or provider.kind != "search":
+                raise ProviderError(ProviderErrorCode.PROVIDER_UNAVAILABLE)
+            selections.append(selection)
+        return tuple(selections)
+
+
+class SearchProviderManager(Protocol):
+    """Minimal manager port used by Search Core; concrete construction stays Platform-owned."""
+
+    async def execute(
+        self,
+        adapter_id: str,
+        request: SearchRequest,
+        request_context: RequestContext,
+        execution: ExecutionContext,
+    ) -> SearchPage:
+        """Call the selected adapter solely through the Provider Manager."""
+
+
+@dataclass(slots=True)
+class _Aggregate:
+    item: SearchItem
+    score: float
+    yaml_priority: int
+    local_rank: int
+    canonical_id: str
+    provenance: list[Provenance] = field(default_factory=list)
+
+
+@dataclass(frozen=True, slots=True)
+class _ProviderOutcome:
+    selection: SearchProviderSelection
+    page: SearchPage | None = None
+    error: ProviderError | None = None
+
+
+class SearchModuleService:
+    """Concrete canonical SearchModule implementing primary selection and explicit fanout."""
+
+    def __init__(self, manager: SearchProviderManager, selector: SearchProviderSelector) -> None:
+        self._manager = manager
+        self._selector = selector
+
+    async def search(
+        self,
+        request: SearchRequest,
+        context: RequestContext,
+        execution: ExecutionContext,
+    ) -> SearchPage:
+        """Execute one selected provider or explicitly requested multi-provider fanout."""
+
+        execution.raise_if_cancelled_or_expired()
+        selections = self._select(request)
+        outcomes = await asyncio.gather(
+            *(
+                self._execute_selection(selection, request, context, execution)
+                for selection in selections
+            )
+        )
+        execution.raise_if_cancelled_or_expired()
+
+        successes: list[tuple[SearchProviderSelection, SearchPage]] = []
+        failures: list[ProviderFailure] = []
+        errors: list[ProviderError] = []
+        for outcome in outcomes:
+            if outcome.page is not None:
+                successes.append((outcome.selection, outcome.page))
+                continue
+            error = outcome.error or ProviderError(ProviderErrorCode.PROVIDER_UNAVAILABLE)
+            errors.append(error)
+            failures.append(
+                ProviderFailure(
+                    provider=outcome.selection.provider.id,
+                    code=_canonical_failure_code(error.code),
+                )
+            )
+
+        if not successes:
+            raise _all_fail_error(errors)
+
+        items = _merge_items(successes)
+        first_page = successes[0][1].page
+        # A provider cursor is meaningful only for that provider. Explicit
+        # fanout deliberately does not expose one provider's continuation as a
+        # canonical multi-provider cursor.
+        page = (
+            first_page
+            if len(successes) == 1
+            else first_page.model_copy(update={"next_cursor": None, "total": None})
+        )
+        return SearchPage(
+            items=items,
+            page=page,
+            meta=SearchMeta(
+                partial=bool(failures),
+                requested=tuple(selection.provider.id for selection in selections),
+                succeeded=tuple(selection.provider.id for selection, _page in successes),
+                failed=tuple(failures),
+            ),
+            context=context,
+        )
+
+    async def _execute_selection(
+        self,
+        selection: SearchProviderSelection,
+        request: SearchRequest,
+        context: RequestContext,
+        execution: ExecutionContext,
+    ) -> _ProviderOutcome:
+        execution.raise_if_cancelled_or_expired()
+        try:
+            page = await self._manager.execute(selection.adapter_id, request, context, execution)
+        except ProviderError as error:
+            return _ProviderOutcome(selection=selection, error=error)
+        except Exception:
+            # Platform diagnostics remain Platform-owned; Core exposes only a safe outcome.
+            return _ProviderOutcome(
+                selection=selection,
+                error=ProviderError(ProviderErrorCode.PROVIDER_UNAVAILABLE),
+            )
+        return _ProviderOutcome(selection=selection, page=page)
+
+    def _select(self, request: SearchRequest) -> tuple[SearchProviderSelection, ...]:
+        if request.providers is None:
+            try:
+                selections = self._selector.select_default(request)
+            except ProviderError:
+                raise
+            except Exception as exc:
+                raise ProviderError(ProviderErrorCode.PROVIDER_UNAVAILABLE) from exc
+            if len(selections) != 1:
+                raise ProviderError(ProviderErrorCode.PROVIDER_UNAVAILABLE)
+            return selections
+
+        try:
+            selections = self._selector.select_explicit(request.providers)
+        except ProviderError:
+            raise
+        except Exception as exc:
+            raise ProviderError(ProviderErrorCode.PROVIDER_UNAVAILABLE) from exc
+        expected = tuple(provider.id for provider in request.providers)
+        selected = tuple(selection.provider.id for selection in selections)
+        if len(selections) != len(expected) or set(selected) != set(expected):
+            raise ProviderError(ProviderErrorCode.PROVIDER_UNAVAILABLE)
+        return selections
+
+
+def _merge_items(
+    pages: list[tuple[SearchProviderSelection, SearchPage]],
+) -> tuple[SearchItem, ...]:
+    aggregates: list[_Aggregate] = []
+    for selection, page in pages:
+        for position, item in enumerate(page.items, start=1):
+            local_rank = item.rank if item.rank is not None else position
+            aggregate = next(
+                (candidate for candidate in aggregates if _same_result(candidate.item, item)), None
+            )
+            contribution = 1 / (RRF_K + local_rank)
+            if aggregate is None:
+                aggregates.append(
+                    _Aggregate(
+                        item=item,
+                        score=contribution,
+                        yaml_priority=selection.yaml_priority,
+                        local_rank=local_rank,
+                        canonical_id=item.id,
+                        provenance=list(item.provenance),
+                    )
+                )
+                continue
+            aggregate.score += contribution
+            aggregate.yaml_priority = min(aggregate.yaml_priority, selection.yaml_priority)
+            aggregate.local_rank = min(aggregate.local_rank, local_rank)
+            aggregate.provenance = _merge_provenance(aggregate.provenance, item.provenance)
+
+    ordered = sorted(
+        aggregates,
+        key=lambda aggregate: (
+            -aggregate.score,
+            aggregate.yaml_priority,
+            aggregate.local_rank,
+            aggregate.canonical_id,
+        ),
+    )
+    return tuple(
+        aggregate.item.model_copy(
+            update={
+                "rank": index,
+                "provenance": tuple(aggregate.provenance),
+            }
+        )
+        for index, aggregate in enumerate(ordered, start=1)
+    )
+
+
+def _same_result(left: SearchItem, right: SearchItem) -> bool:
+    """Apply the approved stable-ID, URL, then normalized title/year deduplication order."""
+
+    left_identifiers = _stable_identifiers(left)
+    right_identifiers = _stable_identifiers(right)
+    if left_identifiers and right_identifiers and left_identifiers.intersection(right_identifiers):
+        return True
+    if left.url is not None and right.url is not None and str(left.url) == str(right.url):
+        return True
+    return _normalized_title_year(left) == _normalized_title_year(right)
+
+
+def _stable_identifiers(item: SearchItem) -> frozenset[tuple[str, str]]:
+    if item.attributes is None:
+        return frozenset()
+    return frozenset(
+        (identifier.scheme.casefold(), identifier.value.strip().casefold())
+        for identifier in item.attributes.identifiers
+    )
+
+
+def _normalized_title_year(item: SearchItem) -> tuple[str, int | None]:
+    year = item.attributes.year if item.attributes is not None else None
+    normalized_title = " ".join(item.title.casefold().split())
+    return normalized_title, year
+
+
+def _merge_provenance(
+    current: list[Provenance], incoming: tuple[Provenance, ...]
+) -> list[Provenance]:
+    seen = {(item.provider, item.attempt, item.outcome, item.retrieved_at) for item in current}
+    for item in incoming:
+        key = (item.provider, item.attempt, item.outcome, item.retrieved_at)
+        if key not in seen:
+            current.append(item)
+            seen.add(key)
+    return current
+
+
+def _canonical_failure_code(code: ProviderErrorCode) -> str:
+    return {
+        ProviderErrorCode.INVALID_REQUEST: "invalid_request",
+        ProviderErrorCode.INVALID_CONFIG: "provider_unavailable",
+        ProviderErrorCode.CANCELLED: "provider_timeout",
+        ProviderErrorCode.DEADLINE_EXCEEDED: "provider_timeout",
+        ProviderErrorCode.RATE_LIMITED: "rate_limited",
+        ProviderErrorCode.PROVIDER_UNAVAILABLE: "provider_unavailable",
+        ProviderErrorCode.INVALID_UPSTREAM_RESPONSE: "provider_unavailable",
+        ProviderErrorCode.POLICY_BLOCKED: "policy_blocked",
+    }[code]
+
+
+def _all_fail_error(errors: list[ProviderError]) -> ProviderError:
+    if errors and all(error.code is ProviderErrorCode.RATE_LIMITED for error in errors):
+        return ProviderError(ProviderErrorCode.RATE_LIMITED)
+    if errors and all(error.code is ProviderErrorCode.POLICY_BLOCKED for error in errors):
+        return ProviderError(ProviderErrorCode.POLICY_BLOCKED)
+    if errors and all(
+        error.code in {ProviderErrorCode.CANCELLED, ProviderErrorCode.DEADLINE_EXCEEDED}
+        for error in errors
+    ):
+        return ProviderError(ProviderErrorCode.DEADLINE_EXCEEDED)
+    return ProviderError(ProviderErrorCode.PROVIDER_UNAVAILABLE)
+
+
+__all__ = [
+    "RRF_K",
+    "OrderedSearchProviderSelector",
+    "SearchModuleService",
+    "SearchProviderManager",
+    "SearchProviderSelection",
+    "SearchProviderSelector",
+]

--- a/src/souwen/providers/information_sources/openalex/__init__.py
+++ b/src/souwen/providers/information_sources/openalex/__init__.py
@@ -1,0 +1,6 @@
+"""OpenAlex Provider v2 adapter. Owner: Providers. Allowed dependencies: SPI and common runtime."""
+
+from .adapter import OpenAlexClientProtocol, OpenAlexSearchProvider
+from .manifest import OPENALEX_PROVIDER_MANIFEST
+
+__all__ = ["OPENALEX_PROVIDER_MANIFEST", "OpenAlexClientProtocol", "OpenAlexSearchProvider"]

--- a/src/souwen/providers/information_sources/openalex/adapter.py
+++ b/src/souwen/providers/information_sources/openalex/adapter.py
@@ -1,0 +1,335 @@
+"""Provider v2 adapter that maps an injected legacy OpenAlex client to canonical Search."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Mapping, Sequence
+from contextlib import suppress
+from typing import Any, Protocol
+from urllib.parse import urlsplit
+
+from souwen.common_runtime.errors import SouWenError
+from souwen.common_runtime.transport.errors import RateLimitError, SourceUnavailableError
+from souwen.platform.provider_spi import (
+    ExecutionContext,
+    PageInfo,
+    ProviderError,
+    ProviderErrorCode,
+    ProviderProbe,
+    Provenance,
+    RequestContext,
+    SearchAttributes,
+    SearchIdentifier,
+    SearchItem,
+    SearchMeta,
+    SearchPage,
+    SearchRequest,
+)
+
+
+_PROVIDER_ID = "openalex"
+
+
+class OpenAlexClientProtocol(Protocol):
+    """The minimal legacy-client surface used by this target adapter."""
+
+    async def search(
+        self,
+        query: str,
+        filters: dict[str, str] | None = None,
+        sort: str | None = None,
+        page: int = 1,
+        per_page: int = 10,
+    ) -> Any:
+        """Return a legacy ``SearchResponse`` compatible object."""
+
+
+class OpenAlexSearchProvider:
+    """Search-only provider that preserves legacy OpenAlex query behavior behind the SPI."""
+
+    capability = "search"
+
+    def __init__(self, client: OpenAlexClientProtocol, *, enabled: bool = True) -> None:
+        self._client = client
+        self._enabled = enabled
+        self._closed = False
+
+    async def search(
+        self,
+        request: SearchRequest,
+        context: RequestContext,
+        execution: ExecutionContext,
+    ) -> SearchPage:
+        """Map canonical paper search to the legacy client's bounded first page."""
+        execution.raise_if_cancelled_or_expired()
+        if self._closed or not self._enabled:
+            raise ProviderError(ProviderErrorCode.INVALID_CONFIG, provider_id=_PROVIDER_ID)
+        if request.domains != ("paper",):
+            raise ProviderError(ProviderErrorCode.INVALID_REQUEST, provider_id=_PROVIDER_ID)
+        if request.page is not None and request.page.cursor is not None:
+            raise ProviderError(ProviderErrorCode.INVALID_REQUEST, provider_id=_PROVIDER_ID)
+
+        limit = request.page.limit if request.page is not None else 10
+        filters = _legacy_filters(request)
+        try:
+            response = await _await_with_execution(
+                self._client.search(
+                    request.query,
+                    filters=filters,
+                    sort=None,
+                    page=1,
+                    per_page=limit,
+                ),
+                execution,
+            )
+            execution.raise_if_cancelled_or_expired()
+            return _to_search_page(response, limit=limit, context=context)
+        except asyncio.CancelledError:
+            raise
+        except ProviderError:
+            raise
+        except RateLimitError as exc:
+            raise ProviderError(
+                ProviderErrorCode.RATE_LIMITED,
+                provider_id=_PROVIDER_ID,
+                retry_after_seconds=getattr(exc, "retry_after", None),
+            ) from None
+        except TimeoutError:
+            raise ProviderError(
+                ProviderErrorCode.DEADLINE_EXCEEDED, provider_id=_PROVIDER_ID
+            ) from None
+        except SourceUnavailableError:
+            raise ProviderError(
+                ProviderErrorCode.PROVIDER_UNAVAILABLE, provider_id=_PROVIDER_ID
+            ) from None
+        except SouWenError as exc:
+            code = (
+                ProviderErrorCode.INVALID_CONFIG
+                if type(exc).__name__ == "ConfigError"
+                else ProviderErrorCode.INVALID_UPSTREAM_RESPONSE
+            )
+            raise ProviderError(code, provider_id=_PROVIDER_ID) from None
+        except (AttributeError, TypeError, ValueError):
+            raise ProviderError(
+                ProviderErrorCode.INVALID_UPSTREAM_RESPONSE, provider_id=_PROVIDER_ID
+            ) from None
+        except Exception:
+            raise ProviderError(
+                ProviderErrorCode.PROVIDER_UNAVAILABLE, provider_id=_PROVIDER_ID
+            ) from None
+
+    async def probe(self, execution: ExecutionContext) -> ProviderProbe:
+        """Return bounded local readiness without issuing a billable/network probe."""
+        execution.raise_if_cancelled_or_expired()
+        return ProviderProbe(
+            provider=_PROVIDER_ID,
+            capability="search",
+            status="unavailable" if self._closed or not self._enabled else "available",
+        )
+
+    async def close(self) -> None:
+        """Close an owned injected client at most once when it exposes a close operation."""
+        if self._closed:
+            return
+        self._closed = True
+        closer = getattr(self._client, "aclose", None) or getattr(self._client, "close", None)
+        if closer is None:
+            return
+        try:
+            result = closer()
+            if inspect.isawaitable(result):
+                await result
+        except asyncio.CancelledError:
+            self._closed = False
+            raise
+
+
+async def _await_with_execution(value: Any, execution: ExecutionContext) -> Any:
+    """Apply the SPI deadline and live cancellation signal to the injected client call."""
+    provider_task = asyncio.ensure_future(value)
+    cancellation_task = asyncio.create_task(execution.cancel_event.wait())
+    try:
+        done, _pending = await asyncio.wait(
+            {provider_task, cancellation_task},
+            timeout=execution.remaining_seconds,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if provider_task in done:
+            return await provider_task
+        provider_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await provider_task
+        code = (
+            ProviderErrorCode.CANCELLED
+            if cancellation_task in done
+            else ProviderErrorCode.DEADLINE_EXCEEDED
+        )
+        raise ProviderError(code, provider_id=_PROVIDER_ID)
+    finally:
+        cancellation_task.cancel()
+        if not provider_task.done():
+            provider_task.cancel()
+        await asyncio.gather(provider_task, cancellation_task, return_exceptions=True)
+
+
+def _legacy_filters(request: SearchRequest) -> dict[str, str] | None:
+    """Map only canonical, reviewed filters in deterministic upstream parameter order."""
+    if request.filters is None:
+        return None
+    filters: dict[str, str] = {}
+    if request.filters.year_from is not None:
+        filters["from_publication_date"] = f"{request.filters.year_from:04d}-01-01"
+    if request.filters.year_to is not None:
+        filters["to_publication_date"] = f"{request.filters.year_to:04d}-12-31"
+    if request.filters.language is not None:
+        filters["language"] = request.filters.language
+    if request.filters.open_access is not None:
+        filters["is_oa"] = "true" if request.filters.open_access else "false"
+    if request.filters.resource_type is not None:
+        filters["type"] = request.filters.resource_type
+    return filters or None
+
+
+def _to_search_page(response: Any, *, limit: int, context: RequestContext) -> SearchPage:
+    """Strictly transform legacy ``SearchResponse`` / ``PaperResult`` data to canonical DTOs."""
+    if getattr(response, "source", None) != _PROVIDER_ID:
+        raise ValueError("unexpected legacy response source")
+    results = getattr(response, "results", None)
+    total = getattr(response, "total_results", None)
+    response_page = getattr(response, "page", None)
+    response_limit = getattr(response, "per_page", None)
+    if not isinstance(results, Sequence) or isinstance(results, (str, bytes)):
+        raise ValueError("invalid legacy search results")
+    if total is not None and (not isinstance(total, int) or isinstance(total, bool) or total < 0):
+        raise ValueError("invalid legacy result total")
+    if response_page != 1 or response_limit != limit:
+        raise ValueError("legacy page does not match canonical request")
+
+    items = tuple(
+        _to_search_item(paper, rank=index) for index, paper in enumerate(results, start=1)
+    )
+    return SearchPage(
+        items=items,
+        page=PageInfo(limit=limit, next_cursor=None, total=total),
+        meta=SearchMeta(requested=(_PROVIDER_ID,), succeeded=(_PROVIDER_ID,)),
+        context=context,
+    )
+
+
+def _to_search_item(paper: Any, *, rank: int) -> SearchItem:
+    """Map one normalized legacy paper while retaining only canonical public metadata."""
+    if getattr(paper, "source", None) != _PROVIDER_ID:
+        raise ValueError("unexpected legacy paper source")
+    title = _required_text(getattr(paper, "title", None))
+    doi = _normalise_doi(getattr(paper, "doi", None))
+    source_url = _normalise_url(getattr(paper, "source_url", None))
+    if doi is None and source_url is None:
+        raise ValueError("paper lacks stable identifier")
+
+    identifiers: list[SearchIdentifier] = []
+    if doi is not None:
+        identifiers.append(SearchIdentifier(scheme="doi", value=doi))
+    if source_url is not None:
+        identifiers.append(SearchIdentifier(scheme="openalex", value=source_url))
+    item_id = f"doi:{doi.lower()}" if doi is not None else f"openalex:{source_url}"
+    canonical_url = f"https://doi.org/{doi}" if doi is not None else source_url
+    raw = getattr(paper, "raw", {})
+    if not isinstance(raw, Mapping):
+        raise ValueError("invalid legacy paper attributes")
+
+    return SearchItem(
+        id=item_id,
+        title=title,
+        url=canonical_url,
+        snippet=_optional_text(getattr(paper, "abstract", None)),
+        rank=rank,
+        provenance=(Provenance(provider=_PROVIDER_ID, attempt=1, outcome="success"),),
+        attributes=SearchAttributes(
+            year=_optional_int(getattr(paper, "year", None)),
+            authors=_author_names(getattr(paper, "authors", None)),
+            identifiers=tuple(identifiers),
+            resource_type=_optional_text(raw.get("type")),
+            open_access=raw.get("is_oa") if isinstance(raw.get("is_oa"), bool) else None,
+            citation_count=_optional_nonnegative_int(getattr(paper, "citation_count", None)),
+        ),
+    )
+
+
+def _required_text(value: Any) -> str:
+    normalized = _optional_text(value)
+    if normalized is None:
+        raise ValueError("missing required text")
+    return normalized
+
+
+def _optional_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError("invalid text")
+    normalized = value.strip()
+    return normalized or None
+
+
+def _normalise_doi(value: Any) -> str | None:
+    doi = _optional_text(value)
+    if doi is None:
+        return None
+    for prefix in ("https://doi.org/", "http://doi.org/"):
+        if doi.lower().startswith(prefix):
+            doi = doi[len(prefix) :]
+            break
+    doi = _required_text(doi)
+    prefix, separator, suffix = doi.partition("/")
+    if not separator or not prefix.startswith("10.") or not prefix[3:].isdigit() or not suffix:
+        raise ValueError("invalid DOI")
+    if any(character.isspace() for character in doi):
+        raise ValueError("invalid DOI")
+    return doi
+
+
+def _normalise_url(value: Any) -> str | None:
+    url = _optional_text(value)
+    if url is None:
+        return None
+    parsed = urlsplit(url)
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname != "openalex.org"
+        or not parsed.path.startswith("/W")
+    ):
+        raise ValueError("invalid OpenAlex source URL")
+    return url
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool) or not 0 <= value <= 9999:
+        raise ValueError("invalid year")
+    return value
+
+
+def _optional_nonnegative_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ValueError("invalid citation count")
+    return value
+
+
+def _author_names(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise ValueError("invalid authors")
+    names: list[str] = []
+    for author in value:
+        name = _required_text(getattr(author, "name", None))
+        if name not in names:
+            names.append(name)
+    return tuple(names)
+
+
+__all__ = ["OpenAlexClientProtocol", "OpenAlexSearchProvider"]

--- a/src/souwen/providers/information_sources/openalex/manifest.py
+++ b/src/souwen/providers/information_sources/openalex/manifest.py
@@ -1,0 +1,46 @@
+"""Static Provider v2 declaration for the built-in OpenAlex search adapter."""
+
+from __future__ import annotations
+
+from souwen.platform.manifest_registry import ProviderManifest
+
+
+OPENALEX_PROVIDER_MANIFEST = ProviderManifest.model_validate(
+    {
+        "schema_version": 2,
+        "id": "openalex",
+        "version": "2.0.0rc2",
+        "contract_version": "provider-v2",
+        "capabilities": ["search"],
+        "adapters": [
+            {
+                "id": "openalex-search",
+                "capability": "search",
+                "export": "OpenAlexSearchProvider",
+                "availability": "configured",
+            }
+        ],
+        "configuration": {
+            "schema_reference": "openalex-provider-config-v1",
+            "unknown_key_policy": "reject",
+            "non_secret_keys": ["enabled"],
+        },
+        # OpenAlex has anonymous access. An API key raises quota but is not a
+        # required v2 secret reference and therefore cannot make it ineligible.
+        "secrets": {"references": []},
+        "network": {
+            "egress_hosts": ["api.openalex.org"],
+            "proxy_supported": True,
+            "browser_required": False,
+        },
+        "risk": {"authenticated": False, "costed": False},
+        "observability": {"dimensions": ["provider", "adapter", "capability", "outcome"]},
+        "compatibility": {
+            "contract_versions": ["provider-v2"],
+            "config_schema_versions": ["openalex-provider-config-v1"],
+        },
+    }
+)
+
+
+__all__ = ["OPENALEX_PROVIDER_MANIFEST"]

--- a/tests/test_openalex_provider_v2.py
+++ b/tests/test_openalex_provider_v2.py
@@ -1,0 +1,326 @@
+"""Deterministic conformance for the OpenAlex Provider v2 adapter."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from souwen.common_runtime.transport.errors import RateLimitError, SourceUnavailableError
+from souwen.core.exceptions import ConfigError
+from souwen.models import Author, PaperResult, SearchResponse
+from souwen.platform.provider_spi import (
+    ExecutionContext,
+    ProviderError,
+    ProviderErrorCode,
+    RequestContext,
+    SearchFilters,
+    SearchPageRequest,
+    SearchRequest,
+)
+from souwen.providers.information_sources.openalex import (
+    OPENALEX_PROVIDER_MANIFEST,
+    OpenAlexSearchProvider,
+)
+from souwen.registry import get
+
+
+class FakeOpenAlexClient:
+    def __init__(self, response: SearchResponse | Exception) -> None:
+        self.response = response
+        self.calls: list[dict[str, object]] = []
+        self.close_count = 0
+
+    async def search(self, query, filters=None, sort=None, page=1, per_page=10):
+        self.calls.append(
+            {
+                "query": query,
+                "filters": filters,
+                "sort": sort,
+                "page": page,
+                "per_page": per_page,
+            }
+        )
+        if isinstance(self.response, Exception):
+            raise self.response
+        return self.response
+
+    async def close(self) -> None:
+        self.close_count += 1
+
+
+def _paper(**overrides: object) -> PaperResult:
+    values: dict[str, object] = {
+        "source": "openalex",
+        "title": "Attention Is All You Need",
+        "authors": [Author(name="Ashish Vaswani"), Author(name="Noam Shazeer")],
+        "abstract": "A dominant approach to sequence modelling.",
+        "doi": "10.1038/s41586-021-03819-2",
+        "year": 2017,
+        "citation_count": 90000,
+        "source_url": "https://openalex.org/W2741809807",
+        "raw": {"type": "article", "is_oa": True},
+    }
+    values.update(overrides)
+    return PaperResult(**values)
+
+
+def _response(*papers: PaperResult, per_page: int = 10) -> SearchResponse:
+    return SearchResponse(
+        query="attention",
+        source="openalex",
+        total_results=len(papers),
+        page=1,
+        per_page=per_page,
+        results=list(papers),
+    )
+
+
+def _request(**overrides: object) -> SearchRequest:
+    values: dict[str, object] = {
+        "query": "attention",
+        "domains": ("paper",),
+    }
+    values.update(overrides)
+    return SearchRequest(**values)
+
+
+def _context() -> RequestContext:
+    return RequestContext(request_id="openalex-provider-v2")
+
+
+def _execution() -> ExecutionContext:
+    return ExecutionContext.with_timeout(5)
+
+
+@pytest.mark.asyncio
+async def test_manifest_and_limited_legacy_registry_parity() -> None:
+    legacy = get("openalex")
+
+    assert OPENALEX_PROVIDER_MANIFEST.id == legacy.name == "openalex"
+    assert OPENALEX_PROVIDER_MANIFEST.capabilities == ("search",)
+    assert OPENALEX_PROVIDER_MANIFEST.adapters[0].id == "openalex-search"
+    assert OPENALEX_PROVIDER_MANIFEST.adapters[0].availability == "configured"
+    assert OPENALEX_PROVIDER_MANIFEST.version == "2.0.0rc2"
+    assert OPENALEX_PROVIDER_MANIFEST.secrets.references == ()
+    assert legacy.needs_config is False
+    assert legacy.optional_credential_effect == "quota"
+
+
+@pytest.mark.asyncio
+async def test_search_maps_legacy_response_to_canonical_page_and_filters() -> None:
+    client = FakeOpenAlexClient(_response(_paper(), per_page=7))
+    provider = OpenAlexSearchProvider(client)
+    request = _request(
+        filters=SearchFilters(
+            year_from=2016,
+            year_to=2018,
+            language="en",
+            open_access=True,
+            resource_type="article",
+        ),
+        page=SearchPageRequest(limit=7),
+    )
+
+    page = await provider.search(request, _context(), _execution())
+
+    assert client.calls == [
+        {
+            "query": "attention",
+            "filters": {
+                "from_publication_date": "2016-01-01",
+                "to_publication_date": "2018-12-31",
+                "language": "en",
+                "is_oa": "true",
+                "type": "article",
+            },
+            "sort": None,
+            "page": 1,
+            "per_page": 7,
+        }
+    ]
+    assert page.page.limit == 7
+    assert page.page.next_cursor is None
+    assert page.page.total == 1
+    assert page.meta.succeeded == ("openalex",)
+    item = page.items[0]
+    assert item.id == "doi:10.1038/s41586-021-03819-2"
+    assert str(item.url) == "https://doi.org/10.1038/s41586-021-03819-2"
+    assert item.rank == 1
+    assert item.provenance[0].provider == "openalex"
+    assert item.attributes is not None
+    assert item.attributes.identifiers[0].scheme == "doi"
+    assert item.attributes.identifiers[1].scheme == "openalex"
+    assert item.attributes.authors == ("Ashish Vaswani", "Noam Shazeer")
+    assert item.attributes.year == 2017
+    assert item.attributes.open_access is True
+    assert item.attributes.citation_count == 90000
+
+
+@pytest.mark.asyncio
+async def test_openalex_identifier_is_used_when_doi_is_absent() -> None:
+    client = FakeOpenAlexClient(_response(_paper(doi=None)))
+    provider = OpenAlexSearchProvider(client)
+
+    page = await provider.search(_request(), _context(), _execution())
+
+    assert page.items[0].id == "openalex:https://openalex.org/W2741809807"
+    assert str(page.items[0].url) == "https://openalex.org/W2741809807"
+
+
+@pytest.mark.asyncio
+async def test_cursor_and_non_paper_requests_fail_before_legacy_client_call() -> None:
+    client = FakeOpenAlexClient(_response(_paper()))
+    provider = OpenAlexSearchProvider(client)
+
+    with pytest.raises(ProviderError) as cursor_error:
+        await provider.search(
+            _request(page=SearchPageRequest(limit=10, cursor="opaque")), _context(), _execution()
+        )
+    with pytest.raises(ProviderError) as domain_error:
+        await provider.search(_request(domains=("web",)), _context(), _execution())
+    with pytest.raises(ProviderError) as mixed_domain_error:
+        await provider.search(_request(domains=("paper", "web")), _context(), _execution())
+
+    assert cursor_error.value.code is ProviderErrorCode.INVALID_REQUEST
+    assert domain_error.value.code is ProviderErrorCode.INVALID_REQUEST
+    assert mixed_domain_error.value.code is ProviderErrorCode.INVALID_REQUEST
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_typed_error_mapping_does_not_expose_legacy_error_text() -> None:
+    client = FakeOpenAlexClient(RateLimitError("secret=not-exposed", retry_after=3))
+    provider = OpenAlexSearchProvider(client)
+
+    with pytest.raises(ProviderError) as exc_info:
+        await provider.search(_request(), _context(), _execution())
+
+    assert exc_info.value.code is ProviderErrorCode.RATE_LIMITED
+    assert exc_info.value.retry_after_seconds == 3
+    assert "not-exposed" not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("failure", "expected"),
+    [
+        (TimeoutError("secret=not-exposed"), ProviderErrorCode.DEADLINE_EXCEEDED),
+        (ConfigError("openalex_api_key", "OpenAlex"), ProviderErrorCode.INVALID_CONFIG),
+        (SourceUnavailableError("secret=not-exposed"), ProviderErrorCode.PROVIDER_UNAVAILABLE),
+    ],
+)
+async def test_timeout_config_and_unavailable_errors_remain_typed_and_safe(
+    failure, expected
+) -> None:
+    provider = OpenAlexSearchProvider(FakeOpenAlexClient(failure))
+
+    with pytest.raises(ProviderError) as exc_info:
+        await provider.search(_request(), _context(), _execution())
+
+    assert exc_info.value.code is expected
+    assert "not-exposed" not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_legacy_page_mismatch_fails_closed() -> None:
+    mismatched = _response(_paper())
+    mismatched.page = 2
+    provider = OpenAlexSearchProvider(FakeOpenAlexClient(mismatched))
+
+    with pytest.raises(ProviderError) as exc_info:
+        await provider.search(_request(), _context(), _execution())
+
+    assert exc_info.value.code is ProviderErrorCode.INVALID_UPSTREAM_RESPONSE
+
+
+@pytest.mark.asyncio
+async def test_invalid_legacy_item_is_classified_without_provider_call_leakage() -> None:
+    client = FakeOpenAlexClient(_response(_paper(doi=None, source_url="")))
+    provider = OpenAlexSearchProvider(client)
+
+    with pytest.raises(ProviderError) as exc_info:
+        await provider.search(_request(), _context(), _execution())
+
+    assert exc_info.value.code is ProviderErrorCode.INVALID_UPSTREAM_RESPONSE
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "paper",
+    [
+        _paper(doi="not-a-doi"),
+        _paper(doi=None, source_url="https://example.com/W2741809807"),
+    ],
+)
+async def test_untrusted_identifiers_fail_closed(paper: PaperResult) -> None:
+    provider = OpenAlexSearchProvider(FakeOpenAlexClient(_response(paper)))
+
+    with pytest.raises(ProviderError) as exc_info:
+        await provider.search(_request(), _context(), _execution())
+
+    assert exc_info.value.code is ProviderErrorCode.INVALID_UPSTREAM_RESPONSE
+
+
+@pytest.mark.asyncio
+async def test_in_flight_cancellation_stops_the_injected_client_call() -> None:
+    entered = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    class BlockingClient:
+        async def search(self, *args, **kwargs):
+            entered.set()
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+    event = asyncio.Event()
+    task = asyncio.create_task(
+        OpenAlexSearchProvider(BlockingClient()).search(
+            _request(),
+            _context(),
+            ExecutionContext.with_timeout(5, cancel_event=event),
+        )
+    )
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    event.set()
+
+    with pytest.raises(ProviderError) as exc_info:
+        await asyncio.wait_for(task, timeout=1)
+
+    assert exc_info.value.code is ProviderErrorCode.CANCELLED
+    assert cancelled.is_set()
+
+
+@pytest.mark.asyncio
+async def test_probe_is_local_and_close_is_idempotent() -> None:
+    client = FakeOpenAlexClient(_response(_paper()))
+    provider = OpenAlexSearchProvider(client)
+
+    probe = await provider.probe(_execution())
+    await provider.close()
+    await provider.close()
+    unavailable = await provider.probe(_execution())
+
+    assert probe.status == "available"
+    assert unavailable.status == "unavailable"
+    assert client.calls == []
+    assert client.close_count == 1
+
+
+@pytest.mark.asyncio
+async def test_cancelled_execution_fails_without_calling_legacy_client() -> None:
+    client = FakeOpenAlexClient(_response(_paper()))
+    provider = OpenAlexSearchProvider(client)
+    event = asyncio.Event()
+    event.set()
+
+    with pytest.raises(ProviderError) as exc_info:
+        await provider.search(
+            _request(), _context(), ExecutionContext.with_timeout(5, cancel_event=event)
+        )
+
+    assert exc_info.value.code is ProviderErrorCode.CANCELLED
+    assert client.calls == []

--- a/tests/test_openalex_search_vertical_v2.py
+++ b/tests/test_openalex_search_vertical_v2.py
@@ -1,0 +1,86 @@
+"""Deterministic P4-02 vertical integration through Module, Manager, and OpenAlex SPI."""
+
+from __future__ import annotations
+
+import pytest
+
+from souwen.models import Author, PaperResult, SearchResponse
+from souwen.modules.search.application import (
+    OrderedSearchProviderSelector,
+    SearchModuleService,
+    SearchProviderSelection,
+)
+from souwen.platform.provider_manager import ProviderManager
+from souwen.platform.provider_spi import (
+    ExecutionContext,
+    ProviderRef,
+    RequestContext,
+    SearchRequest,
+)
+from souwen.providers.information_sources.openalex import (
+    OPENALEX_PROVIDER_MANIFEST,
+    OpenAlexSearchProvider,
+)
+
+
+class _Client:
+    async def search(self, query, filters=None, sort=None, page=1, per_page=10):
+        return SearchResponse(
+            query=query,
+            source="openalex",
+            total_results=1,
+            page=page,
+            per_page=per_page,
+            results=[
+                PaperResult(
+                    source="openalex",
+                    source_url="https://openalex.org/W2741809807",
+                    title="Fixture paper",
+                    authors=[Author(name="Fixture Author")],
+                    doi="10.1000/fixture",
+                    year=2026,
+                    raw={"type": "article", "is_oa": True},
+                )
+            ],
+        )
+
+    async def close(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_openalex_vertical_runs_only_through_provider_manager_and_search_module() -> None:
+    client = _Client()
+    manager = ProviderManager(config_resolver=lambda _manifest: {"enabled": True})
+    manager.register_factory(
+        package_id="openalex",
+        export="OpenAlexSearchProvider",
+        factory=lambda configuration, _secrets: OpenAlexSearchProvider(
+            client, enabled=configuration["enabled"]
+        ),
+        provider_type=OpenAlexSearchProvider,
+    )
+    registrations = manager.discover((OPENALEX_PROVIDER_MANIFEST,))
+    selection = SearchProviderSelection(
+        provider=ProviderRef(id="openalex", kind="search"),
+        adapter_id="openalex-search",
+        yaml_priority=1,
+    )
+    service = SearchModuleService(
+        manager,
+        OrderedSearchProviderSelector({"paper": (selection,)}),
+    )
+    context = RequestContext(request_id="openalex-vertical-v2")
+
+    page = await service.search(
+        SearchRequest(query="fixture", domains=("paper",)),
+        context,
+        ExecutionContext.with_timeout(5),
+    )
+
+    assert registrations[0].accepted is True
+    assert page.context == context
+    assert page.items[0].id == "doi:10.1000/fixture"
+    assert page.meta.requested == ("openalex",)
+    assert page.meta.succeeded == ("openalex",)
+    await manager.close_all()

--- a/tests/test_phase2_module_skeleton.py
+++ b/tests/test_phase2_module_skeleton.py
@@ -55,6 +55,7 @@ SKELETON_PACKAGES = (
 IMPLEMENTED_PACKAGES = frozenset(
     {
         "souwen.modules.search.api",
+        "souwen.modules.search.application",
         "souwen.modules.llm_search.api",
         "souwen.modules.fetch.api",
         "souwen.platform.provider_spi",

--- a/tests/test_search_module_v2.py
+++ b/tests/test_search_module_v2.py
@@ -1,0 +1,425 @@
+"""Deterministic Search Module v2 orchestration conformance tests."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+
+import pytest
+
+from souwen.modules.search.api import SearchModuleService
+from souwen.modules.search.application import (
+    OrderedSearchProviderSelector,
+    SearchProviderSelection,
+)
+from souwen.platform.provider_spi import (
+    ExecutionContext,
+    PageInfo,
+    ProviderError,
+    ProviderErrorCode,
+    ProviderFailure,
+    ProviderRef,
+    Provenance,
+    RequestContext,
+    SearchAttributes,
+    SearchIdentifier,
+    SearchItem,
+    SearchMeta,
+    SearchPage,
+    SearchRequest,
+)
+
+
+def _context() -> RequestContext:
+    return RequestContext(request_id="search-module-test")
+
+
+def _execution() -> ExecutionContext:
+    return ExecutionContext.with_timeout(30)
+
+
+def _provider(provider_id: str) -> ProviderRef:
+    return ProviderRef(id=provider_id, kind="search")
+
+
+def _selection(provider_id: str, *, priority: int = 10) -> SearchProviderSelection:
+    return SearchProviderSelection(
+        provider=_provider(provider_id),
+        adapter_id=f"{provider_id}-adapter",
+        yaml_priority=priority,
+    )
+
+
+def _item(
+    item_id: str,
+    *,
+    title: str | None = None,
+    rank: int = 1,
+    provider: str = "openalex",
+    url: str | None = None,
+    doi: str | None = None,
+    year: int | None = None,
+) -> SearchItem:
+    identifiers = (SearchIdentifier(scheme="doi", value=doi),) if doi is not None else ()
+    return SearchItem(
+        id=item_id,
+        title=title or item_id,
+        rank=rank,
+        url=url,
+        provenance=(Provenance(provider=provider, outcome="success"),),
+        attributes=SearchAttributes(identifiers=identifiers, year=year),
+    )
+
+
+def _page(context: RequestContext, *items: SearchItem) -> SearchPage:
+    return SearchPage(
+        items=items,
+        page=PageInfo(limit=10),
+        meta=SearchMeta(),
+        context=context,
+    )
+
+
+@dataclass
+class _Selector:
+    default: tuple[SearchProviderSelection, ...]
+    explicit: tuple[SearchProviderSelection, ...] = ()
+    default_calls: int = 0
+    explicit_calls: int = 0
+
+    def select_default(self, request: SearchRequest) -> tuple[SearchProviderSelection, ...]:
+        self.default_calls += 1
+        return self.default
+
+    def select_explicit(
+        self, providers: tuple[ProviderRef, ...]
+    ) -> tuple[SearchProviderSelection, ...]:
+        self.explicit_calls += 1
+        return self.explicit
+
+
+@dataclass
+class _Manager:
+    outcomes: dict[str, SearchPage | BaseException]
+    calls: list[str] = field(default_factory=list)
+
+    async def execute(self, adapter_id, request, context, execution):  # noqa: ANN001
+        self.calls.append(adapter_id)
+        outcome = self.outcomes[adapter_id]
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+
+@pytest.mark.asyncio
+async def test_absent_providers_selects_exactly_one_yaml_primary() -> None:
+    context = _context()
+    primary = _selection("openalex", priority=3)
+    selector = _Selector(default=(primary,))
+    manager = _Manager({primary.adapter_id: _page(context, _item("openalex:1"))})
+    service = SearchModuleService(manager, selector)
+
+    result = await service.search(
+        SearchRequest(query="query", domains=("paper",)), context, _execution()
+    )
+
+    assert selector.default_calls == 1
+    assert selector.explicit_calls == 0
+    assert manager.calls == [primary.adapter_id]
+    assert result.meta == SearchMeta(requested=("openalex",), succeeded=("openalex",))
+
+
+def test_ordered_selector_projects_yaml_priority_and_explicit_identity() -> None:
+    lower = _selection("lower", priority=20)
+    primary = _selection("primary", priority=1)
+    selector = OrderedSearchProviderSelector({"paper": (lower, primary)})
+
+    assert selector.select_default(SearchRequest(query="query", domains=("paper",))) == (primary,)
+    assert selector.select_explicit((_provider("lower"), _provider("primary"))) == (
+        lower,
+        primary,
+    )
+    with pytest.raises(ProviderError) as multi_domain:
+        selector.select_default(SearchRequest(query="query", domains=("paper", "web")))
+    assert multi_domain.value.code is ProviderErrorCode.INVALID_REQUEST
+
+
+@pytest.mark.asyncio
+async def test_explicit_single_provider_never_fans_out() -> None:
+    context = _context()
+    selected = _selection("openalex")
+    selector = _Selector(default=(), explicit=(selected,))
+    manager = _Manager({selected.adapter_id: _page(context, _item("openalex:1"))})
+    service = SearchModuleService(manager, selector)
+
+    request = SearchRequest(query="query", domains=("paper",), providers=(_provider("openalex"),))
+    await service.search(request, context, _execution())
+
+    assert selector.default_calls == 0
+    assert selector.explicit_calls == 1
+    assert manager.calls == [selected.adapter_id]
+
+
+@pytest.mark.asyncio
+async def test_explicit_multiple_providers_uses_rrf_and_merges_provenance() -> None:
+    context = _context()
+    first = _selection("first", priority=10)
+    second = _selection("second", priority=1)
+    selector = _Selector(default=(), explicit=(first, second))
+    manager = _Manager(
+        {
+            first.adapter_id: _page(
+                context,
+                _item("first-doi", title="Shared", provider="first", rank=1, doi="10.1/shared"),
+                _item("first-only", provider="first", rank=2),
+            ),
+            second.adapter_id: _page(
+                context,
+                _item(
+                    "second-doi", title="Different", provider="second", rank=2, doi="10.1/shared"
+                ),
+                _item("second-only", provider="second", rank=1),
+            ),
+        }
+    )
+    service = SearchModuleService(manager, selector)
+    request = SearchRequest(
+        query="query",
+        domains=("paper",),
+        providers=(_provider("first"), _provider("second")),
+    )
+
+    result = await service.search(request, context, _execution())
+
+    assert manager.calls == [first.adapter_id, second.adapter_id]
+    assert [item.id for item in result.items] == ["first-doi", "second-only", "first-only"]
+    assert [entry.provider for entry in result.items[0].provenance] == ["first", "second"]
+    assert result.meta == SearchMeta(
+        requested=("first", "second"),
+        succeeded=("first", "second"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_ties_use_yaml_priority_then_provider_local_rank_then_canonical_id() -> None:
+    context = _context()
+    high_priority = _selection("higher-priority", priority=1)
+    low_priority = _selection("lower-priority", priority=9)
+    selector = _Selector(default=(), explicit=(low_priority, high_priority))
+    manager = _Manager(
+        {
+            low_priority.adapter_id: _page(
+                context, _item("zeta", rank=1, provider="lower-priority")
+            ),
+            high_priority.adapter_id: _page(
+                context, _item("beta", rank=1, provider="higher-priority")
+            ),
+        }
+    )
+    service = SearchModuleService(manager, selector)
+    request = SearchRequest(
+        query="query",
+        domains=("paper",),
+        providers=(_provider("lower-priority"), _provider("higher-priority")),
+    )
+
+    result = await service.search(request, context, _execution())
+
+    assert [item.id for item in result.items] == ["beta", "zeta"]
+
+    same_priority = _Selector(default=(), explicit=(low_priority, _selection("other", priority=9)))
+    same_priority_manager = _Manager(
+        {
+            low_priority.adapter_id: _page(
+                context, _item("zeta", rank=1, provider="lower-priority")
+            ),
+            "other-adapter": _page(context, _item("alpha", rank=1, provider="other")),
+        }
+    )
+    canonical_result = await SearchModuleService(same_priority_manager, same_priority).search(
+        SearchRequest(
+            query="query",
+            domains=("paper",),
+            providers=(_provider("lower-priority"), _provider("other")),
+        ),
+        context,
+        _execution(),
+    )
+    assert [item.id for item in canonical_result.items] == ["alpha", "zeta"]
+
+
+@pytest.mark.asyncio
+async def test_url_and_normalized_title_year_are_deduplication_fallbacks() -> None:
+    context = _context()
+    first = _selection("first")
+    second = _selection("second")
+    selector = _Selector(default=(), explicit=(first, second))
+    manager = _Manager(
+        {
+            first.adapter_id: _page(
+                context,
+                _item("url-one", provider="first", url="https://example.com/same"),
+                _item(
+                    "title-one",
+                    title=" A  normalized title ",
+                    provider="first",
+                    rank=2,
+                    year=2024,
+                ),
+            ),
+            second.adapter_id: _page(
+                context,
+                _item("url-two", provider="second", url="https://example.com/same"),
+                _item(
+                    "title-two",
+                    title="a normalized title",
+                    provider="second",
+                    rank=2,
+                    year=2024,
+                ),
+            ),
+        }
+    )
+    request = SearchRequest(
+        query="query",
+        domains=("paper",),
+        providers=(_provider("first"), _provider("second")),
+    )
+
+    result = await SearchModuleService(manager, selector).search(request, context, _execution())
+
+    assert [item.id for item in result.items] == ["url-one", "title-one"]
+    assert all(len(item.provenance) == 2 for item in result.items)
+
+
+@pytest.mark.asyncio
+async def test_any_success_returns_partial_page_with_safe_failed_provider_details() -> None:
+    context = _context()
+    healthy = _selection("healthy")
+    failed = _selection("failed")
+    selector = _Selector(default=(), explicit=(healthy, failed))
+    manager = _Manager(
+        {
+            healthy.adapter_id: _page(context, _item("healthy-item", provider="healthy")),
+            failed.adapter_id: ProviderError(ProviderErrorCode.DEADLINE_EXCEEDED),
+        }
+    )
+    request = SearchRequest(
+        query="query",
+        domains=("paper",),
+        providers=(_provider("healthy"), _provider("failed")),
+    )
+
+    result = await SearchModuleService(manager, selector).search(request, context, _execution())
+
+    assert result.meta == SearchMeta(
+        partial=True,
+        requested=("healthy", "failed"),
+        succeeded=("healthy",),
+        failed=(ProviderFailure(provider="failed", code="provider_timeout"),),
+    )
+
+
+@pytest.mark.asyncio
+async def test_explicit_multi_provider_dispatch_is_concurrent() -> None:
+    context = _context()
+    first = _selection("first")
+    second = _selection("second")
+    both_started = asyncio.Event()
+
+    class ConcurrentManager:
+        def __init__(self) -> None:
+            self.started = 0
+
+        async def execute(self, adapter_id, request, request_context, execution):  # noqa: ANN001
+            self.started += 1
+            if self.started == 2:
+                both_started.set()
+            await asyncio.wait_for(both_started.wait(), timeout=0.5)
+            return _page(context, _item(adapter_id, provider=adapter_id))
+
+    manager = ConcurrentManager()
+    request = SearchRequest(
+        query="query",
+        domains=("paper",),
+        providers=(_provider("first"), _provider("second")),
+    )
+
+    result = await SearchModuleService(
+        manager, _Selector(default=(), explicit=(first, second))
+    ).search(request, context, _execution())
+
+    assert manager.started == 2
+    assert len(result.items) == 2
+
+
+@pytest.mark.asyncio
+async def test_all_failures_raise_typed_canonical_provider_error() -> None:
+    context = _context()
+    first = _selection("first")
+    second = _selection("second")
+    manager = _Manager(
+        {
+            first.adapter_id: ProviderError(ProviderErrorCode.PROVIDER_UNAVAILABLE),
+            second.adapter_id: ProviderError(ProviderErrorCode.INVALID_UPSTREAM_RESPONSE),
+        }
+    )
+    request = SearchRequest(
+        query="query",
+        domains=("paper",),
+        providers=(_provider("first"), _provider("second")),
+    )
+
+    with pytest.raises(ProviderError) as exc_info:
+        await SearchModuleService(manager, _Selector(default=(), explicit=(first, second))).search(
+            request, context, _execution()
+        )
+    assert exc_info.value.code is ProviderErrorCode.PROVIDER_UNAVAILABLE
+
+    timeout_manager = _Manager(
+        {
+            first.adapter_id: ProviderError(ProviderErrorCode.DEADLINE_EXCEEDED),
+            second.adapter_id: ProviderError(ProviderErrorCode.DEADLINE_EXCEEDED),
+        }
+    )
+    with pytest.raises(ProviderError) as timeout_error:
+        await SearchModuleService(
+            timeout_manager, _Selector(default=(), explicit=(first, second))
+        ).search(request, context, _execution())
+    assert timeout_error.value.code is ProviderErrorCode.DEADLINE_EXCEEDED
+
+
+@pytest.mark.asyncio
+async def test_default_selection_count_and_cancel_or_deadline_stop_before_manager_call() -> None:
+    context = _context()
+    first = _selection("first")
+    second = _selection("second")
+    manager = _Manager({})
+    service = SearchModuleService(manager, _Selector(default=(first, second)))
+
+    with pytest.raises(ProviderError) as selection_error:
+        await service.search(
+            SearchRequest(query="query", domains=("paper",)), context, _execution()
+        )
+    assert selection_error.value.code is ProviderErrorCode.PROVIDER_UNAVAILABLE
+    assert manager.calls == []
+
+    cancel_event = asyncio.Event()
+    cancel_event.set()
+    with pytest.raises(ProviderError) as cancelled:
+        await SearchModuleService(manager, _Selector(default=(first,))).search(
+            SearchRequest(query="query", domains=("paper",)),
+            context,
+            ExecutionContext.with_timeout(30, cancel_event=cancel_event),
+        )
+    assert cancelled.value.code is ProviderErrorCode.CANCELLED
+
+    with pytest.raises(ProviderError) as expired:
+        await SearchModuleService(manager, _Selector(default=(first,))).search(
+            SearchRequest(query="query", domains=("paper",)),
+            context,
+            ExecutionContext(deadline_monotonic=time.monotonic() - 1),
+        )
+    assert expired.value.code is ProviderErrorCode.DEADLINE_EXCEEDED
+    assert manager.calls == []


### PR DESCRIPTION
## 目标

交付 Souwen v2rc2 Phase 4 / P4-02：首个 OpenAlex Search Provider v2 垂直切片。

本 PR 不改 Delivery route、rollout mode、legacy OpenAlex route、HFS runtime 或版本发布面。

## 垂直链

```text
SearchModuleService
→ ProviderManager
→ OpenAlexSearchProvider
→ injected legacy OpenAlex client
→ canonical SearchPage
```

## 行为

- 未指定 Provider：从 immutable YAML domain/capability priority projection 选择 exactly one primary。
- 显式单 Provider：只调用一个 Provider。
- 显式多 Provider：真正并发 fanout，使用等权 RRF `k=60`。
- tie-break：YAML priority → provider-local rank → canonical ID。
- 去重：stable domain identifier → canonical URL → normalized title+year。
- 任一 Provider 成功返回 partial SearchPage 和 machine-readable failure；全部失败返回 typed canonical error。
- OpenAlex adapter 只依赖 injected client protocol，不 import 或注册 legacy client。
- OpenAlex canonical mapping 使用 DOI 优先、OpenAlex work URL fallback；不可信 DOI/URL fail closed。
- Provider 内部与 Manager 双层执行 live cancellation/deadline；close idempotent/cancellation-aware。
- immutable manifest 为 search-only、`provider-v2`、`2.0.0rc2`、configured availability。
- legacy registry 与 legacy route 保持不变，继续作为 rollback 路径和迁移期 catalog 真源。

## 验证

```text
P4-02 targeted/vertical/legacy OpenAlex:
43 passed

Full pytest:
2531 passed, 3 skipped

architecture dependency checker:
PASS

ruff check src tests scripts tools:
PASS

ruff format --check src tests scripts tools:
529 files already formatted

generated docs:
PASS
```

## 合并约束

- 仅在 exact-head CI、V2、CodeQL、HFS-local 全绿后以 merge commit 合并。
- PR-context HFS promotion 必须保持 skipped。
- 合并后删除 P4-02 worktree/local/remote branch，再建立 P4-03。
