### PR TITLE
feat(v2): 落地 P4-03 UniAPI LLM Search 垂直切片

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -459,19 +459,23 @@ sources:
 ```yaml
 llm_search_gateways:
   uniapi:
-    api_key: your-secret
-    base_url: https://gateway.example.com/v1
+    api_key: "${UNIAPI_API_KEY}"
+    base_url: "${UNIAPI_BASE_URL}"
 sources:
   uniapi_ark_annotations_deepseek_v3_2_251201:
     enabled: true
     timeout: 45
+  uniapi_ark_annotations_doubao_seed_2_0_lite_260428:
+    enabled: false
 ```
 
-可改为启用 `uniapi_ark_annotations_doubao_seed_2_0_lite_260428`，但不要把两个 source
+可改为启用 `uniapi_ark_annotations_doubao_seed_2_0_lite_260428`，但两个 source 不能同时
+设为 `enabled: true`，否则配置加载会失败。不要把两个 source
 加入默认搜索或通过 `params` 覆盖 `model`、`model_id`、`scheme_id`、`source_id` 或 `gateway_id`。
 这两个 identity 字段集是 immutable；每个 source 只会请求其 Registry 绑定的 exact model。
 
-具体 source 的 `api_key`、`base_url` override 优先于 shared gateway。环境变量使用 JSON：
+YAML 中仅对 gateway 的 `api_key`/`base_url` 支持精确 `${VAR}` 引用；缺失的环境
+变量解析为未配置，不会把字面占位符当成凭据。也可使用 JSON 环境变量：
 
 ```text
 SOUWEN_LLM_SEARCH_GATEWAYS={"uniapi":{"api_key":"...","base_url":"https://gateway.example.com/v1"}}

--- a/souwen.example.yaml
+++ b/souwen.example.yaml
@@ -241,17 +241,11 @@ warp:
 
 # ===== LLM Search 共享 Gateway =====
 # 多个 concrete source 共享一份 gateway 配置；API Key 与私有 URL 不应写入公开产物。
-# 环境变量可使用 SOUWEN_LLM_SEARCH_GATEWAYS JSON 对象。
-llm_search_gateways: {}
-# 示例（按需取消注释并使用真实私有配置）：
-#   uniapi:
-#     api_key: your-secret
-#     base_url: https://gateway.example.com/v1
-# Ark concrete source 仍属实验性，需逐个显式启用：
-# sources:
-#   uniapi_ark_annotations_deepseek_v3_2_251201:
-#     enabled: true
-#     timeout: 45
+# 也可使用 SOUWEN_LLM_SEARCH_GATEWAYS JSON 对象；private URL 不会进入 catalog。
+llm_search_gateways:
+  uniapi:
+    api_key: "${UNIAPI_API_KEY}"
+    base_url: "${UNIAPI_BASE_URL}"
 
 # ===== 数据源频道配置 =====
 # 按源名称配置，覆盖全局默认值。
@@ -291,7 +285,12 @@ llm_search_gateways: {}
 #     enabled: false           # 禁用 Google Patents
 #   openalex:
 #     base_url: https://my-proxy.example.com  # 使用自建代理
-sources: {}
+sources:
+  # RC2 必须由 deployment 显式启用一个；两个同时 true 会使配置加载失败。
+  uniapi_ark_annotations_deepseek_v3_2_251201:
+    enabled: false
+  uniapi_ark_annotations_doubao_seed_2_0_lite_260428:
+    enabled: false
 
 # ─── LLM 摘要配置 ──────────────────────────────────────────────
 # llm:

--- a/src/souwen/config/loader.py
+++ b/src/souwen/config/loader.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 from functools import lru_cache
 from pathlib import Path
 
@@ -33,6 +34,22 @@ _RETIRED_AUTH_ENV_KEYS = {
 }
 
 _NESTED_CONFIG_FIELDS = frozenset({"sources", "llm", "llm_search_gateways", "plugin_config"})
+_EXACT_ENV_REFERENCE = re.compile(r"^\$\{([A-Z_][A-Z0-9_]*)\}$")
+
+
+def _resolve_gateway_env_references(raw: dict) -> None:
+    """Resolve exact ``${VAR}`` gateway scalars without interpolating arbitrary YAML."""
+    gateways = raw.get("llm_search_gateways")
+    if not isinstance(gateways, dict):
+        return
+    for gateway in gateways.values():
+        if not isinstance(gateway, dict):
+            continue
+        for field_name in ("api_key", "base_url"):
+            value = gateway.get(field_name)
+            match = _EXACT_ENV_REFERENCE.fullmatch(value) if isinstance(value, str) else None
+            if match is not None:
+                gateway[field_name] = os.environ.get(match.group(1))
 
 
 def _retired_auth_yaml_keys(raw: dict) -> list[str]:
@@ -99,6 +116,7 @@ def _load_yaml_config() -> dict:
 
     if not raw or not isinstance(raw, dict):
         return {}
+    _resolve_gateway_env_references(raw)
     retired_keys = _retired_auth_yaml_keys(raw)
     if retired_keys:
         raise _retired_auth_config_error(retired_keys)

--- a/src/souwen/config/models.py
+++ b/src/souwen/config/models.py
@@ -20,6 +20,10 @@ logger = logging.getLogger("souwen.config")
 LLM_SEARCH_IDENTITY_PARAMS = frozenset(
     {"api_key", "base_url", "gateway_id", "model", "model_id", "scheme_id", "source_id"}
 )
+UNIAPI_ARK_RC2_SOURCE_IDS = (
+    "uniapi_ark_annotations_deepseek_v3_2_251201",
+    "uniapi_ark_annotations_doubao_seed_2_0_lite_260428",
+)
 
 
 def _normalize_llm_search_base_url(value: str | None) -> str | None:
@@ -210,6 +214,16 @@ class SouWenConfig(BaseModel):
                 detail = ", ".join(f"{key} -> {replacements[key]}" for key in sorted(retired))
                 raise ValueError(f"认证配置字段已移除: {detail}")
         return data
+
+    @model_validator(mode="after")
+    def _only_one_uniapi_ark_source_may_be_explicitly_enabled(self) -> "SouWenConfig":
+        """Prevent deployment config from silently selecting or switching Ark models."""
+        enabled = self.enabled_uniapi_ark_source_ids()
+        if len(enabled) > 1:
+            raise ValueError(
+                "UniAPI Ark RC2 requires exactly zero or one explicitly enabled source"
+            )
+        return self
 
     # ===== 论文数据源 =====
     openalex_api_key: str | None = None
@@ -527,6 +541,31 @@ class SouWenConfig(BaseModel):
     def get_llm_search_gateway(self, gateway_id: str) -> LLMSearchGatewayConfig:
         """获取共享 LLM-search gateway；不存在时返回空配置。"""
         return self.llm_search_gateways.get(gateway_id, LLMSearchGatewayConfig())
+
+    def enabled_uniapi_ark_source_ids(self) -> tuple[str, ...]:
+        """Return only RC2 Ark sources with an explicit YAML/config ``enabled: true``."""
+        enabled: list[str] = []
+        for source_id in UNIAPI_ARK_RC2_SOURCE_IDS:
+            source = self.sources.get(source_id)
+            if (
+                source is not None
+                and "enabled" in source.model_fields_set
+                and source.enabled is True
+            ):
+                enabled.append(source_id)
+        return tuple(enabled)
+
+    def missing_uniapi_gateway_fields(self) -> tuple[str, ...]:
+        """Return safe config paths only, never credential or private URL values."""
+        gateway = self.get_llm_search_gateway("uniapi")
+        return tuple(
+            field_name
+            for field_name, value in (
+                ("llm_search_gateways.uniapi.api_key", gateway.api_key),
+                ("llm_search_gateways.uniapi.base_url", gateway.base_url),
+            )
+            if not value
+        )
 
     def resolve_llm_search_gateway_field(
         self,

--- a/src/souwen/config/template.py
+++ b/src/souwen/config/template.py
@@ -145,11 +145,18 @@ warp:
 #       search_depth: advanced
 #   google_patents:
 #     enabled: false
-sources: {}
+sources:
+  uniapi_ark_annotations_deepseek_v3_2_251201:
+    enabled: false
+  uniapi_ark_annotations_doubao_seed_2_0_lite_260428:
+    enabled: false
 
 # ===== LLM Search 共享 Gateway =====
-# 两个实验性 Ark concrete source 共用一份 api_key/base_url；它们默认关闭，需显式启用。
-llm_search_gateways: {}
+# 两个 immutable Ark adapter 共用一份 gateway；只能显式启用其中一个。
+llm_search_gateways:
+  uniapi:
+    api_key: "${UNIAPI_API_KEY}"
+    base_url: "${UNIAPI_BASE_URL}"
 
 # ===== LLM 摘要与 enriched synthesis =====
 # credentials/base_url stay on llm; requests can name only an allowlisted profile.

--- a/src/souwen/modules/llm_search/api/__init__.py
+++ b/src/souwen/modules/llm_search/api/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Protocol
 
+from souwen.modules.llm_search.application import LLMSearchModuleService
 from souwen.platform.provider_spi import (
     ExecutionContext,
     LLMSearchRequest,
@@ -21,4 +22,9 @@ class LLMSearchModule(Protocol):
         """Execute LLM Search without exposing a concrete provider."""
 
 
-__all__ = ["LLMSearchModule", "LLMSearchRequest", "LLMSearchResult"]
+__all__ = [
+    "LLMSearchModule",
+    "LLMSearchModuleService",
+    "LLMSearchRequest",
+    "LLMSearchResult",
+]

--- a/src/souwen/modules/llm_search/application/__init__.py
+++ b/src/souwen/modules/llm_search/application/__init__.py
@@ -1,3 +1,5 @@
-"""LLM Search application layer. Owner: LLM Search Core. Allowed dependencies: own domain, ports, and common runtime."""
+"""LLM Search application layer. Owner: LLM Search Core."""
 
-__all__: list[str] = []
+from .orchestration import LLMSearchModuleService, LLMSearchProviderManager
+
+__all__ = ["LLMSearchModuleService", "LLMSearchProviderManager"]

--- a/src/souwen/modules/llm_search/application/orchestration.py
+++ b/src/souwen/modules/llm_search/application/orchestration.py
@@ -1,0 +1,74 @@
+"""Canonical LLM Search orchestration through an injected Provider Manager port."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from souwen.platform.provider_spi import (
+    ExecutionContext,
+    LLMSearchRequest,
+    LLMSearchResult,
+    ProviderError,
+    ProviderErrorCode,
+    RequestContext,
+)
+
+
+class LLMSearchProviderManager(Protocol):
+    """Minimal manager port used by LLM Search Core."""
+
+    async def execute(
+        self,
+        adapter_id: str,
+        request: LLMSearchRequest,
+        request_context: RequestContext,
+        execution: ExecutionContext,
+    ) -> LLMSearchResult:
+        """Execute exactly one configured LLM Search adapter."""
+
+
+class LLMSearchModuleService:
+    """Execute the deployment-selected immutable LLM Search provider.
+
+    RC2 intentionally permits exactly one YAML-enabled UniAPI adapter. The
+    request identifies that public provider for contract transparency, but it
+    cannot select a different source, scheme, gateway, or model.
+    """
+
+    def __init__(self, manager: LLMSearchProviderManager, configured_adapter_id: str) -> None:
+        configured_adapter_id = configured_adapter_id.strip()
+        if not configured_adapter_id:
+            raise ValueError("configured_adapter_id must not be blank")
+        self._manager = manager
+        self._configured_adapter_id = configured_adapter_id
+
+    async def search(
+        self,
+        request: LLMSearchRequest,
+        context: RequestContext,
+        execution: ExecutionContext,
+    ) -> LLMSearchResult:
+        """Reject request-side provider overrides before any provider call."""
+        execution.raise_if_cancelled_or_expired()
+        if request.strategy != "single" or len(request.providers) != 1:
+            raise ProviderError(ProviderErrorCode.INVALID_REQUEST)
+        provider = request.providers[0]
+        if provider.kind != "llm_search" or provider.id != self._configured_adapter_id:
+            raise ProviderError(ProviderErrorCode.INVALID_REQUEST)
+
+        result = await self._manager.execute(
+            self._configured_adapter_id,
+            request,
+            context,
+            execution,
+        )
+        execution.raise_if_cancelled_or_expired()
+        if result.query != request.query or result.context != context:
+            raise ProviderError(
+                ProviderErrorCode.INVALID_UPSTREAM_RESPONSE,
+                provider_id=self._configured_adapter_id,
+            )
+        return result
+
+
+__all__ = ["LLMSearchModuleService", "LLMSearchProviderManager"]

--- a/src/souwen/providers/llm_sources/uniapi_ark_annotations/__init__.py
+++ b/src/souwen/providers/llm_sources/uniapi_ark_annotations/__init__.py
@@ -1,0 +1,19 @@
+"""Immutable UniAPI Ark annotation Provider v2 adapters."""
+
+from .adapter import (
+    UniApiArkAnnotationsDeepSeekProvider,
+    UniApiArkAnnotationsDoubaoProvider,
+)
+from .manifest import (
+    UNIAPI_ARK_DEEPSEEK_MANIFEST,
+    UNIAPI_ARK_DOUBAO_MANIFEST,
+    UNIAPI_ARK_MANIFESTS,
+)
+
+__all__ = [
+    "UNIAPI_ARK_DEEPSEEK_MANIFEST",
+    "UNIAPI_ARK_DOUBAO_MANIFEST",
+    "UNIAPI_ARK_MANIFESTS",
+    "UniApiArkAnnotationsDeepSeekProvider",
+    "UniApiArkAnnotationsDoubaoProvider",
+]

--- a/src/souwen/providers/llm_sources/uniapi_ark_annotations/adapter.py
+++ b/src/souwen/providers/llm_sources/uniapi_ark_annotations/adapter.py
@@ -1,0 +1,463 @@
+"""Provider v2 adapters for structured UniAPI Ark web-search annotations."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import inspect
+import ipaddress
+from collections.abc import Mapping
+from contextlib import suppress
+from datetime import datetime, timezone
+from typing import Any, Callable, ClassVar, Protocol
+from urllib.parse import urlsplit, urlunsplit
+
+from souwen.common_runtime.errors import SouWenError
+from souwen.common_runtime.transport.errors import (
+    AuthError,
+    RateLimitError,
+    SourceUnavailableError,
+)
+from souwen.common_runtime.transport.http_client import HttpTransport
+from souwen.platform.provider_spi import (
+    EvidenceItem,
+    ExecutionContext,
+    LLMSearchRequest,
+    LLMSearchResult,
+    ProviderError,
+    ProviderErrorCode,
+    ProviderProbe,
+    Provenance,
+    RequestContext,
+    SearchItem,
+    SearchMeta,
+    Usage,
+)
+
+from .manifest import DEEPSEEK_ADAPTER_ID, DOUBAO_ADAPTER_ID
+
+
+_RESPONSE_PATH = "/v1/responses"
+_DEFAULT_TIMEOUT_SECONDS = 45.0
+_DEFAULT_MAX_KEYWORD = 10
+_MAX_RESULTS = 50
+
+
+class _ResponseProtocol(Protocol):
+    def json(self) -> Any:
+        """Return a decoded response payload."""
+
+
+class ArkTransportProtocol(Protocol):
+    async def post(
+        self,
+        url: str,
+        json: dict[str, Any] | None = None,
+        data: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        retry_policy: str = "default",
+    ) -> _ResponseProtocol:
+        """Execute one Ark Responses request."""
+
+    async def close(self) -> None:
+        """Release owned transport resources."""
+
+
+class _UniApiArkAnnotationsProvider:
+    """One exact source/model binding with no request-side identity override."""
+
+    capability = "llm_search"
+    ADAPTER_ID: ClassVar[str]
+    MODEL_ID: ClassVar[str]
+
+    def __init__(
+        self,
+        configuration: Mapping[str, Any],
+        secrets: Mapping[str, str],
+        *,
+        transport: ArkTransportProtocol | None = None,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._enabled, self._max_keyword, timeout = _validated_configuration(configuration)
+        api_key, base_url = _validated_secrets(secrets)
+        self._transport = transport or HttpTransport(
+            base_url=base_url,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            timeout=timeout,
+            max_retries=0,
+            proxy=None,
+            follow_redirects=False,
+        )
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self._closed = False
+
+    async def search(
+        self,
+        request: LLMSearchRequest,
+        context: RequestContext,
+        execution: ExecutionContext,
+    ) -> LLMSearchResult:
+        """Execute one paid, single-attempt Ark request and require structured evidence."""
+        execution.raise_if_cancelled_or_expired()
+        if self._closed or not self._enabled:
+            raise ProviderError(ProviderErrorCode.INVALID_CONFIG, provider_id=self.ADAPTER_ID)
+        if (
+            request.strategy != "single"
+            or len(request.providers) != 1
+            or request.providers[0].kind != "llm_search"
+            or request.providers[0].id != self.ADAPTER_ID
+            or request.fetch is not None
+            or request.synthesis_profile is not None
+        ):
+            raise ProviderError(ProviderErrorCode.INVALID_REQUEST, provider_id=self.ADAPTER_ID)
+
+        max_results = request.max_results_per_provider or self._max_keyword
+        if not 1 <= max_results <= _MAX_RESULTS:
+            raise ProviderError(ProviderErrorCode.INVALID_REQUEST, provider_id=self.ADAPTER_ID)
+        payload = {
+            "model": self.MODEL_ID,
+            "input": request.query,
+            "tools": [{"type": "web_search", "max_keyword": max_results}],
+        }
+        try:
+            response = await _await_with_execution(
+                self._transport.post(
+                    _RESPONSE_PATH,
+                    json=payload,
+                    retry_policy="single_attempt",
+                ),
+                execution,
+                self.ADAPTER_ID,
+            )
+            execution.raise_if_cancelled_or_expired()
+            response_payload = response.json()
+            retrieved_at = self._clock()
+            if retrieved_at.tzinfo is None:
+                raise ValueError("retrieval timestamp must be timezone-aware")
+            return _parse_result(
+                response_payload,
+                adapter_id=self.ADAPTER_ID,
+                model_id=self.MODEL_ID,
+                query=request.query,
+                context=context,
+                retrieved_at=retrieved_at,
+                max_results=max_results,
+            )
+        except asyncio.CancelledError:
+            raise
+        except ProviderError:
+            raise
+        except RateLimitError as exc:
+            raise ProviderError(
+                ProviderErrorCode.RATE_LIMITED,
+                provider_id=self.ADAPTER_ID,
+                retry_after_seconds=getattr(exc, "retry_after", None),
+            ) from None
+        except AuthError:
+            raise ProviderError(
+                ProviderErrorCode.INVALID_CONFIG,
+                provider_id=self.ADAPTER_ID,
+            ) from None
+        except TimeoutError:
+            raise ProviderError(
+                ProviderErrorCode.DEADLINE_EXCEEDED,
+                provider_id=self.ADAPTER_ID,
+            ) from None
+        except SourceUnavailableError:
+            raise ProviderError(
+                ProviderErrorCode.PROVIDER_UNAVAILABLE,
+                provider_id=self.ADAPTER_ID,
+            ) from None
+        except (AttributeError, TypeError, ValueError):
+            raise ProviderError(
+                ProviderErrorCode.INVALID_UPSTREAM_RESPONSE,
+                provider_id=self.ADAPTER_ID,
+            ) from None
+        except SouWenError:
+            raise ProviderError(
+                ProviderErrorCode.INVALID_UPSTREAM_RESPONSE,
+                provider_id=self.ADAPTER_ID,
+            ) from None
+        except Exception:
+            raise ProviderError(
+                ProviderErrorCode.PROVIDER_UNAVAILABLE,
+                provider_id=self.ADAPTER_ID,
+            ) from None
+
+    async def probe(self, execution: ExecutionContext) -> ProviderProbe:
+        """Return credential/config readiness without a network or paid request."""
+        execution.raise_if_cancelled_or_expired()
+        return ProviderProbe(
+            provider=self.ADAPTER_ID,
+            capability="llm_search",
+            status="unavailable" if self._closed or not self._enabled else "available",
+        )
+
+    async def close(self) -> None:
+        """Close the owned transport at most once."""
+        if self._closed:
+            return
+        self._closed = True
+        closer = getattr(self._transport, "close", None)
+        if closer is None:
+            return
+        try:
+            result = closer()
+            if inspect.isawaitable(result):
+                await result
+        except asyncio.CancelledError:
+            self._closed = False
+            raise
+
+
+class UniApiArkAnnotationsDeepSeekProvider(_UniApiArkAnnotationsProvider):
+    """Ark annotations adapter bound to DeepSeek V3.2's exact model ID."""
+
+    ADAPTER_ID = DEEPSEEK_ADAPTER_ID
+    MODEL_ID = "deepseek-v3-2-251201"
+
+
+class UniApiArkAnnotationsDoubaoProvider(_UniApiArkAnnotationsProvider):
+    """Ark annotations adapter bound to Doubao Seed 2.0 Lite's exact model ID."""
+
+    ADAPTER_ID = DOUBAO_ADAPTER_ID
+    MODEL_ID = "doubao-seed-2-0-lite-260428"
+
+
+def _validated_configuration(configuration: Mapping[str, Any]) -> tuple[bool, int, float]:
+    if not isinstance(configuration, Mapping) or set(configuration).difference(
+        {"enabled", "max_keyword", "timeout_seconds"}
+    ):
+        raise ValueError("invalid provider configuration")
+    enabled = configuration.get("enabled")
+    if enabled is not True:
+        raise ValueError("provider must be explicitly enabled")
+    max_keyword = configuration.get("max_keyword", _DEFAULT_MAX_KEYWORD)
+    timeout = configuration.get("timeout_seconds", _DEFAULT_TIMEOUT_SECONDS)
+    if (
+        not isinstance(max_keyword, int)
+        or isinstance(max_keyword, bool)
+        or not 1 <= max_keyword <= _MAX_RESULTS
+    ):
+        raise ValueError("invalid max_keyword")
+    if (
+        not isinstance(timeout, (int, float))
+        or isinstance(timeout, bool)
+        or not 1 <= float(timeout) <= 120
+    ):
+        raise ValueError("invalid timeout_seconds")
+    return enabled, max_keyword, float(timeout)
+
+
+def _validated_secrets(secrets: Mapping[str, str]) -> tuple[str, str]:
+    if not isinstance(secrets, Mapping):
+        raise ValueError("invalid provider secrets")
+    api_key = secrets.get("UNIAPI_API_KEY")
+    base_url = secrets.get("UNIAPI_BASE_URL")
+    if not isinstance(api_key, str) or not api_key.strip():
+        raise ValueError("missing provider credential")
+    if not isinstance(base_url, str) or not base_url.strip():
+        raise ValueError("missing provider gateway")
+    parsed = urlsplit(base_url.strip())
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+    ):
+        raise ValueError("invalid provider gateway")
+    return api_key.strip(), base_url.strip().rstrip("/")
+
+
+async def _await_with_execution(
+    value: Any,
+    execution: ExecutionContext,
+    provider_id: str,
+) -> Any:
+    provider_task = asyncio.ensure_future(value)
+    cancellation_task = asyncio.create_task(execution.cancel_event.wait())
+    try:
+        done, _pending = await asyncio.wait(
+            {provider_task, cancellation_task},
+            timeout=execution.remaining_seconds,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if provider_task in done:
+            return await provider_task
+        provider_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await provider_task
+        code = (
+            ProviderErrorCode.CANCELLED
+            if cancellation_task in done
+            else ProviderErrorCode.DEADLINE_EXCEEDED
+        )
+        raise ProviderError(code, provider_id=provider_id)
+    finally:
+        cancellation_task.cancel()
+        if not provider_task.done():
+            provider_task.cancel()
+        await asyncio.gather(provider_task, cancellation_task, return_exceptions=True)
+
+
+def _parse_result(
+    payload: Any,
+    *,
+    adapter_id: str,
+    model_id: str,
+    query: str,
+    context: RequestContext,
+    retrieved_at: datetime,
+    max_results: int,
+) -> LLMSearchResult:
+    if not isinstance(payload, Mapping):
+        raise ValueError("response must be an object")
+    if payload.get("status") not in {"completed", "incomplete"}:
+        raise ValueError("response status is invalid")
+    if payload.get("model") != model_id:
+        raise ValueError("served model does not match immutable adapter")
+    output = payload.get("output")
+    if not isinstance(output, list) or not any(
+        isinstance(item, Mapping)
+        and item.get("type") == "web_search_call"
+        and item.get("status") == "completed"
+        for item in output
+    ):
+        raise ValueError("response has no completed search receipt")
+
+    items: list[SearchItem] = []
+    evidence: list[EvidenceItem] = []
+    seen_urls: set[str] = set()
+    for annotation in _structured_annotations(output):
+        if annotation.get("type") != "url_citation":
+            continue
+        title = annotation.get("title")
+        url = annotation.get("url")
+        if not isinstance(title, str) or not title.strip() or not isinstance(url, str):
+            continue
+        normalized_url = _public_url(url)
+        if normalized_url is None or normalized_url in seen_urls:
+            continue
+        seen_urls.add(normalized_url)
+        digest = hashlib.sha256(normalized_url.encode("utf-8")).hexdigest()
+        item_id = f"url:{digest}"
+        evidence_id = f"evidence:{digest}"
+        summary = annotation.get("summary")
+        snippet = summary.strip() if isinstance(summary, str) and summary.strip() else None
+        provenance = Provenance(
+            provider=adapter_id,
+            attempt=1,
+            outcome="success",
+            retrieved_at=retrieved_at,
+        )
+        items.append(
+            SearchItem(
+                id=item_id,
+                title=title.strip(),
+                url=normalized_url,
+                snippet=snippet,
+                rank=len(items) + 1,
+                provenance=(provenance,),
+            )
+        )
+        evidence.append(
+            EvidenceItem(
+                id=evidence_id,
+                item_id=item_id,
+                provider=adapter_id,
+                public_url=normalized_url,
+                title_or_snippet=snippet or title.strip(),
+                retrieved_at=retrieved_at,
+            )
+        )
+        if len(items) >= max_results:
+            break
+    if not items:
+        raise ValueError("response has no structured public evidence")
+
+    usage = payload.get("usage")
+    return LLMSearchResult(
+        query=query,
+        items=tuple(items),
+        evidence=tuple(evidence),
+        # RC2 never guesses or rewrites citations from answer text. The
+        # structured evidence result remains useful without an answer.
+        answer=None,
+        meta=SearchMeta(requested=(adapter_id,), succeeded=(adapter_id,)),
+        usage=Usage(
+            input_tokens=_reported_usage(usage, "input_tokens"),
+            output_tokens=_reported_usage(usage, "output_tokens"),
+            cost=None,
+            currency=None,
+        ),
+        context=context,
+    )
+
+
+def _structured_annotations(output: list[Any]) -> tuple[Mapping[str, Any], ...]:
+    annotations: list[Mapping[str, Any]] = []
+    for item in output:
+        if not isinstance(item, Mapping) or item.get("status") not in {"completed", "incomplete"}:
+            continue
+        message = item.get("message")
+        if not isinstance(message, Mapping):
+            continue
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if not isinstance(part, Mapping):
+                continue
+            part_annotations = part.get("annotations")
+            if isinstance(part_annotations, list):
+                annotations.extend(
+                    annotation for annotation in part_annotations if isinstance(annotation, Mapping)
+                )
+    return tuple(annotations)
+
+
+def _public_url(value: str) -> str | None:
+    parsed = urlsplit(value.strip())
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+    ):
+        return None
+    host = parsed.hostname.rstrip(".").lower()
+    if host == "localhost" or host.endswith(".localhost") or host.endswith(".local"):
+        return None
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        pass
+    else:
+        if not address.is_global:
+            return None
+    port = parsed.port
+    netloc = f"[{host}]" if ":" in host else host
+    if port is not None and not (
+        (parsed.scheme == "http" and port == 80) or (parsed.scheme == "https" and port == 443)
+    ):
+        netloc = f"{netloc}:{port}"
+    return urlunsplit((parsed.scheme.lower(), netloc, parsed.path or "/", parsed.query, ""))
+
+
+def _reported_usage(value: Any, field: str) -> int | None:
+    if not isinstance(value, Mapping):
+        return None
+    candidate = value.get(field)
+    if isinstance(candidate, int) and not isinstance(candidate, bool) and candidate >= 0:
+        return candidate
+    return None
+
+
+__all__ = [
+    "ArkTransportProtocol",
+    "UniApiArkAnnotationsDeepSeekProvider",
+    "UniApiArkAnnotationsDoubaoProvider",
+]

--- a/src/souwen/providers/llm_sources/uniapi_ark_annotations/manifest.py
+++ b/src/souwen/providers/llm_sources/uniapi_ark_annotations/manifest.py
@@ -1,0 +1,68 @@
+"""Static manifests for the two immutable RC2 UniAPI Ark adapters."""
+
+from __future__ import annotations
+
+from souwen.platform.manifest_registry import ProviderManifest
+
+
+DEEPSEEK_ADAPTER_ID = "uniapi_ark_annotations_deepseek_v3_2_251201"
+DOUBAO_ADAPTER_ID = "uniapi_ark_annotations_doubao_seed_2_0_lite_260428"
+
+
+def _manifest(adapter_id: str, export: str) -> ProviderManifest:
+    return ProviderManifest.model_validate(
+        {
+            "schema_version": 2,
+            "id": adapter_id,
+            "version": "2.0.0rc2",
+            "contract_version": "provider-v2",
+            "capabilities": ["llm_search"],
+            "adapters": [
+                {
+                    "id": adapter_id,
+                    "capability": "llm_search",
+                    "export": export,
+                    "availability": "configured",
+                }
+            ],
+            "configuration": {
+                "schema_reference": "uniapi-ark-provider-config-v1",
+                "unknown_key_policy": "reject",
+                "non_secret_keys": ["enabled", "max_keyword", "timeout_seconds"],
+            },
+            "secrets": {"references": ["UNIAPI_API_KEY", "UNIAPI_BASE_URL"]},
+            # The gateway host is deployment-owned and may be private. It is
+            # deliberately absent from public static catalog metadata.
+            "network": {
+                "egress_hosts": [],
+                "proxy_supported": False,
+                "browser_required": False,
+            },
+            "risk": {"authenticated": True, "costed": True},
+            "observability": {"dimensions": ["provider", "adapter", "capability", "outcome"]},
+            "compatibility": {
+                "contract_versions": ["provider-v2"],
+                "config_schema_versions": ["uniapi-ark-provider-config-v1"],
+            },
+        }
+    )
+
+
+UNIAPI_ARK_DEEPSEEK_MANIFEST = _manifest(
+    DEEPSEEK_ADAPTER_ID,
+    "UniApiArkAnnotationsDeepSeekProvider",
+)
+UNIAPI_ARK_DOUBAO_MANIFEST = _manifest(
+    DOUBAO_ADAPTER_ID,
+    "UniApiArkAnnotationsDoubaoProvider",
+)
+UNIAPI_ARK_MANIFESTS = (UNIAPI_ARK_DEEPSEEK_MANIFEST, UNIAPI_ARK_DOUBAO_MANIFEST)
+
+
+__all__ = [
+    "DEEPSEEK_ADAPTER_ID",
+    "DOUBAO_ADAPTER_ID",
+    "UNIAPI_ARK_DEEPSEEK_MANIFEST",
+    "UNIAPI_ARK_DOUBAO_MANIFEST",
+    "UNIAPI_ARK_MANIFESTS",
+]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -160,6 +160,39 @@ class TestDefaults:
         cfg = SouWenConfig(plugin_config={"demo": {"api_key": "k", "limit": 3}})
         assert cfg.plugin_config["demo"] == {"api_key": "k", "limit": 3}
 
+    def test_uniapi_ark_sources_are_opt_in_and_mutually_exclusive(self):
+        deepseek = "uniapi_ark_annotations_deepseek_v3_2_251201"
+        doubao = "uniapi_ark_annotations_doubao_seed_2_0_lite_260428"
+
+        assert SouWenConfig().enabled_uniapi_ark_source_ids() == ()
+        assert SouWenConfig(
+            sources={deepseek: {"enabled": True}}
+        ).enabled_uniapi_ark_source_ids() == (deepseek,)
+        # Merely configuring another field is not an implicit enable.
+        assert (
+            SouWenConfig(sources={deepseek: {"timeout": 45}}).enabled_uniapi_ark_source_ids() == ()
+        )
+        with pytest.raises(ValueError, match="zero or one explicitly enabled"):
+            SouWenConfig(
+                sources={
+                    deepseek: {"enabled": True},
+                    doubao: {"enabled": True},
+                }
+            )
+
+    def test_uniapi_missing_gateway_diagnostic_contains_paths_not_values(self):
+        cfg = SouWenConfig(
+            llm_search_gateways={
+                "uniapi": {
+                    "api_key": "fixture-secret",
+                    "base_url": None,
+                }
+            }
+        )
+
+        assert cfg.missing_uniapi_gateway_fields() == ("llm_search_gateways.uniapi.base_url",)
+        assert "fixture-secret" not in repr(cfg)
+
     def test_retired_auth_fields_removed(self):
         """旧认证字段已从配置模型移除。"""
         cfg = SouWenConfig()

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -175,6 +175,54 @@ class TestYamlLoading:
         assert cfg.llm_search_gateways["uniapi"].api_key == "yaml-secret"
         assert cfg.llm_search_gateways["uniapi"].base_url == "https://gateway.example.com/v1"
 
+    def test_yaml_gateway_exact_env_references_are_resolved_without_literal_fallback(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("UNIAPI_API_KEY", "env-secret")
+        monkeypatch.setenv("UNIAPI_BASE_URL", "https://private-gateway.example.test/v1")
+        (tmp_path / "souwen.yaml").write_text(
+            textwrap.dedent(
+                """
+                llm_search_gateways:
+                  uniapi:
+                    api_key: "${UNIAPI_API_KEY}"
+                    base_url: "${UNIAPI_BASE_URL}"
+                """
+            ).strip(),
+            encoding="utf-8",
+        )
+
+        cfg = reload_config()
+
+        assert cfg.llm_search_gateways["uniapi"].api_key == "env-secret"
+        assert (
+            cfg.llm_search_gateways["uniapi"].base_url == "https://private-gateway.example.test/v1"
+        )
+
+    def test_missing_yaml_gateway_env_reference_is_unavailable_not_a_literal(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.delenv("UNIAPI_API_KEY", raising=False)
+        monkeypatch.delenv("UNIAPI_BASE_URL", raising=False)
+        (tmp_path / "souwen.yaml").write_text(
+            textwrap.dedent(
+                """
+                llm_search_gateways:
+                  uniapi:
+                    api_key: "${UNIAPI_API_KEY}"
+                    base_url: "${UNIAPI_BASE_URL}"
+                """
+            ).strip(),
+            encoding="utf-8",
+        )
+
+        cfg = reload_config()
+
+        assert cfg.missing_uniapi_gateway_fields() == (
+            "llm_search_gateways.uniapi.api_key",
+            "llm_search_gateways.uniapi.base_url",
+        )
+
 
 class TestEnvOverride:
     """环境变量解析与类型转换。"""

--- a/tests/test_llm_search_module_v2.py
+++ b/tests/test_llm_search_module_v2.py
@@ -1,0 +1,126 @@
+"""Deterministic orchestration tests for the canonical LLM Search module."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from souwen.modules.llm_search.application import LLMSearchModuleService
+from souwen.platform.provider_spi import (
+    EvidenceItem,
+    ExecutionContext,
+    LLMSearchRequest,
+    LLMSearchResult,
+    ProviderError,
+    ProviderErrorCode,
+    ProviderRef,
+    Provenance,
+    RequestContext,
+    SearchItem,
+    SearchMeta,
+    Usage,
+)
+
+
+ADAPTER_ID = "uniapi_ark_annotations_deepseek_v3_2_251201"
+
+
+class _Manager:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def execute(self, adapter_id, request, request_context, execution):
+        self.calls.append(adapter_id)
+        retrieved_at = datetime(2026, 7, 24, tzinfo=timezone.utc)
+        item = SearchItem(
+            id="url:fixture",
+            title="Fixture",
+            url="https://example.com/fixture",
+            rank=1,
+            provenance=(
+                Provenance(
+                    provider=adapter_id,
+                    outcome="success",
+                    retrieved_at=retrieved_at,
+                ),
+            ),
+        )
+        return LLMSearchResult(
+            query=request.query,
+            items=(item,),
+            evidence=(
+                EvidenceItem(
+                    id="evidence:fixture",
+                    item_id=item.id,
+                    provider=adapter_id,
+                    public_url="https://example.com/fixture",
+                    title_or_snippet="Fixture",
+                    retrieved_at=retrieved_at,
+                ),
+            ),
+            meta=SearchMeta(requested=(adapter_id,), succeeded=(adapter_id,)),
+            usage=Usage(),
+            context=request_context,
+        )
+
+
+def _request(*, provider_id: str = ADAPTER_ID, strategy: str = "single") -> LLMSearchRequest:
+    return LLMSearchRequest(
+        query="query",
+        providers=(ProviderRef(id=provider_id, kind="llm_search"),),
+        strategy=strategy,
+    )
+
+
+@pytest.mark.asyncio
+async def test_module_executes_only_the_deployment_configured_adapter() -> None:
+    manager = _Manager()
+    result = await LLMSearchModuleService(manager, ADAPTER_ID).search(
+        _request(),
+        RequestContext(request_id="module-v2"),
+        ExecutionContext.with_timeout(5),
+    )
+
+    assert result.query == "query"
+    assert manager.calls == [ADAPTER_ID]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "canonical_request",
+    [
+        _request(provider_id="uniapi_ark_annotations_doubao_seed_2_0_lite_260428"),
+        _request(strategy="fanout"),
+    ],
+)
+async def test_module_rejects_request_side_source_or_strategy_override(
+    canonical_request: LLMSearchRequest,
+) -> None:
+    manager = _Manager()
+    with pytest.raises(ProviderError) as caught:
+        await LLMSearchModuleService(manager, ADAPTER_ID).search(
+            canonical_request,
+            RequestContext(request_id="module-v2"),
+            ExecutionContext.with_timeout(5),
+        )
+
+    assert caught.value.code is ProviderErrorCode.INVALID_REQUEST
+    assert manager.calls == []
+
+
+@pytest.mark.asyncio
+async def test_module_honours_cancellation_before_provider_dispatch() -> None:
+    manager = _Manager()
+    execution = ExecutionContext.with_timeout(5)
+    execution.cancel_event.set()
+
+    with pytest.raises(ProviderError) as caught:
+        await LLMSearchModuleService(manager, ADAPTER_ID).search(
+            _request(),
+            RequestContext(request_id="module-v2"),
+            execution,
+        )
+
+    assert caught.value.code is ProviderErrorCode.CANCELLED
+    assert manager.calls == []

--- a/tests/test_phase2_module_skeleton.py
+++ b/tests/test_phase2_module_skeleton.py
@@ -49,7 +49,7 @@ SKELETON_PACKAGES = (
     "souwen.providers.fetch_sources",
 )
 
-# P4-01 intentionally promotes these Phase-2 placeholders into real internal
+# Phase 4 intentionally promotes these Phase-2 placeholders into real internal
 # interfaces. Their strict contracts and import boundaries have dedicated tests;
 # the remaining packages must stay inert until their owning migration slice.
 IMPLEMENTED_PACKAGES = frozenset(
@@ -57,6 +57,7 @@ IMPLEMENTED_PACKAGES = frozenset(
         "souwen.modules.search.api",
         "souwen.modules.search.application",
         "souwen.modules.llm_search.api",
+        "souwen.modules.llm_search.application",
         "souwen.modules.fetch.api",
         "souwen.platform.provider_spi",
         "souwen.platform.manifest_registry",

--- a/tests/test_uniapi_ark_provider_v2.py
+++ b/tests/test_uniapi_ark_provider_v2.py
@@ -1,0 +1,337 @@
+"""Provider v2 conformance for the immutable UniAPI Ark adapters."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from souwen.platform.provider_spi import (
+    ExecutionContext,
+    LLMSearchRequest,
+    ProviderError,
+    ProviderErrorCode,
+    ProviderRef,
+    RequestContext,
+)
+from souwen.providers.llm_sources.uniapi_ark_annotations.adapter import (
+    UniApiArkAnnotationsDeepSeekProvider,
+    UniApiArkAnnotationsDoubaoProvider,
+)
+from souwen.providers.llm_sources.uniapi_ark_annotations.manifest import (
+    DEEPSEEK_ADAPTER_ID,
+    DOUBAO_ADAPTER_ID,
+    UNIAPI_ARK_DEEPSEEK_MANIFEST,
+    UNIAPI_ARK_DOUBAO_MANIFEST,
+)
+from souwen.web.llm_search.schemes.ark_annotations import (
+    ARK_ANNOTATIONS_DEEPSEEK,
+    ARK_ANNOTATIONS_DOUBAO,
+)
+
+
+class _Response:
+    def __init__(self, payload: Any) -> None:
+        self._payload = payload
+
+    def json(self) -> Any:
+        return self._payload
+
+
+class _Transport:
+    def __init__(self, payload: Any) -> None:
+        self.payload = payload
+        self.calls: list[dict[str, Any]] = []
+        self.closed = 0
+
+    async def post(self, url, json=None, data=None, headers=None, retry_policy="default"):
+        self.calls.append(
+            {
+                "url": url,
+                "json": json,
+                "data": data,
+                "headers": headers,
+                "retry_policy": retry_policy,
+            }
+        )
+        return _Response(self.payload)
+
+    async def close(self) -> None:
+        self.closed += 1
+
+
+class _BlockingTransport(_Transport):
+    async def post(self, *args, **kwargs):
+        await asyncio.Event().wait()
+
+
+def _payload(
+    model_id: str,
+    *,
+    annotations: list[dict[str, Any]] | None = None,
+    include_search_call: bool = True,
+    usage: Any = None,
+) -> dict[str, Any]:
+    output: list[dict[str, Any]] = []
+    if include_search_call:
+        output.append({"type": "web_search_call", "status": "completed"})
+    output.append(
+        {
+            "type": "message",
+            "status": "completed",
+            "message": {
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": "Untrusted answer https://must-not-be-inferred.example/",
+                        "annotations": annotations or [],
+                    }
+                ]
+            },
+        }
+    )
+    return {
+        "status": "completed",
+        "model": model_id,
+        "output": output,
+        "usage": usage,
+    }
+
+
+def _provider(provider_type, payload):
+    transport = _Transport(payload)
+    provider = provider_type(
+        {"enabled": True, "max_keyword": 10, "timeout_seconds": 45},
+        {
+            "UNIAPI_API_KEY": "fixture-secret",
+            "UNIAPI_BASE_URL": "https://gateway.example.test",
+        },
+        transport=transport,
+        clock=lambda: datetime(2026, 7, 24, tzinfo=timezone.utc),
+    )
+    return provider, transport
+
+
+def _request(adapter_id: str, *, max_results: int | None = None) -> LLMSearchRequest:
+    return LLMSearchRequest(
+        query="  canonical query  ",
+        providers=(ProviderRef(id=adapter_id, kind="llm_search"),),
+        strategy="single",
+        max_results_per_provider=max_results,
+    )
+
+
+def test_manifests_match_legacy_immutable_source_and_model_identities() -> None:
+    pairs = (
+        (
+            UNIAPI_ARK_DEEPSEEK_MANIFEST,
+            ARK_ANNOTATIONS_DEEPSEEK,
+            UniApiArkAnnotationsDeepSeekProvider,
+        ),
+        (
+            UNIAPI_ARK_DOUBAO_MANIFEST,
+            ARK_ANNOTATIONS_DOUBAO,
+            UniApiArkAnnotationsDoubaoProvider,
+        ),
+    )
+    for manifest, legacy, provider_type in pairs:
+        assert manifest.version == "2.0.0rc2"
+        assert manifest.id == legacy.source_id == provider_type.ADAPTER_ID
+        assert provider_type.MODEL_ID == legacy.model_id
+        assert manifest.adapters[0].availability == "configured"
+        assert manifest.secrets.references == ("UNIAPI_API_KEY", "UNIAPI_BASE_URL")
+        assert manifest.network.egress_hosts == ()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider_type", "adapter_id", "model_id"),
+    [
+        (
+            UniApiArkAnnotationsDeepSeekProvider,
+            DEEPSEEK_ADAPTER_ID,
+            "deepseek-v3-2-251201",
+        ),
+        (
+            UniApiArkAnnotationsDoubaoProvider,
+            DOUBAO_ADAPTER_ID,
+            "doubao-seed-2-0-lite-260428",
+        ),
+    ],
+)
+async def test_each_adapter_executes_one_bound_request_and_emits_evidence_usage(
+    provider_type, adapter_id: str, model_id: str
+) -> None:
+    provider, transport = _provider(
+        provider_type,
+        _payload(
+            model_id,
+            annotations=[
+                {
+                    "type": "url_citation",
+                    "title": "Structured source",
+                    "url": "https://example.com/source",
+                    "summary": "Provider-reported summary",
+                },
+                {
+                    "type": "url_citation",
+                    "title": "Duplicate",
+                    "url": "https://example.com/source#fragment",
+                },
+            ],
+            usage={"input_tokens": 11, "output_tokens": 7, "total_tokens": 18},
+        ),
+    )
+    result = await provider.search(
+        _request(adapter_id, max_results=2),
+        RequestContext(request_id="provider-v2"),
+        ExecutionContext.with_timeout(5),
+    )
+
+    assert result.answer is None
+    assert len(result.items) == len(result.evidence) == 1
+    assert result.evidence[0].item_id == result.items[0].id
+    assert result.evidence[0].provider == adapter_id
+    assert result.usage.input_tokens == 11
+    assert result.usage.output_tokens == 7
+    assert result.usage.cost is None
+    assert transport.calls == [
+        {
+            "url": "/v1/responses",
+            "json": {
+                "model": model_id,
+                "input": "canonical query",
+                "tools": [{"type": "web_search", "max_keyword": 2}],
+            },
+            "data": None,
+            "headers": None,
+            "retry_policy": "single_attempt",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        _payload("deepseek-v3-2-251201", annotations=[]),
+        _payload(
+            "deepseek-v3-2-251201",
+            annotations=[
+                {
+                    "type": "url_citation",
+                    "title": "Private literal",
+                    "url": "http://127.0.0.1/private",
+                }
+            ],
+        ),
+        _payload(
+            "deepseek-v3-2-251201",
+            annotations=[
+                {
+                    "type": "url_citation",
+                    "title": "Unsafe scheme",
+                    "url": "file:///private/data",
+                }
+            ],
+        ),
+        _payload(
+            "deepseek-v3-2-251201",
+            annotations=[
+                {
+                    "type": "url_citation",
+                    "title": "Structured",
+                    "url": "https://example.com/source",
+                }
+            ],
+            include_search_call=False,
+        ),
+        _payload(
+            "unexpected-model",
+            annotations=[
+                {
+                    "type": "url_citation",
+                    "title": "Structured",
+                    "url": "https://example.com/source",
+                }
+            ],
+        ),
+    ],
+)
+async def test_provider_fails_closed_without_valid_structured_public_evidence(payload) -> None:
+    provider, _transport = _provider(UniApiArkAnnotationsDeepSeekProvider, payload)
+
+    with pytest.raises(ProviderError) as caught:
+        await provider.search(
+            _request(DEEPSEEK_ADAPTER_ID),
+            RequestContext(request_id="provider-v2"),
+            ExecutionContext.with_timeout(5),
+        )
+
+    assert caught.value.code is ProviderErrorCode.INVALID_UPSTREAM_RESPONSE
+    assert "must-not-be-inferred" not in str(caught.value)
+
+
+@pytest.mark.asyncio
+async def test_provider_rejects_request_identity_and_hidden_workflow_overrides() -> None:
+    provider, transport = _provider(
+        UniApiArkAnnotationsDeepSeekProvider,
+        _payload("deepseek-v3-2-251201"),
+    )
+    wrong_source = _request(DOUBAO_ADAPTER_ID)
+    fetch_request = _request(DEEPSEEK_ADAPTER_ID).model_copy(update={"fetch": {"enabled": True}})
+
+    for request in (wrong_source, fetch_request):
+        with pytest.raises(ProviderError) as caught:
+            await provider.search(
+                request,
+                RequestContext(request_id="provider-v2"),
+                ExecutionContext.with_timeout(5),
+            )
+        assert caught.value.code is ProviderErrorCode.INVALID_REQUEST
+    assert transport.calls == []
+
+
+@pytest.mark.asyncio
+async def test_provider_live_cancellation_closes_the_pending_gateway_call() -> None:
+    transport = _BlockingTransport({})
+    provider = UniApiArkAnnotationsDeepSeekProvider(
+        {"enabled": True},
+        {
+            "UNIAPI_API_KEY": "fixture-secret",
+            "UNIAPI_BASE_URL": "https://gateway.example.test",
+        },
+        transport=transport,
+    )
+    execution = ExecutionContext.with_timeout(5)
+    task = asyncio.create_task(
+        provider.search(
+            _request(DEEPSEEK_ADAPTER_ID),
+            RequestContext(request_id="provider-v2"),
+            execution,
+        )
+    )
+    await asyncio.sleep(0)
+    execution.cancel_event.set()
+
+    with pytest.raises(ProviderError) as caught:
+        await task
+    assert caught.value.code is ProviderErrorCode.CANCELLED
+
+
+@pytest.mark.asyncio
+async def test_probe_is_local_and_close_is_idempotent() -> None:
+    provider, transport = _provider(
+        UniApiArkAnnotationsDeepSeekProvider,
+        _payload("deepseek-v3-2-251201"),
+    )
+    assert (await provider.probe(ExecutionContext.with_timeout(5))).status == "available"
+    assert transport.calls == []
+
+    await provider.close()
+    await provider.close()
+
+    assert transport.closed == 1
+    assert (await provider.probe(ExecutionContext.with_timeout(5))).status == "unavailable"

--- a/tests/test_uniapi_llm_search_vertical_v2.py
+++ b/tests/test_uniapi_llm_search_vertical_v2.py
@@ -1,0 +1,168 @@
+"""End-to-end in-process P4-03 vertical using a deterministic fake gateway."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from souwen.config import SouWenConfig
+from souwen.modules.llm_search.application import LLMSearchModuleService
+from souwen.platform.provider_manager import ProviderManager
+from souwen.platform.provider_spi import (
+    ExecutionContext,
+    LLMSearchRequest,
+    ProviderRef,
+    RequestContext,
+)
+from souwen.providers.llm_sources.uniapi_ark_annotations.adapter import (
+    UniApiArkAnnotationsDeepSeekProvider,
+)
+from souwen.providers.llm_sources.uniapi_ark_annotations.manifest import (
+    DEEPSEEK_ADAPTER_ID,
+    UNIAPI_ARK_MANIFESTS,
+)
+
+
+class _Response:
+    def json(self):
+        return {
+            "status": "completed",
+            "model": "deepseek-v3-2-251201",
+            "output": [
+                {"type": "web_search_call", "status": "completed"},
+                {
+                    "type": "message",
+                    "status": "completed",
+                    "message": {
+                        "content": [
+                            {
+                                "annotations": [
+                                    {
+                                        "type": "url_citation",
+                                        "title": "Vertical fixture",
+                                        "url": "https://example.com/vertical",
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                },
+            ],
+            "usage": {},
+        }
+
+
+class _Gateway:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def post(self, *args, **kwargs):
+        self.calls += 1
+        return _Response()
+
+    async def close(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_config_to_manager_to_module_to_provider_vertical() -> None:
+    config = SouWenConfig(
+        sources={DEEPSEEK_ADAPTER_ID: {"enabled": True}},
+        llm_search_gateways={
+            "uniapi": {
+                "api_key": "fixture-secret",
+                "base_url": "https://gateway.example.test",
+            }
+        },
+    )
+    selected = config.enabled_uniapi_ark_source_ids()[0]
+    gateway = _Gateway()
+
+    def resolve_config(manifest):
+        if manifest.id != selected:
+            raise ValueError("adapter is disabled")
+        source = config.get_source_config(selected)
+        return {
+            "enabled": True,
+            "max_keyword": source.params.get("max_keyword", 10),
+            "timeout_seconds": source.timeout or 45,
+        }
+
+    def resolve_secrets(_manifest, _references):
+        uniapi = config.get_llm_search_gateway("uniapi")
+        return {
+            "UNIAPI_API_KEY": uniapi.api_key or "",
+            "UNIAPI_BASE_URL": uniapi.base_url or "",
+        }
+
+    manager = ProviderManager(
+        config_resolver=resolve_config,
+        secret_resolver=resolve_secrets,
+    )
+
+    def factory(configuration, secrets):
+        return UniApiArkAnnotationsDeepSeekProvider(
+            configuration,
+            secrets,
+            transport=gateway,
+            clock=lambda: datetime(2026, 7, 24, tzinfo=timezone.utc),
+        )
+
+    manager.register_factory(
+        package_id=selected,
+        export="UniApiArkAnnotationsDeepSeekProvider",
+        factory=factory,
+        provider_type=UniApiArkAnnotationsDeepSeekProvider,
+    )
+    registrations = manager.discover(UNIAPI_ARK_MANIFESTS)
+
+    assert tuple(registration.accepted for registration in registrations) == (True, True)
+    assert manager.eligible_adapter_ids == (selected,)
+    assert manager.diagnostics[-1].reason_code == "factory_missing"
+
+    result = await LLMSearchModuleService(manager, selected).search(
+        LLMSearchRequest(
+            query="vertical query",
+            providers=(ProviderRef(id=selected, kind="llm_search"),),
+            strategy="single",
+        ),
+        RequestContext(request_id="vertical-v2"),
+        ExecutionContext.with_timeout(5),
+    )
+
+    assert result.items[0].title == "Vertical fixture"
+    assert result.evidence[0].item_id == result.items[0].id
+    assert result.usage.input_tokens is None
+    assert result.usage.output_tokens is None
+    assert gateway.calls == 1
+
+
+def test_enabled_uniapi_without_gateway_is_provider_local_unavailable() -> None:
+    config = SouWenConfig(sources={DEEPSEEK_ADAPTER_ID: {"enabled": True}})
+    manager = ProviderManager(
+        config_resolver=lambda manifest: (
+            {"enabled": True}
+            if manifest.id == DEEPSEEK_ADAPTER_ID
+            else (_ for _ in ()).throw(ValueError("adapter is disabled"))
+        ),
+        secret_resolver=lambda _manifest, _references: {},
+    )
+    manager.register_factory(
+        package_id=DEEPSEEK_ADAPTER_ID,
+        export="UniApiArkAnnotationsDeepSeekProvider",
+        factory=UniApiArkAnnotationsDeepSeekProvider,
+        provider_type=UniApiArkAnnotationsDeepSeekProvider,
+    )
+
+    manager.discover(UNIAPI_ARK_MANIFESTS)
+
+    assert config.missing_uniapi_gateway_fields() == (
+        "llm_search_gateways.uniapi.api_key",
+        "llm_search_gateways.uniapi.base_url",
+    )
+    assert manager.eligible_adapter_ids == ()
+    assert {diagnostic.reason_code for diagnostic in manager.diagnostics} == {
+        "secret_unavailable",
+        "factory_missing",
+    }


### PR DESCRIPTION
## 范围

交付 P4-03，不包含 Delivery route、P4-04 Fetch、HFS promotion 或版本面升级。

- 新增 `LLMSearchModuleService`，仅允许 deployment 配置的单一 adapter，拒绝 request 覆盖 source、strategy、gateway 或 model。
- 新增两个 immutable Provider v2 adapter：
  - `uniapi_ark_annotations_deepseek_v3_2_251201`
  - `uniapi_ark_annotations_doubao_seed_2_0_lite_260428`
- 固定 Ark Responses 单次调用与 exact model ID；只接受 structured URL annotations，不从 answer 文本猜 URL。
- canonical result 保证每个 item 关联 stable evidence，`usage` 始终存在且只记录 provider 实报 token；未知 cost 为 `null`。
- YAML source 默认全部关闭；两个同时显式启用时配置加载失败。
- 支持 gateway YAML exact `${VAR}` 引用；缺失凭据只形成 safe unavailable/missing-field 诊断，不阻塞配置或其他 Provider。
- 保留 legacy enriched route 与 Registry source 作为 rollback 路径。

## 本地验证

- `pytest tests/ -v --tb=short`：2550 passed, 3 skipped
- `ruff check src tests scripts tools`：PASS
- `ruff format --check src tests scripts tools`：536 files formatted
- `python3 scripts/ci/check_architecture_dependencies.py`：PASS
- `PYTHONPATH=src python3 tools/gen_docs.py --check`：PASS
- `pytest tests/test_import_surface.py -q`：28 passed

## 安全与发布边界

- 普通测试只使用 fake gateway，没有真实 UniAPI 请求或费用。
- 不记录 credential、private gateway URL、raw response 或 answer text。
- PR context 必须保持 HFS promotion/rollback/pause jobs skipped。