### PR TITLE
feat(v2): add builtin fetch vertical

### DIFF
--- a/src/souwen/modules/fetch/api/__init__.py
+++ b/src/souwen/modules/fetch/api/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Protocol
 
+from souwen.modules.fetch.application import FetchModuleService
 from souwen.platform.provider_spi import ExecutionContext, FetchBatch, FetchRequest, RequestContext
 
 
@@ -16,4 +17,4 @@ class FetchModule(Protocol):
         """Execute Fetch without exposing a concrete provider."""
 
 
-__all__ = ["FetchBatch", "FetchModule", "FetchRequest"]
+__all__ = ["FetchBatch", "FetchModule", "FetchModuleService", "FetchRequest"]

--- a/src/souwen/modules/fetch/application/__init__.py
+++ b/src/souwen/modules/fetch/application/__init__.py
@@ -1,3 +1,5 @@
-"""Fetch application layer. Owner: Fetch Core. Allowed dependencies: own domain, ports, and common runtime."""
+"""Fetch application layer. Owner: Fetch Core."""
 
-__all__: list[str] = []
+from .orchestration import FetchModuleService, FetchProviderManager
+
+__all__ = ["FetchModuleService", "FetchProviderManager"]

--- a/src/souwen/modules/fetch/application/orchestration.py
+++ b/src/souwen/modules/fetch/application/orchestration.py
@@ -1,0 +1,154 @@
+"""Canonical Fetch batch orchestration through an injected Provider Manager port."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Protocol
+
+from souwen.platform.provider_spi import (
+    ErrorDetail,
+    ExecutionContext,
+    FetchBatch,
+    FetchMeta,
+    FetchRequest,
+    FetchResult,
+    FetchTargetRequest,
+    ProviderError,
+    ProviderErrorCode,
+    Provenance,
+    RequestContext,
+)
+
+
+BUILTIN_FETCH_ADAPTER_ID = "builtin-fetch"
+
+
+class FetchProviderManager(Protocol):
+    async def execute(
+        self,
+        adapter_id: str,
+        request: FetchTargetRequest,
+        request_context: RequestContext,
+        execution: ExecutionContext,
+    ) -> FetchResult:
+        """Execute one target through one selected Fetch adapter."""
+
+
+class FetchModuleService:
+    """Run the RC2 builtin Fetch provider for every canonical target."""
+
+    def __init__(
+        self,
+        manager: FetchProviderManager,
+        configured_adapter_id: str = BUILTIN_FETCH_ADAPTER_ID,
+    ) -> None:
+        if not configured_adapter_id.strip():
+            raise ValueError("configured_adapter_id must not be blank")
+        self._manager = manager
+        self._adapter_id = configured_adapter_id
+
+    async def fetch(
+        self,
+        request: FetchRequest,
+        context: RequestContext,
+        execution: ExecutionContext,
+    ) -> FetchBatch:
+        execution.raise_if_cancelled_or_expired()
+        if request.strategy not in {None, "fallback"}:
+            raise ProviderError(ProviderErrorCode.INVALID_REQUEST)
+        if request.providers is not None and (
+            len(request.providers) != 1
+            or request.providers[0].kind != "fetch"
+            or request.providers[0].id != self._adapter_id
+        ):
+            raise ProviderError(ProviderErrorCode.INVALID_REQUEST)
+
+        items = await asyncio.gather(
+            *(self._fetch_target(target, request, context, execution) for target in request.targets)
+        )
+        execution.raise_if_cancelled_or_expired()
+        partial = any(
+            item.status != "success"
+            or item.content_metadata is None
+            or item.content_metadata.quality == "low"
+            for item in items
+        )
+        return FetchBatch(items=items, meta=FetchMeta(partial=partial), context=context)
+
+    async def _fetch_target(
+        self,
+        target: object,
+        request: FetchRequest,
+        context: RequestContext,
+        execution: ExecutionContext,
+    ) -> FetchResult:
+        target_request = FetchTargetRequest(
+            target=target,
+            content=request.content,
+            policy=request.policy,
+        )
+        try:
+            return await self._manager.execute(
+                self._adapter_id,
+                target_request,
+                context,
+                execution,
+            )
+        except ProviderError as exc:
+            return _failed_result(target_request, context, self._adapter_id, exc)
+        except Exception:
+            return _failed_result(
+                target_request,
+                context,
+                self._adapter_id,
+                ProviderError(ProviderErrorCode.PROVIDER_UNAVAILABLE),
+            )
+
+
+def _failed_result(
+    request: FetchTargetRequest,
+    context: RequestContext,
+    adapter_id: str,
+    error: ProviderError,
+) -> FetchResult:
+    code = _canonical_error_code(error.code)
+    return FetchResult(
+        target=request.target,
+        final_url=None,
+        status="blocked" if error.code is ProviderErrorCode.POLICY_BLOCKED else "failed",
+        provenance=(Provenance(provider=adapter_id, outcome="failed"),),
+        error=ErrorDetail(
+            code=code,
+            message=_safe_error_message(code),
+            retryable=error.retryable,
+            request_id=context.request_id,
+            provider=adapter_id,
+        ),
+    )
+
+
+def _canonical_error_code(code: ProviderErrorCode) -> str:
+    return {
+        ProviderErrorCode.INVALID_REQUEST: "invalid_request",
+        ProviderErrorCode.CANCELLED: "provider_timeout",
+        ProviderErrorCode.DEADLINE_EXCEEDED: "provider_timeout",
+        ProviderErrorCode.RATE_LIMITED: "rate_limited",
+        ProviderErrorCode.POLICY_BLOCKED: "policy_blocked",
+        ProviderErrorCode.PAYLOAD_TOO_LARGE: "payload_too_large",
+        ProviderErrorCode.UNSUPPORTED_MEDIA_TYPE: "unsupported_media_type",
+    }.get(code, "provider_unavailable")
+
+
+def _safe_error_message(code: str) -> str:
+    return {
+        "invalid_request": "Fetch request is invalid",
+        "provider_timeout": "Fetch provider timed out",
+        "rate_limited": "Fetch provider was rate limited",
+        "policy_blocked": "Fetch target was blocked by policy",
+        "payload_too_large": "Fetch response exceeded the size limit",
+        "unsupported_media_type": "Fetch response media type is unsupported",
+        "provider_unavailable": "Fetch provider is unavailable",
+    }[code]
+
+
+__all__ = ["BUILTIN_FETCH_ADAPTER_ID", "FetchModuleService", "FetchProviderManager"]

--- a/src/souwen/platform/provider_spi/dto.py
+++ b/src/souwen/platform/provider_spi/dto.py
@@ -81,6 +81,8 @@ CanonicalErrorCode: TypeAlias = Literal[
     "conflict",
     "api_major_mismatch",
     "rate_limited",
+    "payload_too_large",
+    "unsupported_media_type",
     "provider_timeout",
     "provider_unavailable",
     "policy_blocked",

--- a/src/souwen/platform/provider_spi/errors.py
+++ b/src/souwen/platform/provider_spi/errors.py
@@ -16,6 +16,8 @@ class ProviderErrorCode(str, Enum):
     PROVIDER_UNAVAILABLE = "provider_unavailable"
     INVALID_UPSTREAM_RESPONSE = "invalid_upstream_response"
     POLICY_BLOCKED = "policy_blocked"
+    PAYLOAD_TOO_LARGE = "payload_too_large"
+    UNSUPPORTED_MEDIA_TYPE = "unsupported_media_type"
 
 
 _SAFE_MESSAGES: dict[ProviderErrorCode, str] = {
@@ -27,6 +29,8 @@ _SAFE_MESSAGES: dict[ProviderErrorCode, str] = {
     ProviderErrorCode.PROVIDER_UNAVAILABLE: "Provider is unavailable",
     ProviderErrorCode.INVALID_UPSTREAM_RESPONSE: "Provider returned an invalid response",
     ProviderErrorCode.POLICY_BLOCKED: "Provider operation was blocked by policy",
+    ProviderErrorCode.PAYLOAD_TOO_LARGE: "Provider response exceeded the size limit",
+    ProviderErrorCode.UNSUPPORTED_MEDIA_TYPE: "Provider response media type is unsupported",
 }
 
 

--- a/src/souwen/providers/fetch_sources/builtin/__init__.py
+++ b/src/souwen/providers/fetch_sources/builtin/__init__.py
@@ -1,0 +1,6 @@
+"""Builtin canonical Fetch Provider v2 adapter."""
+
+from .adapter import BuiltinFetchProvider, LegacyBuiltinFetchClientProtocol
+from .manifest import BUILTIN_FETCH_MANIFEST
+
+__all__ = ["BUILTIN_FETCH_MANIFEST", "BuiltinFetchProvider", "LegacyBuiltinFetchClientProtocol"]

--- a/src/souwen/providers/fetch_sources/builtin/adapter.py
+++ b/src/souwen/providers/fetch_sources/builtin/adapter.py
@@ -1,0 +1,216 @@
+"""Canonical builtin Fetch adapter over the existing SSRF-safe fetch client."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from datetime import datetime, timezone
+from typing import Any, Callable, Protocol
+
+from souwen.common_runtime.errors import SouWenError
+from souwen.common_runtime.transport.errors import RateLimitError, SourceUnavailableError
+from souwen.platform.provider_spi import (
+    ContentMetadata,
+    ExecutionContext,
+    FetchResult,
+    FetchTargetRequest,
+    ProviderError,
+    ProviderErrorCode,
+    ProviderProbe,
+    Provenance,
+    RequestContext,
+)
+
+
+_PROVIDER_ID = "builtin-fetch"
+_DEFAULT_MAX_CODE_POINTS = 200_000
+
+
+class LegacyBuiltinFetchClientProtocol(Protocol):
+    async def fetch(
+        self,
+        url: str,
+        timeout: float = 30.0,
+        start_index: int = 0,
+        max_length: int | None = None,
+        respect_robots_txt: bool | None = None,
+        selector: str | None = None,
+        enforce_target_contract: bool = False,
+    ) -> Any:
+        """Return a legacy FetchResult produced by the safe redirect pipeline."""
+
+
+class BuiltinFetchProvider:
+    """Fetch one target with mandatory target media, size, and URL policy."""
+
+    capability = "fetch"
+
+    def __init__(
+        self,
+        client: LegacyBuiltinFetchClientProtocol,
+        *,
+        enabled: bool = True,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._client = client
+        self._enabled = enabled
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self._closed = False
+
+    async def fetch(
+        self,
+        request: FetchTargetRequest,
+        context: RequestContext,
+        execution: ExecutionContext,
+    ) -> FetchResult:
+        execution.raise_if_cancelled_or_expired()
+        if self._closed or not self._enabled:
+            raise ProviderError(ProviderErrorCode.INVALID_CONFIG, provider_id=_PROVIDER_ID)
+        max_code_points = (
+            request.content.max_code_points
+            if request.content is not None and request.content.max_code_points is not None
+            else _DEFAULT_MAX_CODE_POINTS
+        )
+        try:
+            receipt = await asyncio.wait_for(
+                self._client.fetch(
+                    str(request.target),
+                    timeout=min(30.0, execution.remaining_seconds),
+                    max_length=max_code_points,
+                    respect_robots_txt=(
+                        request.policy.respect_robots if request.policy is not None else None
+                    ),
+                    enforce_target_contract=True,
+                ),
+                timeout=execution.remaining_seconds,
+            )
+            execution.raise_if_cancelled_or_expired()
+            return _canonical_result(
+                receipt,
+                request=request,
+                context=context,
+                retrieved_at=self._clock(),
+            )
+        except asyncio.CancelledError:
+            raise
+        except ProviderError:
+            raise
+        except (asyncio.TimeoutError, TimeoutError):
+            raise ProviderError(
+                ProviderErrorCode.DEADLINE_EXCEEDED,
+                provider_id=_PROVIDER_ID,
+            ) from None
+        except RateLimitError as exc:
+            raise ProviderError(
+                ProviderErrorCode.RATE_LIMITED,
+                provider_id=_PROVIDER_ID,
+                retry_after_seconds=getattr(exc, "retry_after", None),
+            ) from None
+        except SourceUnavailableError:
+            raise ProviderError(
+                ProviderErrorCode.PROVIDER_UNAVAILABLE,
+                provider_id=_PROVIDER_ID,
+            ) from None
+        except (AttributeError, TypeError, ValueError):
+            raise ProviderError(
+                ProviderErrorCode.INVALID_UPSTREAM_RESPONSE,
+                provider_id=_PROVIDER_ID,
+            ) from None
+        except SouWenError:
+            raise ProviderError(
+                ProviderErrorCode.PROVIDER_UNAVAILABLE,
+                provider_id=_PROVIDER_ID,
+            ) from None
+        except Exception:
+            raise ProviderError(
+                ProviderErrorCode.PROVIDER_UNAVAILABLE,
+                provider_id=_PROVIDER_ID,
+            ) from None
+
+    async def probe(self, execution: ExecutionContext) -> ProviderProbe:
+        execution.raise_if_cancelled_or_expired()
+        return ProviderProbe(
+            provider=_PROVIDER_ID,
+            capability="fetch",
+            status="unavailable" if self._closed or not self._enabled else "available",
+        )
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        closer = getattr(self._client, "close", None) or getattr(self._client, "aclose", None)
+        if closer is None:
+            return
+        try:
+            result = closer()
+            if inspect.isawaitable(result):
+                await result
+        except asyncio.CancelledError:
+            self._closed = False
+            raise
+
+
+def _canonical_result(
+    receipt: Any,
+    *,
+    request: FetchTargetRequest,
+    context: RequestContext,
+    retrieved_at: datetime,
+) -> FetchResult:
+    del context
+    raw = getattr(receipt, "raw", None)
+    if not isinstance(raw, dict):
+        raise ValueError("missing target receipt metadata")
+    error_code = raw.get("target_error_code")
+    if getattr(receipt, "error", None):
+        code = {
+            "policy_blocked": ProviderErrorCode.POLICY_BLOCKED,
+            "response_too_large": ProviderErrorCode.PAYLOAD_TOO_LARGE,
+            "unsupported_media_type": ProviderErrorCode.UNSUPPORTED_MEDIA_TYPE,
+            "empty_content": ProviderErrorCode.INVALID_UPSTREAM_RESPONSE,
+        }.get(error_code, ProviderErrorCode.PROVIDER_UNAVAILABLE)
+        raise ProviderError(code, provider_id=_PROVIDER_ID)
+
+    content = getattr(receipt, "content", None)
+    if not isinstance(content, str) or not content.strip():
+        raise ProviderError(
+            ProviderErrorCode.INVALID_UPSTREAM_RESPONSE,
+            provider_id=_PROVIDER_ID,
+        )
+    media_type = raw.get("media_type")
+    if not isinstance(media_type, str) or not media_type:
+        raise ValueError("missing media type")
+    if retrieved_at.tzinfo is None:
+        raise ValueError("retrieved_at must be timezone-aware")
+    final_url = getattr(receipt, "final_url", None)
+    return FetchResult(
+        target=request.target,
+        final_url=final_url,
+        status="success",
+        title=getattr(receipt, "title", None) or None,
+        content=content,
+        content_metadata=ContentMetadata(
+            media_type=media_type,
+            charset=raw.get("charset") if isinstance(raw.get("charset"), str) else None,
+            retrieved_at=retrieved_at,
+            truncated=bool(getattr(receipt, "content_truncated", False)),
+            content_length=(
+                raw.get("content_length_bytes")
+                if isinstance(raw.get("content_length_bytes"), int)
+                else None
+            ),
+            quality="low" if len(content.strip()) <= 63 else "high",
+        ),
+        provenance=(
+            Provenance(
+                provider=_PROVIDER_ID,
+                attempt=1,
+                outcome="success",
+                retrieved_at=retrieved_at,
+            ),
+        ),
+    )
+
+
+__all__ = ["BuiltinFetchProvider", "LegacyBuiltinFetchClientProtocol"]

--- a/src/souwen/providers/fetch_sources/builtin/manifest.py
+++ b/src/souwen/providers/fetch_sources/builtin/manifest.py
@@ -1,0 +1,39 @@
+"""Static Provider v2 declaration for target-native builtin Fetch."""
+
+from souwen.platform.manifest_registry import ProviderManifest
+
+
+BUILTIN_FETCH_MANIFEST = ProviderManifest.model_validate(
+    {
+        "schema_version": 2,
+        "id": "builtin-fetch",
+        "version": "2.0.0rc2",
+        "contract_version": "provider-v2",
+        "capabilities": ["fetch"],
+        "adapters": [
+            {
+                "id": "builtin-fetch",
+                "capability": "fetch",
+                "export": "BuiltinFetchProvider",
+                "availability": "always",
+            }
+        ],
+        "configuration": {
+            "schema_reference": "builtin-fetch-provider-config-v1",
+            "unknown_key_policy": "reject",
+            "non_secret_keys": ["enabled"],
+        },
+        "secrets": {"references": []},
+        # Targets are request-specific and validated before every connection.
+        "network": {"egress_hosts": [], "proxy_supported": True, "browser_required": False},
+        "risk": {"authenticated": False, "costed": False},
+        "observability": {"dimensions": ["provider", "adapter", "capability", "outcome"]},
+        "compatibility": {
+            "contract_versions": ["provider-v2"],
+            "config_schema_versions": ["builtin-fetch-provider-config-v1"],
+        },
+    }
+)
+
+
+__all__ = ["BUILTIN_FETCH_MANIFEST"]

--- a/src/souwen/web/builtin.py
+++ b/src/souwen/web/builtin.py
@@ -81,6 +81,30 @@ _ROBOTS_USER_AGENT = "SouWen/1.0 (+https://github.com/BlueSkyXN/SouWen)"
 
 
 _CJK_PATTERN = r"[\u4e00-\u9fff\u3400-\u4dbf\uf900-\ufaff\u3040-\u30ff\u31f0-\u31ff\uac00-\ud7af]"
+_TARGET_JSON_MEDIA_TYPES = frozenset({"application/json"})
+_TARGET_XML_MEDIA_TYPES = frozenset({"application/xml", "text/xml"})
+
+
+def _target_media_type(value: str | None) -> tuple[str, str | None]:
+    """Parse a bounded response content type for the canonical Fetch contract."""
+    raw_value = value if isinstance(value, str) else ""
+    parts = [part.strip() for part in raw_value.split(";")]
+    media_type = parts[0].lower()
+    charset = None
+    for part in parts[1:]:
+        if part.lower().startswith("charset="):
+            charset = part.split("=", 1)[1].strip().strip('"') or None
+    return media_type, charset
+
+
+def _target_media_type_allowed(media_type: str) -> bool:
+    return (
+        media_type.startswith("text/")
+        or media_type in _TARGET_JSON_MEDIA_TYPES
+        or media_type in _TARGET_XML_MEDIA_TYPES
+        or media_type.endswith("+json")
+        or media_type.endswith("+xml")
+    )
 
 
 def _count_words(text: str) -> int:
@@ -293,6 +317,7 @@ class BuiltinFetcherClient(BaseScraper):
         max_length: int | None = None,
         respect_robots_txt: bool | None = None,
         selector: str | None = None,
+        enforce_target_contract: bool = False,
     ) -> FetchResult:
         """抓取单个 URL 的内容
 
@@ -320,6 +345,7 @@ class BuiltinFetcherClient(BaseScraper):
                 start_index=start_index,
                 max_length=max_length,
                 selector=selector,
+                enforce_target_contract=enforce_target_contract,
             )
         finally:
             self.respect_robots_txt = prev_robots
@@ -330,6 +356,7 @@ class BuiltinFetcherClient(BaseScraper):
         start_index: int = 0,
         max_length: int | None = None,
         selector: str | None = None,
+        enforce_target_contract: bool = False,
     ) -> FetchResult:
         try:
             # robots.txt 合规检查（在任何重定向 / 抓取之前）
@@ -341,7 +368,15 @@ class BuiltinFetcherClient(BaseScraper):
                     final_url=url,
                     source=self.PROVIDER_NAME,
                     error=reason,
-                    raw={"provider": "builtin", "blocked_by_robots": True},
+                    raw={
+                        "provider": "builtin",
+                        "blocked_by_robots": True,
+                        **(
+                            {"target_error_code": "policy_blocked"}
+                            if enforce_target_contract
+                            else {}
+                        ),
+                    },
                 )
 
             # 手动重定向循环 — 每一跳解析并绑定到已校验 IP，防 DNS rebinding。
@@ -358,6 +393,15 @@ class BuiltinFetcherClient(BaseScraper):
                         final_url=current_url,
                         source=self.PROVIDER_NAME,
                         error=f"SSRF: {target_label}被拦截 ({reason})",
+                        raw={
+                            "provider": "builtin",
+                            "blocked_by_ssrf": True,
+                            **(
+                                {"target_error_code": "policy_blocked"}
+                                if enforce_target_contract
+                                else {}
+                            ),
+                        },
                     )
 
                 resp = await self._fetch(
@@ -425,8 +469,45 @@ class BuiltinFetcherClient(BaseScraper):
                             "status_code": resp.status_code,
                             "content_length": declared_size,
                             "oversized": True,
+                            **(
+                                {"target_error_code": "response_too_large"}
+                                if enforce_target_contract
+                                else {}
+                            ),
                         },
                     )
+
+            media_type, charset = _target_media_type(resp.headers.get("content-type"))
+            if enforce_target_contract and not _target_media_type_allowed(media_type):
+                return FetchResult(
+                    url=url,
+                    final_url=final_url,
+                    source=self.PROVIDER_NAME,
+                    error="响应媒体类型不受支持",
+                    raw={
+                        "provider": "builtin",
+                        "status_code": resp.status_code,
+                        "media_type": media_type or "unknown",
+                        "target_error_code": "unsupported_media_type",
+                    },
+                )
+
+            body = getattr(resp, "content", b"")
+            body_size = len(body) if isinstance(body, bytes | bytearray) else 0
+            if enforce_target_contract and body_size > self.MAX_RESPONSE_SIZE:
+                return FetchResult(
+                    url=url,
+                    final_url=final_url,
+                    source=self.PROVIDER_NAME,
+                    error="解压后响应体超过上限",
+                    raw={
+                        "provider": "builtin",
+                        "status_code": resp.status_code,
+                        "content_length": body_size,
+                        "oversized": True,
+                        "target_error_code": "response_too_large",
+                    },
+                )
 
             html = resp.text
 
@@ -448,21 +529,46 @@ class BuiltinFetcherClient(BaseScraper):
                         "status_code": resp.status_code,
                         "content_length": len(html),
                         "oversized": True,
+                        **(
+                            {"target_error_code": "response_too_large"}
+                            if enforce_target_contract
+                            else {}
+                        ),
                     },
                 )
 
-            if not html or len(html.strip()) < 100:
+            if not html or (not enforce_target_contract and len(html.strip()) < 100):
                 return FetchResult(
                     url=url,
                     final_url=final_url,
                     source=self.PROVIDER_NAME,
                     error="页面内容过短或为空",
-                    raw={"status_code": resp.status_code, "content_length": len(html)},
+                    raw={
+                        "status_code": resp.status_code,
+                        "content_length": body_size if enforce_target_contract else len(html),
+                        **(
+                            {"target_error_code": "empty_content"}
+                            if enforce_target_contract
+                            else {}
+                        ),
+                    },
                 )
 
             # 提取正文：CSS 选择器优先，否则 trafilatura 全页提取
             selector_matched = False
-            if selector:
+            if enforce_target_contract and media_type not in {
+                "text/html",
+                "application/xhtml+xml",
+            }:
+                extracted = {
+                    "content": html.strip(),
+                    "title": "",
+                    "author": None,
+                    "date": None,
+                    "description": "",
+                    "content_format": "text",
+                }
+            elif selector:
                 try:
                     from bs4 import BeautifulSoup
 
@@ -523,7 +629,10 @@ class BuiltinFetcherClient(BaseScraper):
             MIN_WORD_COUNT = 10
             word_count = _count_words(content) if content else 0
 
-            if not content or len(content) < MIN_CONTENT_LENGTH or word_count < MIN_WORD_COUNT:
+            if not content or (
+                not enforce_target_contract
+                and (len(content) < MIN_CONTENT_LENGTH or word_count < MIN_WORD_COUNT)
+            ):
                 return FetchResult(
                     url=url,
                     final_url=final_url,
@@ -534,6 +643,11 @@ class BuiltinFetcherClient(BaseScraper):
                         "content_length": len(html),
                         "extracted_length": len(content) if content else 0,
                         "word_count": word_count,
+                        **(
+                            {"target_error_code": "empty_content"}
+                            if enforce_target_contract
+                            else {}
+                        ),
                     },
                 )
 
@@ -573,6 +687,15 @@ class BuiltinFetcherClient(BaseScraper):
                     "provider": "builtin",
                     "status_code": resp.status_code,
                     "content_length": len(html),
+                    **(
+                        {
+                            "content_length_bytes": body_size,
+                            "media_type": media_type,
+                            "charset": charset,
+                        }
+                        if enforce_target_contract
+                        else {}
+                    ),
                     "extracted_length": full_length,
                     "returned_length": len(sliced),
                     "start_index": start_index,

--- a/tests/contracts/fixtures/target_api_contract_v2.json
+++ b/tests/contracts/fixtures/target_api_contract_v2.json
@@ -127,6 +127,8 @@
     "conflict": 409,
     "api_major_mismatch": 409,
     "rate_limited": 429,
+    "payload_too_large": 413,
+    "unsupported_media_type": 415,
     "provider_unavailable": 502,
     "provider_timeout": 504,
     "internal_error": 500

--- a/tests/test_builtin_fetch_provider_v2.py
+++ b/tests/test_builtin_fetch_provider_v2.py
@@ -1,0 +1,132 @@
+"""Deterministic P4-04 builtin Fetch Provider conformance."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from souwen.models import FetchResult as LegacyFetchResult
+from souwen.platform.provider_spi import (
+    ExecutionContext,
+    FetchContentOptions,
+    FetchTargetRequest,
+    ProviderError,
+    ProviderErrorCode,
+    RequestContext,
+)
+from souwen.providers.fetch_sources.builtin import BUILTIN_FETCH_MANIFEST, BuiltinFetchProvider
+
+
+class _Client:
+    def __init__(self, result: LegacyFetchResult) -> None:
+        self.result = result
+        self.calls = []
+        self.closed = 0
+
+    async def fetch(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        return self.result
+
+    async def close(self):
+        self.closed += 1
+
+
+def _legacy_result(content: str = "Useful canonical content") -> LegacyFetchResult:
+    return LegacyFetchResult(
+        url="https://example.com/page",
+        final_url="https://example.com/final",
+        title="Example",
+        content=content,
+        content_format="text",
+        source="builtin",
+        raw={
+            "provider": "builtin",
+            "media_type": "text/plain",
+            "charset": "utf-8",
+            "content_length_bytes": len(content.encode()),
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_provider_maps_safe_receipt_and_preserves_low_quality_partial_signal() -> None:
+    client = _Client(_legacy_result("short"))
+    provider = BuiltinFetchProvider(
+        client,
+        clock=lambda: datetime(2026, 7, 24, tzinfo=timezone.utc),
+    )
+    result = await provider.fetch(
+        FetchTargetRequest(
+            target="https://example.com/page",
+            content=FetchContentOptions(max_code_points=321),
+        ),
+        RequestContext(request_id="builtin-v2"),
+        ExecutionContext.with_timeout(5),
+    )
+
+    assert result.status == "success"
+    assert result.content == "short"
+    assert result.content_metadata is not None
+    assert result.content_metadata.quality == "low"
+    assert result.content_metadata.media_type == "text/plain"
+    assert client.calls[0][1]["max_length"] == 321
+    assert client.calls[0][1]["enforce_target_contract"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("target_error_code", "expected"),
+    [
+        ("policy_blocked", ProviderErrorCode.POLICY_BLOCKED),
+        ("response_too_large", ProviderErrorCode.PAYLOAD_TOO_LARGE),
+        ("unsupported_media_type", ProviderErrorCode.UNSUPPORTED_MEDIA_TYPE),
+        ("empty_content", ProviderErrorCode.INVALID_UPSTREAM_RESPONSE),
+    ],
+)
+async def test_provider_maps_target_receipt_failures_without_raw_detail(
+    target_error_code: str,
+    expected: ProviderErrorCode,
+) -> None:
+    client = _Client(
+        LegacyFetchResult(
+            url="https://example.com/page",
+            final_url="https://example.com/page",
+            source="builtin",
+            error="raw private upstream detail",
+            raw={"target_error_code": target_error_code},
+        )
+    )
+    provider = BuiltinFetchProvider(client)
+
+    with pytest.raises(ProviderError) as caught:
+        await provider.fetch(
+            FetchTargetRequest(target="https://example.com/page"),
+            RequestContext(request_id="builtin-v2"),
+            ExecutionContext.with_timeout(5),
+        )
+
+    assert caught.value.code is expected
+    assert "private" not in str(caught.value)
+
+
+@pytest.mark.asyncio
+async def test_probe_and_close_are_local_and_idempotent() -> None:
+    client = _Client(_legacy_result())
+    provider = BuiltinFetchProvider(client)
+
+    assert (await provider.probe(ExecutionContext.with_timeout(5))).status == "available"
+    await provider.close()
+    await provider.close()
+
+    assert client.calls == []
+    assert client.closed == 1
+    assert (await provider.probe(ExecutionContext.with_timeout(5))).status == "unavailable"
+
+
+def test_builtin_manifest_is_anonymous_zero_cost_fetch_only() -> None:
+    assert BUILTIN_FETCH_MANIFEST.version == "2.0.0rc2"
+    assert BUILTIN_FETCH_MANIFEST.capabilities == ("fetch",)
+    assert BUILTIN_FETCH_MANIFEST.secrets.references == ()
+    assert BUILTIN_FETCH_MANIFEST.risk.authenticated is False
+    assert BUILTIN_FETCH_MANIFEST.risk.costed is False

--- a/tests/test_builtin_fetch_vertical_v2.py
+++ b/tests/test_builtin_fetch_vertical_v2.py
@@ -1,0 +1,63 @@
+"""P4-04 Module to Manager to builtin Provider deterministic vertical."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from souwen.models import FetchResult as LegacyFetchResult
+from souwen.modules.fetch.application import FetchModuleService
+from souwen.platform.provider_manager import ProviderManager
+from souwen.platform.provider_spi import ExecutionContext, FetchRequest, RequestContext
+from souwen.providers.fetch_sources.builtin import BUILTIN_FETCH_MANIFEST, BuiltinFetchProvider
+
+
+class _Client:
+    async def fetch(self, url, **kwargs):
+        return LegacyFetchResult(
+            url=url,
+            final_url=url,
+            content="vertical canonical content " * 4,
+            content_format="text",
+            source="builtin",
+            raw={
+                "provider": "builtin",
+                "media_type": "application/json",
+                "charset": "utf-8",
+                "content_length_bytes": 128,
+            },
+        )
+
+    async def close(self):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_module_manager_provider_vertical() -> None:
+    manager = ProviderManager(config_resolver=lambda _manifest: {"enabled": True})
+    client = _Client()
+
+    def factory(_configuration, _secrets):
+        return BuiltinFetchProvider(
+            client,
+            clock=lambda: datetime(2026, 7, 24, tzinfo=timezone.utc),
+        )
+
+    manager.register_factory(
+        package_id="builtin-fetch",
+        export="BuiltinFetchProvider",
+        factory=factory,
+        provider_type=BuiltinFetchProvider,
+    )
+    assert manager.discover([BUILTIN_FETCH_MANIFEST])[0].accepted is True
+
+    batch = await FetchModuleService(manager).fetch(
+        FetchRequest(targets=("https://example.com/a", "https://example.com/b")),
+        RequestContext(request_id="builtin-vertical-v2"),
+        ExecutionContext.with_timeout(5),
+    )
+
+    assert [item.status for item in batch.items] == ["success", "success"]
+    assert all(item.content_metadata.media_type == "application/json" for item in batch.items)
+    assert batch.meta.partial is False

--- a/tests/test_fetch_module_v2.py
+++ b/tests/test_fetch_module_v2.py
@@ -1,0 +1,80 @@
+"""Canonical Fetch Module batch and partial-result behavior."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from souwen.modules.fetch.application import FetchModuleService
+from souwen.platform.provider_spi import (
+    ContentMetadata,
+    ExecutionContext,
+    FetchRequest,
+    FetchResult,
+    ProviderError,
+    ProviderErrorCode,
+    ProviderRef,
+    Provenance,
+    RequestContext,
+)
+
+
+class _Manager:
+    async def execute(self, adapter_id, request, request_context, execution):
+        if "blocked" in str(request.target):
+            raise ProviderError(ProviderErrorCode.POLICY_BLOCKED, provider_id=adapter_id)
+        content = (
+            "short" if "short" in str(request.target) else "long enough canonical content " * 4
+        )
+        return FetchResult(
+            target=request.target,
+            final_url=request.target,
+            status="success",
+            content=content,
+            content_metadata=ContentMetadata(
+                media_type="text/plain",
+                retrieved_at=datetime(2026, 7, 24, tzinfo=timezone.utc),
+                truncated=False,
+                quality="low" if len(content) <= 63 else "high",
+            ),
+            provenance=(Provenance(provider=adapter_id, outcome="success"),),
+        )
+
+
+@pytest.mark.asyncio
+async def test_module_keeps_order_and_marks_low_or_failed_items_partial() -> None:
+    context = RequestContext(request_id="fetch-module-v2")
+    batch = await FetchModuleService(_Manager()).fetch(
+        FetchRequest(
+            targets=(
+                "https://example.com/long",
+                "https://example.com/short",
+                "https://example.com/blocked",
+            )
+        ),
+        context,
+        ExecutionContext.with_timeout(5),
+    )
+
+    assert [item.status for item in batch.items] == ["success", "success", "blocked"]
+    assert batch.items[1].content_metadata.quality == "low"
+    assert batch.items[2].error.code == "policy_blocked"
+    assert batch.meta.partial is True
+    assert batch.context == context
+
+
+@pytest.mark.asyncio
+async def test_module_rejects_request_side_provider_or_fanout_override() -> None:
+    service = FetchModuleService(_Manager())
+    context = RequestContext(request_id="fetch-module-v2")
+    for request in (
+        FetchRequest(targets=("https://example.com",), strategy="fanout"),
+        FetchRequest(
+            targets=("https://example.com",),
+            providers=(ProviderRef(id="other", kind="fetch"),),
+        ),
+    ):
+        with pytest.raises(ProviderError) as caught:
+            await service.fetch(request, context, ExecutionContext.with_timeout(5))
+        assert caught.value.code is ProviderErrorCode.INVALID_REQUEST

--- a/tests/test_phase2_module_skeleton.py
+++ b/tests/test_phase2_module_skeleton.py
@@ -59,6 +59,7 @@ IMPLEMENTED_PACKAGES = frozenset(
         "souwen.modules.llm_search.api",
         "souwen.modules.llm_search.application",
         "souwen.modules.fetch.api",
+        "souwen.modules.fetch.application",
         "souwen.platform.provider_spi",
         "souwen.platform.manifest_registry",
         "souwen.platform.provider_manager",

--- a/tests/test_web/test_builtin.py
+++ b/tests/test_web/test_builtin.py
@@ -530,6 +530,66 @@ class TestMaxResponseSize:
         assert result.raw.get("oversized") is True
 
     @pytest.mark.asyncio
+    async def test_target_contract_rejects_unsupported_media_type(self):
+        mock_resp = MagicMock()
+        mock_resp.text = "%PDF fixture"
+        mock_resp.content = b"%PDF fixture"
+        mock_resp.status_code = 200
+        mock_resp.headers = {"content-type": "application/pdf"}
+
+        with patch.object(BuiltinFetcherClient, "_fetch", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = mock_resp
+            async with BuiltinFetcherClient() as client:
+                result = await client.fetch(
+                    "https://example.com/file.pdf",
+                    enforce_target_contract=True,
+                )
+
+        assert result.raw["target_error_code"] == "unsupported_media_type"
+
+    @pytest.mark.asyncio
+    async def test_target_contract_keeps_short_text_as_low_quality_candidate(self):
+        mock_resp = MagicMock()
+        mock_resp.text = "short"
+        mock_resp.content = b"short"
+        mock_resp.status_code = 200
+        mock_resp.headers = {"content-type": "text/plain; charset=utf-8"}
+
+        with patch.object(BuiltinFetcherClient, "_fetch", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = mock_resp
+            async with BuiltinFetcherClient() as client:
+                result = await client.fetch(
+                    "https://example.com/short",
+                    enforce_target_contract=True,
+                )
+
+        assert result.error is None
+        assert result.content == "short"
+        assert result.raw["media_type"] == "text/plain"
+        assert result.raw["charset"] == "utf-8"
+        assert result.raw["content_length_bytes"] == 5
+
+    @pytest.mark.asyncio
+    async def test_target_contract_caps_decompressed_response_bytes(self):
+        body = b"x" * (BuiltinFetcherClient.MAX_RESPONSE_SIZE + 1)
+        mock_resp = MagicMock()
+        mock_resp.text = "not-read-after-byte-cap"
+        mock_resp.content = body
+        mock_resp.status_code = 200
+        mock_resp.headers = {"content-type": "text/plain"}
+
+        with patch.object(BuiltinFetcherClient, "_fetch", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = mock_resp
+            async with BuiltinFetcherClient() as client:
+                result = await client.fetch(
+                    "https://example.com/large",
+                    enforce_target_contract=True,
+                )
+
+        assert result.raw["target_error_code"] == "response_too_large"
+        assert result.raw["content_length"] == BuiltinFetcherClient.MAX_RESPONSE_SIZE + 1
+
+    @pytest.mark.asyncio
     async def test_normal_size_ok(self):
         mock_resp = MagicMock()
         mock_resp.text = _ok_html()


### PR DESCRIPTION
## 目标

交付 P4-04 builtin Fetch target vertical：`FetchModuleService → ProviderManager → BuiltinFetchProvider → legacy SSRF-safe builtin client`。

## 实现

- 新增 builtin Provider v2 manifest、adapter 与 Module orchestration。
- canonical Fetch 支持 1–20 targets，保留输入顺序；low-quality 或单项失败时返回 partial。
- target 模式仅接受 `text/*`、JSON、XML、`+json`、`+xml`。
- target 模式执行 10 MiB 响应上限、空正文失败、1–63 字符 low-quality、默认 200,000 / 最大 1,000,000 Unicode code points。
- 复用现有 builtin SSRF/DNS binding/Host-SNI/逐跳 redirect 校验；target request 不存在 `skip_ssrf_check` 或等价字段。
- 新增稳定 `payload_too_large` (413) 与 `unsupported_media_type` (415) contract/error mapping。
- legacy 默认调用保持 `enforce_target_contract=False`，不改变原有返回 shape 或 rollout rollback 路径。

## 边界

- 未实现 P4-05 Browser Worker。
- 未执行真实网络、浏览器或 HFS promotion。
- 未修改 Delivery route、认证、Panel、SDK、workflow 或 release surface。

## 验证

- `pytest tests/ -v --tb=short`: 2561 passed, 3 skipped
- `pytest tests/test_import_surface.py -q`: 28 passed
- focused/web/architecture: 135 passed；489 passed, 2 skipped；71 passed
- `python3 scripts/ci/check_architecture_dependencies.py`: PASS
- `ruff check src tests scripts tools`: PASS
- `ruff format --check src tests scripts tools`: PASS
- `PYTHONPATH=src python3 tools/gen_docs.py --check`: PASS
- `git diff --check`: PASS
