### PR TITLE
feat(v2): 交付 target Delivery API 与认证边界

### DIFF
--- a/docs/internal/phase1/target-canonical-contract-fixtures.md
+++ b/docs/internal/phase1/target-canonical-contract-fixtures.md
@@ -1,6 +1,7 @@
 # Phase 1：Target Canonical Contract Fixtures
 
-**状态**：Accepted target baseline；不是 current runtime contract。
+**状态**：Accepted target baseline；API contract 已由 rollout-gated target runtime 实现，
+Provider manifest 仍是 Phase 5 待完成基线。
 
 ## 1. 载体与单一真源
 
@@ -8,7 +9,7 @@ Phase 1 以 language-neutral JSON 冻结已批准的 target contract：
 
 | Artifact | 目的 | 不是 |
 |---|---|---|
-| [`target_api_contract_v2.json`](../../../tests/contracts/fixtures/target_api_contract_v2.json) | approved decision、canonical operation、golden response and budget baseline | FastAPI runtime snapshot、生产 route implementation |
+| [`target_api_contract_v2.json`](../../../tests/contracts/fixtures/target_api_contract_v2.json) | approved decision、canonical operation、golden response and budget baseline | generated/release `openapi.json` |
 | [`target_openapi_skeleton_v2.json`](../../../tests/contracts/fixtures/target_openapi_skeleton_v2.json) | target OpenAPI semantic skeleton and target probe alias policy | generated/release `openapi.json` |
 | [`target_provider_manifest_v2.json`](../../../tests/contracts/fixtures/target_provider_manifest_v2.json) | v2 manifest/conformance minimum and safe negative cases | current plugin entry-point schema |
 | [`test_target_canonical_contract.py`](../../../tests/contracts/test_target_canonical_contract.py) | standard-library deterministic invariants | target route, SDK or provider integration test |
@@ -28,9 +29,12 @@ errors; and `/healthz`/`/readyz` canonical probes with 2.x aliases. The detailed
 [SPEC-05](../spec-05-provider-spi-manifest-conformance.md), and future artifact placement is governed by
 [SPEC-08](../spec-08-directory-dependency.md).
 
-`implemented_by_current_runtime: false` and `x-souwen-contract-stage: target_skeleton_not_runtime` are
-deliberate anti-confusion markers. They prevent a passing static fixture test from being misreported as proof that
-the current FastAPI application serves target `/api/v1` operations or canonical probes.
+P4-06 将 API fixture 更新为 `implemented_by_current_runtime: true`，并将 OpenAPI stage 更新为
+`target_runtime_rollout_gated`。该声明只在 `SOUWEN_V2_ROLLOUT=target` 时覆盖 target Data API；
+default `legacy` 仍保留 current route 作回滚路径。`target_provider_manifest_v2.json` 继续保持
+`implemented_by_current_runtime: false`，直到 Phase 5 完成全量 Provider 处置。Static fixture 仍不是
+runtime proof；runtime 语义由 `tests/test_delivery_api_v2.py` 对真实 `app.openapi()`、route、auth、
+headers 和 probes 进行 deterministic 对照。
 
 ## 3. Deterministic acceptance and next implementation gate
 
@@ -41,6 +45,6 @@ pytest tests/contracts/test_target_canonical_contract.py -v --tb=short
 ```
 
 This verifies fixture integrity, target/current separation, accepted decision values, OpenAPI skeleton parity,
-and manifest safety/conformance declarations. It does not validate production route behavior. A later target
-implementation must add route/schema tests for every golden, generate immutable OpenAPI and clients from one
-source, and prove the selected Provider packages through the SPEC-05 harness.
+and manifest safety/conformance declarations. P4-06 route/schema behavior is validated separately by
+`tests/test_delivery_api_v2.py`. Phase 6 must still generate an immutable OpenAPI artifact and clients from one
+source; Phase 5 must prove every selected Provider package through the SPEC-05 harness.

--- a/src/souwen/delivery/api/__init__.py
+++ b/src/souwen/delivery/api/__init__.py
@@ -1,3 +1,28 @@
-"""Delivery HTTP boundary. Owner: Delivery API. Allowed dependencies: ``souwen.modules.*.api``."""
+"""Target External Data API adapters. Owner: Delivery API."""
 
-__all__: list[str] = []
+from .app import create_target_delivery_app
+from .errors import TargetDeliveryError
+from .models import ProbeResponse, ProviderCatalog, ProviderCatalogItem
+from .rollout import RolloutMode, resolve_rollout_mode
+from .router import (
+    ReadinessSnapshot,
+    RuntimeMetadata,
+    TargetDeliveryServices,
+    create_probe_router,
+    create_target_api_router,
+)
+
+__all__ = [
+    "ProbeResponse",
+    "ProviderCatalog",
+    "ProviderCatalogItem",
+    "ReadinessSnapshot",
+    "RolloutMode",
+    "RuntimeMetadata",
+    "TargetDeliveryError",
+    "TargetDeliveryServices",
+    "create_probe_router",
+    "create_target_api_router",
+    "create_target_delivery_app",
+    "resolve_rollout_mode",
+]

--- a/src/souwen/delivery/api/app.py
+++ b/src/souwen/delivery/api/app.py
@@ -1,0 +1,99 @@
+"""Standalone target Delivery app factory for deterministic tests and split deployment."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from contextlib import asynccontextmanager
+import logging
+
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from starlette.exceptions import HTTPException as StarletteHTTPException
+from starlette.middleware.gzip import GZipMiddleware
+
+from souwen.common_runtime.observability import get_request_id
+
+from .errors import TargetDeliveryError, error_response, from_http_status
+from .middleware import TargetRequestContextMiddleware
+from .openapi import normalize_target_openapi
+from .router import (
+    Dependency,
+    RuntimeMetadata,
+    TargetDeliveryServices,
+    create_probe_router,
+    create_target_api_router,
+)
+
+
+logger = logging.getLogger("souwen.delivery.api")
+Closer = Callable[[], Awaitable[None]]
+
+
+def create_target_delivery_app(
+    services: TargetDeliveryServices,
+    metadata: RuntimeMetadata,
+    *,
+    require_user: Dependency,
+    rate_limit: Dependency,
+    closer: Closer | None = None,
+) -> FastAPI:
+    """Create the target-only app without concrete Provider or config imports."""
+
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI):
+        try:
+            yield
+        finally:
+            if closer is not None:
+                await closer()
+
+    app = FastAPI(
+        title="SouWen External Data API",
+        version=metadata.version,
+        description="Souwen v2 target External Data API",
+        lifespan=lifespan,
+    )
+    app.add_middleware(GZipMiddleware, minimum_size=1000)
+    app.add_middleware(TargetRequestContextMiddleware, mode=metadata.rollout_mode)
+    app.include_router(
+        create_target_api_router(
+            services,
+            require_user=require_user,
+            rate_limit=rate_limit,
+        ),
+        prefix="/api/v1",
+    )
+    app.include_router(create_probe_router(services.readiness, metadata))
+    default_openapi = app.openapi
+
+    def target_openapi():
+        return normalize_target_openapi(default_openapi(), metadata.rollout_mode)
+
+    app.openapi = target_openapi
+
+    @app.exception_handler(TargetDeliveryError)
+    async def target_error_handler(_request: Request, exc: TargetDeliveryError):
+        return error_response(exc, get_request_id())
+
+    @app.exception_handler(StarletteHTTPException)
+    async def http_error_handler(_request: Request, exc: StarletteHTTPException):
+        return error_response(
+            from_http_status(exc.status_code),
+            get_request_id(),
+            extra_headers=dict(exc.headers or {}),
+        )
+
+    @app.exception_handler(RequestValidationError)
+    async def validation_error_handler(_request: Request, _exc: RequestValidationError):
+        return error_response(TargetDeliveryError("invalid_request", 400), get_request_id())
+
+    @app.exception_handler(Exception)
+    async def unhandled_error_handler(_request: Request, _exc: Exception):
+        request_id = get_request_id()
+        logger.exception("unhandled target Delivery error [%s]", request_id)
+        return error_response(TargetDeliveryError("internal_error", 500), request_id)
+
+    return app
+
+
+__all__ = ["create_target_delivery_app"]

--- a/src/souwen/delivery/api/errors.py
+++ b/src/souwen/delivery/api/errors.py
@@ -1,0 +1,146 @@
+"""Canonical target error translation with no raw provider detail."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+import time
+
+from fastapi.responses import JSONResponse
+
+from souwen.platform.provider_spi import (
+    CanonicalErrorCode,
+    ErrorDetail,
+    ErrorResponse,
+    ProviderError,
+    ProviderErrorCode,
+    RequestContext,
+)
+
+
+_SAFE_MESSAGES: dict[CanonicalErrorCode, str] = {
+    "invalid_request": "Request is invalid",
+    "unauthenticated": "Authentication is required",
+    "forbidden": "Permission is denied",
+    "not_found": "Resource was not found",
+    "conflict": "Request conflicts with current state",
+    "api_major_mismatch": "Client API major does not match",
+    "rate_limited": "Request rate limit was reached",
+    "payload_too_large": "Response exceeded the size limit",
+    "unsupported_media_type": "Response media type is unsupported",
+    "worker_unavailable": "Browser Worker is unavailable",
+    "worker_not_ready": "Browser Worker is not ready",
+    "worker_overloaded": "Browser Worker is overloaded",
+    "worker_timeout": "Browser Worker timed out",
+    "worker_protocol_mismatch": "Browser Worker protocol does not match",
+    "provider_timeout": "Provider timed out",
+    "provider_unavailable": "Provider is unavailable",
+    "policy_blocked": "Operation was blocked by policy",
+    "internal_error": "Service encountered an internal error",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class TargetDeliveryError(Exception):
+    code: CanonicalErrorCode
+    status_code: int
+    retryable: bool = False
+    provider: str | None = None
+    retry_after_seconds: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.retry_after_seconds is not None and self.retry_after_seconds < 0:
+            raise ValueError("retry_after_seconds must be non-negative")
+        Exception.__init__(self, self.code)
+
+
+def from_provider_error(error: ProviderError) -> TargetDeliveryError:
+    mapping: dict[ProviderErrorCode, tuple[CanonicalErrorCode, int]] = {
+        ProviderErrorCode.INVALID_REQUEST: ("invalid_request", 400),
+        ProviderErrorCode.INVALID_CONFIG: ("provider_unavailable", 502),
+        ProviderErrorCode.CANCELLED: ("provider_timeout", 504),
+        ProviderErrorCode.DEADLINE_EXCEEDED: ("provider_timeout", 504),
+        ProviderErrorCode.RATE_LIMITED: ("rate_limited", 429),
+        ProviderErrorCode.PROVIDER_UNAVAILABLE: ("provider_unavailable", 502),
+        ProviderErrorCode.INVALID_UPSTREAM_RESPONSE: ("provider_unavailable", 502),
+        ProviderErrorCode.POLICY_BLOCKED: ("policy_blocked", 403),
+        ProviderErrorCode.PAYLOAD_TOO_LARGE: ("payload_too_large", 413),
+        ProviderErrorCode.UNSUPPORTED_MEDIA_TYPE: ("unsupported_media_type", 415),
+        ProviderErrorCode.WORKER_UNAVAILABLE: ("worker_unavailable", 502),
+        ProviderErrorCode.WORKER_NOT_READY: ("worker_not_ready", 503),
+        ProviderErrorCode.WORKER_OVERLOADED: ("worker_overloaded", 503),
+        ProviderErrorCode.WORKER_TIMEOUT: ("worker_timeout", 504),
+        ProviderErrorCode.WORKER_PROTOCOL_MISMATCH: ("worker_protocol_mismatch", 409),
+    }
+    code, status_code = mapping[error.code]
+    return TargetDeliveryError(
+        code,
+        status_code,
+        retryable=error.retryable,
+        provider=error.provider_id,
+        retry_after_seconds=error.retry_after_seconds,
+    )
+
+
+def error_response(
+    error: TargetDeliveryError,
+    request_id: str,
+    *,
+    extra_headers: dict[str, str] | None = None,
+) -> JSONResponse:
+    headers = dict(extra_headers or {})
+    if error.status_code == 429:
+        retry_after = max(1, math.ceil(error.retry_after_seconds or 1))
+        headers.setdefault("Retry-After", str(retry_after))
+        headers.setdefault("X-RateLimit-Limit", "unknown")
+        headers.setdefault("X-RateLimit-Remaining", "0")
+        headers.setdefault("X-RateLimit-Reset", str(math.ceil(time.time() + retry_after)))
+    elif error.retry_after_seconds is not None:
+        headers["Retry-After"] = str(max(1, math.ceil(error.retry_after_seconds)))
+    context = RequestContext(request_id=request_id)
+    payload = ErrorResponse(
+        error=ErrorDetail(
+            code=error.code,
+            message=_SAFE_MESSAGES[error.code],
+            retryable=error.retryable,
+            request_id=request_id,
+            provider=error.provider,
+        ),
+        context=context,
+    )
+    return JSONResponse(
+        status_code=error.status_code,
+        content=payload.model_dump(mode="json"),
+        headers=headers or None,
+    )
+
+
+def from_http_status(status_code: int) -> TargetDeliveryError:
+    mapping: dict[int, CanonicalErrorCode] = {
+        400: "invalid_request",
+        401: "unauthenticated",
+        403: "forbidden",
+        404: "not_found",
+        405: "invalid_request",
+        409: "conflict",
+        413: "payload_too_large",
+        415: "unsupported_media_type",
+        429: "rate_limited",
+        502: "provider_unavailable",
+        503: "provider_unavailable",
+        504: "provider_timeout",
+    }
+    code = mapping.get(status_code, "internal_error")
+    return TargetDeliveryError(
+        code,
+        400 if status_code == 405 else status_code if code != "internal_error" else 500,
+        retryable=status_code in {429, 502, 503, 504},
+    )
+
+
+__all__ = [
+    "TargetDeliveryError",
+    "error_response",
+    "from_http_status",
+    "from_provider_error",
+]

--- a/src/souwen/delivery/api/middleware.py
+++ b/src/souwen/delivery/api/middleware.py
@@ -1,0 +1,87 @@
+"""Target request correlation and API-major response headers."""
+
+from __future__ import annotations
+
+import re
+from uuid import uuid4
+
+from souwen.common_runtime.observability import get_request_id, request_id_var
+
+from .rollout import RolloutMode, is_target_contract_path
+
+
+_VALID_REQUEST_ID = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+
+def _request_id(scope: dict) -> str:
+    headers = dict(scope.get("headers", ()))
+    try:
+        raw = headers.get(b"x-request-id", b"").decode("ascii")
+    except UnicodeDecodeError:
+        raw = ""
+    return raw if _VALID_REQUEST_ID.fullmatch(raw) else uuid4().hex[:12]
+
+
+def _with_contract_headers(message: dict, request_id: str, mode: RolloutMode) -> dict:
+    existing = [
+        (name, value)
+        for name, value in message.get("headers", ())
+        if name.lower() not in {b"x-request-id", b"x-souwen-api-major", b"x-souwen-rollout-mode"}
+    ]
+    return {
+        **message,
+        "headers": [
+            *existing,
+            (b"x-request-id", request_id.encode("ascii")),
+            (b"x-souwen-api-major", b"2"),
+            (b"x-souwen-rollout-mode", mode.value.encode("ascii")),
+        ],
+    }
+
+
+class TargetRequestContextMiddleware:
+    """Full request context for a standalone target Delivery application."""
+
+    def __init__(self, app, *, mode: RolloutMode) -> None:
+        self.app = app
+        self.mode = mode
+
+    async def __call__(self, scope, receive, send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        request_id = _request_id(scope)
+        token = request_id_var.set(request_id)
+
+        async def send_wrapper(message):
+            if message["type"] == "http.response.start":
+                message = _with_contract_headers(message, request_id, self.mode)
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        finally:
+            request_id_var.reset(token)
+
+
+class TargetContractHeadersMiddleware:
+    """Add target headers when the legacy host app owns request correlation."""
+
+    def __init__(self, app, *, mode: RolloutMode) -> None:
+        self.app = app
+        self.mode = mode
+
+    async def __call__(self, scope, receive, send) -> None:
+        if scope["type"] != "http" or not is_target_contract_path(scope.get("path", ""), self.mode):
+            await self.app(scope, receive, send)
+            return
+
+        async def send_wrapper(message):
+            if message["type"] == "http.response.start":
+                message = _with_contract_headers(message, get_request_id(), self.mode)
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)
+
+
+__all__ = ["TargetContractHeadersMiddleware", "TargetRequestContextMiddleware"]

--- a/src/souwen/delivery/api/models.py
+++ b/src/souwen/delivery/api/models.py
@@ -1,0 +1,67 @@
+"""Delivery-owned response DTOs not represented by a business Module."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field, model_validator
+
+from souwen.platform.provider_spi import CanonicalModel, Capability, Provenance, RequestContext
+
+from .rollout import RolloutMode
+
+
+class ProviderCatalogItem(CanonicalModel):
+    """Safe Provider v2 availability without config or secret values."""
+
+    provider: str = Field(min_length=1, max_length=128)
+    capabilities: tuple[Capability, ...] = Field(min_length=1)
+    availability: Literal["available", "unavailable"]
+    provenance: tuple[Provenance, ...] = Field(min_length=1)
+    reason: Literal["available", "disabled", "missing_configuration", "not_eligible"]
+    missing_fields: tuple[str, ...] = ()
+
+    @model_validator(mode="after")
+    def _status_matches_reason(self) -> ProviderCatalogItem:
+        if (self.availability == "available") != (self.reason == "available"):
+            raise ValueError("provider catalog status and reason do not match")
+        if self.missing_fields and self.reason != "missing_configuration":
+            raise ValueError("missing fields require missing_configuration")
+        return self
+
+
+class ProviderCatalog(CanonicalModel):
+    """Migrated Provider v2 catalog without legacy source or config readback fields."""
+
+    items: tuple[ProviderCatalogItem, ...]
+    context: RequestContext
+
+
+class ProbeResponse(CanonicalModel):
+    """Superset payload shared by canonical probes and their 2.x aliases."""
+
+    status: Literal["ok", "ready", "not_ready"]
+    ready: bool
+    version: str = Field(min_length=1, max_length=64)
+    source_sha: str | None = Field(default=None, min_length=40, max_length=40)
+    rollout_mode: RolloutMode
+    config_revision: str | None = Field(default=None, min_length=1, max_length=128)
+    components: dict[
+        str,
+        Literal["ready", "not_ready", "optional_unavailable", "disabled"],
+    ] = Field(default_factory=dict)
+    error: str | None = Field(default=None, min_length=1, max_length=256)
+    context: RequestContext
+
+    @model_validator(mode="after")
+    def _status_matches_readiness(self) -> ProbeResponse:
+        if self.status == "not_ready" and self.ready:
+            raise ValueError("not_ready status cannot be ready")
+        if self.status in {"ok", "ready"} and not self.ready:
+            raise ValueError("successful probe status must be ready")
+        if self.ready and self.error is not None:
+            raise ValueError("ready probe cannot include an error")
+        return self
+
+
+__all__ = ["ProbeResponse", "ProviderCatalog", "ProviderCatalogItem"]

--- a/src/souwen/delivery/api/openapi.py
+++ b/src/souwen/delivery/api/openapi.py
@@ -1,0 +1,97 @@
+"""OpenAPI normalization for rollout-gated target operations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .rollout import RolloutMode
+
+
+_TARGET_METHODS = {
+    "/api/v1/search": "post",
+    "/api/v1/llm-search": "post",
+    "/api/v1/fetch": "post",
+    "/api/v1/providers": "get",
+}
+_PROBE_METHODS = {
+    "/health": "get",
+    "/healthz": "get",
+    "/readiness": "get",
+    "/readyz": "get",
+}
+_COMMON_RESPONSE_HEADERS = (
+    "X-SouWen-API-Major",
+    "X-Request-ID",
+    "X-SouWen-Rollout-Mode",
+)
+_RATE_LIMIT_HEADERS = (
+    "Retry-After",
+    "X-RateLimit-Limit",
+    "X-RateLimit-Remaining",
+    "X-RateLimit-Reset",
+)
+
+
+def _header_components() -> dict[str, dict[str, Any]]:
+    return {
+        "X-SouWen-API-Major": {"required": True, "schema": {"const": "2"}},
+        "X-Request-ID": {"required": True, "schema": {"type": "string"}},
+        "X-SouWen-Rollout-Mode": {
+            "required": True,
+            "schema": {"enum": ["legacy", "target"]},
+        },
+        "Retry-After": {"required": True, "schema": {"type": "string"}},
+        "X-RateLimit-Limit": {"required": True, "schema": {"type": "string"}},
+        "X-RateLimit-Remaining": {"required": True, "schema": {"type": "string"}},
+        "X-RateLimit-Reset": {"required": True, "schema": {"type": "string"}},
+    }
+
+
+def _add_response_headers(operation: dict[str, Any]) -> None:
+    responses = operation.setdefault("responses", {})
+    for status, response in responses.items():
+        if not isinstance(response, dict):
+            continue
+        headers = response.setdefault("headers", {})
+        for name in _COMMON_RESPONSE_HEADERS:
+            headers.setdefault(name, {"$ref": f"#/components/headers/{name}"})
+        if status == "429":
+            for name in _RATE_LIMIT_HEADERS:
+                headers.setdefault(name, {"$ref": f"#/components/headers/{name}"})
+
+
+def normalize_target_openapi(schema: dict[str, Any], mode: RolloutMode) -> dict[str, Any]:
+    schema["x-souwen-api-major"] = 2
+    schema["x-souwen-rollout-mode"] = mode.value
+    schema["x-souwen-contract-stage"] = "target_runtime_rollout_gated"
+    components = schema.setdefault("components", {})
+    components.setdefault("headers", {}).update(_header_components())
+    if mode is RolloutMode.TARGET:
+        components.setdefault("securitySchemes", {}).setdefault(
+            "UserToken",
+            {"type": "http", "scheme": "bearer"},
+        )
+    operations = dict(_PROBE_METHODS)
+    if mode is RolloutMode.TARGET:
+        operations.update(_TARGET_METHODS)
+    for path, method in operations.items():
+        operation = schema.get("paths", {}).get(path, {}).get(method)
+        if not isinstance(operation, dict):
+            continue
+        _add_response_headers(operation)
+        if path in _TARGET_METHODS:
+            operation["security"] = [{"UserToken": []}]
+        else:
+            operation["security"] = []
+        responses = operation.setdefault("responses", {})
+        if path in _TARGET_METHODS:
+            responses.pop("422", None)
+            responses.setdefault("400", {"description": "Invalid target request"})
+        if path == "/health":
+            operation["x-souwen-alias-of"] = "/healthz"
+        elif path == "/readiness":
+            operation["x-souwen-alias-of"] = "/readyz"
+    return schema
+
+
+__all__ = ["normalize_target_openapi"]

--- a/src/souwen/delivery/api/rollout.py
+++ b/src/souwen/delivery/api/rollout.py
@@ -1,0 +1,40 @@
+"""Deployment-scoped RC2 rollout mode and target route ownership."""
+
+from __future__ import annotations
+
+import os
+from enum import Enum
+
+
+class RolloutMode(str, Enum):
+    LEGACY = "legacy"
+    TARGET = "target"
+
+
+_TARGET_DATA_PATHS = frozenset(
+    {
+        "/api/v1/search",
+        "/api/v1/llm-search",
+        "/api/v1/fetch",
+        "/api/v1/providers",
+    }
+)
+_TARGET_PROBE_PATHS = frozenset({"/health", "/healthz", "/readiness", "/readyz"})
+
+
+def resolve_rollout_mode(value: str | None = None) -> RolloutMode:
+    raw = os.environ.get("SOUWEN_V2_ROLLOUT", "legacy") if value is None else value
+    normalized = raw.strip().lower()
+    try:
+        return RolloutMode(normalized)
+    except ValueError:
+        raise ValueError("SOUWEN_V2_ROLLOUT must be exactly 'legacy' or 'target'") from None
+
+
+def is_target_contract_path(path: str, mode: RolloutMode) -> bool:
+    return path in _TARGET_PROBE_PATHS or (
+        mode is RolloutMode.TARGET and path in _TARGET_DATA_PATHS
+    )
+
+
+__all__ = ["RolloutMode", "is_target_contract_path", "resolve_rollout_mode"]

--- a/src/souwen/delivery/api/router.py
+++ b/src/souwen/delivery/api/router.py
@@ -1,0 +1,219 @@
+"""Thin FastAPI adapters over injected Module public APIs."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Protocol
+
+from fastapi import APIRouter, Depends, Header
+from fastapi.responses import JSONResponse
+
+from souwen.common_runtime.observability import get_request_id, get_source_sha
+from souwen.modules.fetch.api import FetchBatch, FetchModule, FetchRequest
+from souwen.modules.llm_search.api import LLMSearchModule, LLMSearchRequest, LLMSearchResult
+from souwen.modules.search.api import SearchModule, SearchPage, SearchRequest
+from souwen.platform.provider_spi import (
+    ErrorResponse,
+    ExecutionContext,
+    ProviderError,
+    RequestContext,
+)
+
+from .errors import TargetDeliveryError, from_provider_error
+from .models import ProbeResponse, ProviderCatalog, ProviderCatalogItem
+from .rollout import RolloutMode
+
+
+Dependency = Callable[..., object]
+_ERROR = {"model": ErrorResponse, "description": "Canonical target error"}
+
+
+@dataclass(frozen=True, slots=True)
+class ReadinessSnapshot:
+    ready: bool
+    components: dict[str, str]
+    error: str | None = None
+
+
+class ReadinessCheck(Protocol):
+    def __call__(self) -> ReadinessSnapshot | Awaitable[ReadinessSnapshot]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeMetadata:
+    version: str
+    source_sha: str | None
+    rollout_mode: RolloutMode
+    config_revision: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class TargetDeliveryServices:
+    search: SearchModule
+    llm_search: LLMSearchModule
+    fetch: FetchModule
+    provider_items: tuple[ProviderCatalogItem, ...]
+    readiness: ReadinessCheck
+
+
+def _context() -> RequestContext:
+    return RequestContext(request_id=get_request_id())
+
+
+def _require_api_major(
+    api_major: str | None = Header(default=None, alias="X-SouWen-API-Major"),
+) -> None:
+    if api_major is not None and api_major.strip() != "2":
+        raise TargetDeliveryError("api_major_mismatch", 409)
+
+
+async def _readiness(check: ReadinessCheck) -> ReadinessSnapshot:
+    result = check()
+    if inspect.isawaitable(result):
+        result = await result
+    if not isinstance(result, ReadinessSnapshot):
+        raise RuntimeError("readiness check returned an invalid result")
+    return result
+
+
+def create_target_api_router(
+    services: TargetDeliveryServices,
+    *,
+    require_user: Dependency,
+    rate_limit: Dependency,
+) -> APIRouter:
+    router = APIRouter(
+        dependencies=[Depends(require_user), Depends(rate_limit), Depends(_require_api_major)]
+    )
+
+    @router.post(
+        "/search",
+        response_model=SearchPage,
+        operation_id="search",
+        responses={code: _ERROR for code in (400, 401, 409, 429, 502, 504)},
+    )
+    async def search(payload: SearchRequest) -> SearchPage:
+        context = _context()
+        try:
+            return await services.search.search(
+                payload,
+                context,
+                ExecutionContext.with_timeout(30),
+            )
+        except ProviderError as exc:
+            raise from_provider_error(exc) from None
+
+    @router.post(
+        "/llm-search",
+        response_model=LLMSearchResult,
+        operation_id="llmSearch",
+        responses={code: _ERROR for code in (400, 401, 409, 429, 502, 504)},
+    )
+    async def llm_search(payload: LLMSearchRequest) -> LLMSearchResult:
+        timeout = payload.budget.timeout_seconds if payload.budget else 90
+        context = _context()
+        try:
+            return await services.llm_search.search(
+                payload,
+                context,
+                ExecutionContext.with_timeout(timeout),
+            )
+        except ProviderError as exc:
+            raise from_provider_error(exc) from None
+
+    @router.post(
+        "/fetch",
+        response_model=FetchBatch,
+        operation_id="fetch",
+        responses={code: _ERROR for code in (400, 401, 403, 409, 413, 415, 429, 502, 503, 504)},
+    )
+    async def fetch(payload: FetchRequest) -> FetchBatch:
+        context = _context()
+        try:
+            return await services.fetch.fetch(
+                payload,
+                context,
+                ExecutionContext.with_timeout(30),
+            )
+        except ProviderError as exc:
+            raise from_provider_error(exc) from None
+
+    @router.get(
+        "/providers",
+        response_model=ProviderCatalog,
+        operation_id="listProviders",
+        responses={code: _ERROR for code in (400, 401, 409, 429)},
+    )
+    async def providers() -> ProviderCatalog:
+        return ProviderCatalog(items=services.provider_items, context=_context())
+
+    return router
+
+
+def create_probe_router(
+    readiness_check: ReadinessCheck,
+    metadata: RuntimeMetadata,
+) -> APIRouter:
+    router = APIRouter()
+
+    @router.get(
+        "/health",
+        response_model=ProbeResponse,
+        operation_id="healthLegacyAlias",
+        openapi_extra={"x-souwen-alias-of": "/healthz"},
+    )
+    @router.get("/healthz", response_model=ProbeResponse, operation_id="healthz")
+    async def health() -> ProbeResponse:
+        return ProbeResponse(
+            status="ok",
+            ready=True,
+            version=metadata.version,
+            source_sha=metadata.source_sha or get_source_sha(),
+            rollout_mode=metadata.rollout_mode,
+            config_revision=metadata.config_revision,
+            components={"api": "ready"},
+            context=_context(),
+        )
+
+    @router.get(
+        "/readiness",
+        response_model=ProbeResponse,
+        operation_id="readinessLegacyAlias",
+        responses={503: {"model": ProbeResponse, "description": "Runtime is not ready"}},
+        openapi_extra={"x-souwen-alias-of": "/readyz"},
+    )
+    @router.get(
+        "/readyz",
+        response_model=ProbeResponse,
+        operation_id="readyz",
+        responses={503: {"model": ProbeResponse, "description": "Runtime is not ready"}},
+    )
+    async def readiness():
+        snapshot = await _readiness(readiness_check)
+        response = ProbeResponse(
+            status="ready" if snapshot.ready else "not_ready",
+            ready=snapshot.ready,
+            version=metadata.version,
+            source_sha=metadata.source_sha or get_source_sha(),
+            rollout_mode=metadata.rollout_mode,
+            config_revision=metadata.config_revision,
+            components=snapshot.components,
+            error=snapshot.error,
+            context=_context(),
+        )
+        if snapshot.ready:
+            return response
+        return JSONResponse(status_code=503, content=response.model_dump(mode="json"))
+
+    return router
+
+
+__all__ = [
+    "ReadinessSnapshot",
+    "RuntimeMetadata",
+    "TargetDeliveryServices",
+    "create_probe_router",
+    "create_target_api_router",
+]

--- a/src/souwen/modules/fetch/application/orchestration.py
+++ b/src/souwen/modules/fetch/application/orchestration.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 from typing import Protocol
 
 from souwen.platform.provider_spi import (
@@ -21,6 +22,12 @@ from souwen.platform.provider_spi import (
 
 
 BUILTIN_FETCH_ADAPTER_ID = "builtin-fetch"
+
+
+@dataclass(frozen=True, slots=True)
+class _TargetOutcome:
+    result: FetchResult
+    error: ProviderError | None = None
 
 
 class FetchProviderManager(Protocol):
@@ -75,10 +82,13 @@ class FetchModuleService:
         ):
             raise ProviderError(ProviderErrorCode.INVALID_REQUEST)
 
-        items = await asyncio.gather(
+        outcomes = await asyncio.gather(
             *(self._fetch_target(target, request, context, execution) for target in request.targets)
         )
+        items = [outcome.result for outcome in outcomes]
         execution.raise_if_cancelled_or_expired()
+        if not any(item.status == "success" for item in items):
+            raise _all_failed_error(outcomes, self._adapter_id)
         partial = any(
             item.status != "success"
             or item.content_metadata is None
@@ -93,7 +103,7 @@ class FetchModuleService:
         request: FetchRequest,
         context: RequestContext,
         execution: ExecutionContext,
-    ) -> FetchResult:
+    ) -> _TargetOutcome:
         target_request = FetchTargetRequest(
             target=target,
             content=request.content,
@@ -106,49 +116,62 @@ class FetchModuleService:
                 context,
                 execution,
             )
+            builtin_error = None
         except ProviderError as exc:
+            builtin_error = exc
             builtin_result = _failed_result(target_request, context, self._adapter_id, exc)
         except Exception:
+            builtin_error = ProviderError(ProviderErrorCode.PROVIDER_UNAVAILABLE)
             builtin_result = _failed_result(
                 target_request,
                 context,
                 self._adapter_id,
-                ProviderError(ProviderErrorCode.PROVIDER_UNAVAILABLE),
+                builtin_error,
             )
 
         if not self._should_try_browser(target_request, builtin_result):
-            return builtin_result
+            return _TargetOutcome(builtin_result, builtin_error)
         try:
             browser_result = await self._browser_executor.fetch(
                 target_request,
                 context,
                 execution,
             )
+            browser_error = None
         except ProviderError as exc:
+            browser_error = exc
             browser_result = _failed_result(target_request, context, self._adapter_id, exc)
         except Exception:
+            browser_error = ProviderError(ProviderErrorCode.WORKER_UNAVAILABLE)
             browser_result = _failed_result(
                 target_request,
                 context,
                 self._adapter_id,
-                ProviderError(ProviderErrorCode.WORKER_UNAVAILABLE),
+                browser_error,
             )
         if builtin_result.status == "success":
             if browser_result.status == "success":
-                return browser_result.model_copy(
+                return _TargetOutcome(
+                    browser_result.model_copy(
+                        update={
+                            "provenance": builtin_result.provenance + browser_result.provenance,
+                        }
+                    )
+                )
+            return _TargetOutcome(
+                builtin_result.model_copy(
                     update={
                         "provenance": builtin_result.provenance + browser_result.provenance,
                     }
                 )
-            return builtin_result.model_copy(
+            )
+        return _TargetOutcome(
+            browser_result.model_copy(
                 update={
                     "provenance": builtin_result.provenance + browser_result.provenance,
                 }
-            )
-        return browser_result.model_copy(
-            update={
-                "provenance": builtin_result.provenance + browser_result.provenance,
-            }
+            ),
+            browser_error,
         )
 
     def _should_try_browser(
@@ -222,6 +245,23 @@ def _safe_error_message(code: str) -> str:
         "worker_protocol_mismatch": "Browser Worker protocol does not match",
         "provider_unavailable": "Fetch provider is unavailable",
     }[code]
+
+
+def _all_failed_error(outcomes: list[_TargetOutcome], adapter_id: str) -> ProviderError:
+    errors = [outcome.error for outcome in outcomes if outcome.error is not None]
+    codes = {error.code for error in errors}
+    provider_code = next(iter(codes)) if len(codes) == 1 else ProviderErrorCode.PROVIDER_UNAVAILABLE
+    retry_after = None
+    if provider_code is ProviderErrorCode.RATE_LIMITED:
+        retry_values = [
+            error.retry_after_seconds for error in errors if error.retry_after_seconds is not None
+        ]
+        retry_after = max(retry_values) if retry_values else None
+    return ProviderError(
+        provider_code,
+        provider_id=adapter_id,
+        retry_after_seconds=retry_after,
+    )
 
 
 __all__ = [

--- a/src/souwen/server/app.py
+++ b/src/souwen/server/app.py
@@ -83,13 +83,29 @@ from starlette.middleware.gzip import GZipMiddleware
 from souwen import __version__
 from souwen.config import ensure_config_file, get_config
 from souwen.core.redaction import redact_secret_text, redact_secret_value
+from souwen.delivery.api import (
+    ReadinessSnapshot,
+    RolloutMode,
+    RuntimeMetadata,
+    TargetDeliveryError,
+    create_probe_router,
+    create_target_api_router,
+    resolve_rollout_mode,
+)
+from souwen.delivery.api.errors import error_response as target_error_response
+from souwen.delivery.api.errors import from_http_status as target_error_from_http_status
+from souwen.delivery.api.middleware import TargetContractHeadersMiddleware
+from souwen.delivery.api.openapi import normalize_target_openapi
+from souwen.delivery.api.rollout import is_target_contract_path
 from souwen.logging_config import setup_logging
 from souwen.plugin import ensure_plugins_loaded, get_loaded_plugins
 from souwen.common_runtime.observability import get_request_id, get_source_sha
-from souwen.server.auth import is_admin_open_enabled
+from souwen.server.auth import check_target_user_auth, is_admin_open_enabled
+from souwen.server.limiter import rate_limit_target_data
 from souwen.server.middleware import RequestIDMiddleware
 from souwen.server.routes import router, admin_router
-from souwen.server.schemas import ErrorResponse, HealthResponse, ReadinessResponse
+from souwen.server.schemas import ErrorResponse
+from souwen.server.v2_runtime import TargetRuntime, build_target_runtime
 from souwen.web.fetch import _current_plugin_owner
 
 logger = logging.getLogger("souwen.server")
@@ -231,6 +247,12 @@ async def lifespan(app: FastAPI):
         except Exception:
             logger.warning("MCP HTTP lifespan 关闭失败", exc_info=True)
 
+    if _target_runtime is not None:
+        try:
+            await _target_runtime.close()
+        except Exception:
+            logger.warning("Target runtime 关闭失败", exc_info=True)
+
     # 关闭会话缓存的 aiosqlite 连接
     try:
         from souwen.core.session_cache import get_session_cache
@@ -248,6 +270,39 @@ async def lifespan(app: FastAPI):
 
 
 _cfg_at_boot = get_config()
+_rollout_mode = resolve_rollout_mode()
+_target_runtime: TargetRuntime | None = (
+    build_target_runtime(_cfg_at_boot) if _rollout_mode is RolloutMode.TARGET else None
+)
+
+
+def _legacy_readiness() -> ReadinessSnapshot:
+    try:
+        from souwen.registry.meta import get_all_sources
+
+        ready = bool(get_all_sources())
+    except Exception:
+        ready = False
+    return ReadinessSnapshot(
+        ready=ready,
+        components={"api": "ready", "legacy_registry": "ready" if ready else "not_ready"},
+        error=None if ready else "legacy source registry is unavailable",
+    )
+
+
+_runtime_metadata = (
+    _target_runtime.metadata
+    if _target_runtime is not None
+    else RuntimeMetadata(
+        version=__version__,
+        source_sha=get_source_sha(),
+        rollout_mode=RolloutMode.LEGACY,
+        config_revision=os.environ.get("SOUWEN_CONFIG_REVISION", "").strip() or None,
+    )
+)
+_readiness_check = (
+    _target_runtime.services.readiness if _target_runtime is not None else _legacy_readiness
+)
 _fastapi_kwargs: dict = {
     "title": "SouWen API",
     "description": "面向 AI Agent 的学术论文 + 专利 + 网页统一搜索 API",
@@ -275,11 +330,32 @@ if cfg.cors_origins:
         allow_headers=["*"],
     )
 
-# 3. Request ID + 访问日志（最外层 ASGI 中间件）
+# 3. Request ID + 访问日志
 app.add_middleware(RequestIDMiddleware)
 
+# 4. Target contract identity is outermost and replaces duplicate headers.
+app.add_middleware(TargetContractHeadersMiddleware, mode=_rollout_mode)
+
+if _target_runtime is not None:
+    app.include_router(
+        create_target_api_router(
+            _target_runtime.services,
+            require_user=check_target_user_auth,
+            rate_limit=rate_limit_target_data,
+        ),
+        prefix="/api/v1",
+    )
 app.include_router(router, prefix="/api/v1")
 app.include_router(admin_router, prefix="/api/v1/admin")
+app.include_router(create_probe_router(_readiness_check, _runtime_metadata))
+_default_openapi = app.openapi
+
+
+def _rollout_openapi():
+    return normalize_target_openapi(_default_openapi(), _rollout_mode)
+
+
+app.openapi = _rollout_openapi
 
 # --- MCP 网络端点挂载（可选） ---
 _mcp_cfg = get_config()
@@ -309,6 +385,15 @@ def _safe_error_detail(detail: object) -> str:
     return text or ""
 
 
+def _is_target_request(request: Request) -> bool:
+    return is_target_contract_path(request.url.path, _rollout_mode)
+
+
+@app.exception_handler(TargetDeliveryError)
+async def target_delivery_exception_handler(request: Request, exc: TargetDeliveryError):
+    return target_error_response(exc, get_request_id())
+
+
 @app.exception_handler(StarletteHTTPException)
 async def http_exception_handler(request: Request, exc: StarletteHTTPException):
     """HTTP 异常处理器 — 将 Starlette HTTPException 转换为统一的 ErrorResponse 格式
@@ -320,6 +405,12 @@ async def http_exception_handler(request: Request, exc: StarletteHTTPException):
     Returns:
         JSONResponse：包含 ErrorResponse 的 JSON 响应，保留原始状态码和响应头
     """
+    if _is_target_request(request):
+        return target_error_response(
+            target_error_from_http_status(exc.status_code),
+            get_request_id(),
+            extra_headers=dict(getattr(exc, "headers", None) or {}),
+        )
     return JSONResponse(
         status_code=exc.status_code,
         content=ErrorResponse(
@@ -344,6 +435,11 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
     Returns:
         JSONResponse：422 响应，包含详细的验证错误信息
     """
+    if _is_target_request(request):
+        return target_error_response(
+            TargetDeliveryError("invalid_request", 400),
+            get_request_id(),
+        )
     fields = []
     for err in exc.errors():
         loc = ".".join(str(part) for part in err.get("loc", []))
@@ -373,6 +469,8 @@ async def unhandled_exception_handler(request: Request, exc: Exception):
     """
     rid = get_request_id()
     logger.exception("未处理异常 [%s]", rid)
+    if _is_target_request(request):
+        return target_error_response(TargetDeliveryError("internal_error", 500), rid)
     return JSONResponse(
         status_code=500,
         content=ErrorResponse(
@@ -404,58 +502,6 @@ def _status_to_code(status_code: int) -> str:
         503: "service_unavailable",
         504: "gateway_timeout",
     }.get(status_code, "error")
-
-
-@app.get("/health", response_model=HealthResponse)
-async def health():
-    """健康检查端点 /health
-
-    用于容器编排系统（K8s）探针检查服务是否存活。返回当前应用版本。
-
-    Returns:
-        HealthResponse: {"status": "ok", "version": "<version>"}
-    """
-    return {"status": "ok", "version": __version__, "source_sha": get_source_sha()}
-
-
-@app.get("/readiness", response_model=ReadinessResponse)
-async def readiness():
-    """K8s readiness 探针：仅做本地检查（配置可加载 + 数据源注册表非空）。
-
-    不做任何网络调用，避免探针超时。
-    """
-    try:
-        source_sha = get_source_sha()
-        get_config()
-        from souwen.registry.meta import get_all_sources
-
-        sources = get_all_sources()
-        if not sources:
-            return JSONResponse(
-                status_code=503,
-                content=ReadinessResponse(
-                    ready=False,
-                    version=__version__,
-                    source_sha=source_sha,
-                    error="source registry is empty",
-                ).model_dump(),
-            )
-        return {
-            "ready": True,
-            "version": __version__,
-            "source_sha": source_sha,
-            "error": None,
-        }
-    except Exception as exc:  # pragma: no cover - 防御性
-        return JSONResponse(
-            status_code=503,
-            content=ReadinessResponse(
-                ready=False,
-                version=__version__,
-                source_sha=get_source_sha(),
-                error=_safe_error_detail(f"{type(exc).__name__}: {exc}"),
-            ).model_dump(),
-        )
 
 
 def _get_panel_payload() -> tuple[str, str] | None:

--- a/src/souwen/server/auth.py
+++ b/src/souwen/server/auth.py
@@ -38,7 +38,7 @@ import logging
 import os
 import secrets
 
-from fastapi import Depends, Header, HTTPException, status
+from fastapi import Depends, Header, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from souwen.config import get_config
@@ -272,3 +272,38 @@ def check_search_auth(
             detail="认证失败：需要有效的 Bearer Token",
             headers={"WWW-Authenticate": "Bearer"},
         )
+
+
+def check_target_user_auth(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
+    souwen_token: str | None = Header(default=None, alias="X-SouWen-Token"),
+) -> None:
+    """Fail closed for target Data APIs unless open/guest is explicit."""
+    cfg = get_config()
+    custom_header_present = souwen_token is not None
+    authorization_present = "authorization" in request.headers
+    token = (
+        (souwen_token or "").strip()
+        if custom_header_present
+        else (credentials.credentials if credentials else "")
+    )
+    admin_password = cfg.effective_admin_password or ""
+    user_password = cfg.effective_user_password or ""
+    is_admin = bool(admin_password) and secrets.compare_digest(token, admin_password)
+    is_user = bool(user_password) and secrets.compare_digest(token, user_password)
+    if is_admin or is_user:
+        return
+    if custom_header_present or authorization_present:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="target Data API credential is invalid",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    if cfg.guest_enabled or cfg.user_password == "":
+        return
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="target Data API requires an explicit user or admin credential",
+        headers={"WWW-Authenticate": "Bearer"},
+    )

--- a/src/souwen/server/limiter.py
+++ b/src/souwen/server/limiter.py
@@ -48,6 +48,7 @@
 from __future__ import annotations
 
 import ipaddress
+import hashlib
 import logging
 import time
 from collections import defaultdict, deque
@@ -242,6 +243,7 @@ def get_client_ip(request: Request) -> str:
 
 # 全局限流器实例
 _search_limiter = InMemoryRateLimiter(max_requests=60, window_seconds=60)
+_target_data_limiter = InMemoryRateLimiter(max_requests=60, window_seconds=60)
 
 
 def rate_limit_search(request: Request) -> None:
@@ -262,3 +264,19 @@ def rate_limit_search(request: Request) -> None:
             ...
     """
     _search_limiter.check(get_client_ip(request))
+
+
+def rate_limit_target_data(request: Request) -> None:
+    """Limit target Data API by application credential, falling back to client IP."""
+    custom_token = request.headers.get("x-souwen-token")
+    token = custom_token.strip() if custom_token is not None else ""
+    if custom_token is None:
+        scheme, separator, value = request.headers.get("authorization", "").partition(" ")
+        if separator and scheme.lower() == "bearer":
+            token = value.strip()
+    if token:
+        digest = hashlib.sha256(token.encode("utf-8")).hexdigest()
+        key = f"credential:{digest}"
+    else:
+        key = f"ip:{get_client_ip(request)}"
+    _target_data_limiter.check(key)

--- a/src/souwen/server/middleware.py
+++ b/src/souwen/server/middleware.py
@@ -17,7 +17,7 @@ r"""SouWen ASGI 中间件 — 请求 ID 注入 + 响应计时 + 访问日志
     RequestIDMiddleware(app)
         - 功能：Raw ASGI 中间件，处理 HTTP 请求和响应
         - 逻辑：
-            1. 提取或生成 request_id（验证格式 [\w\-]{1,64}）
+            1. 提取或生成 request_id（验证格式 [A-Za-z0-9_-]{1,64}）
             2. 通过 contextvars 传播 ID
             3. 记录响应状态码和耗时
             4. 添加 X-Request-ID 和 X-Response-Time 响应头
@@ -52,7 +52,7 @@ from souwen.common_runtime.observability import (
 
 logger = logging.getLogger("souwen.server")
 
-_VALID_REQUEST_ID = re.compile(r"^[\w\-]{1,64}$")
+_VALID_REQUEST_ID = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
 
 # 不记录访问日志的路径（健康检查 / 面板静态资源）
 _SKIP_LOG_PATHS = frozenset({"/health", "/panel"})
@@ -92,8 +92,11 @@ class RequestIDMiddleware:
 
         # --- 提取或生成 Request ID ---
         headers = dict(scope.get("headers", []))
-        raw_id = headers.get(b"x-request-id", b"").decode("ascii", errors="ignore")
-        if raw_id and _VALID_REQUEST_ID.match(raw_id):
+        try:
+            raw_id = headers.get(b"x-request-id", b"").decode("ascii")
+        except UnicodeDecodeError:
+            raw_id = ""
+        if _VALID_REQUEST_ID.fullmatch(raw_id):
             rid = raw_id
         else:
             rid = uuid4().hex[:12]

--- a/src/souwen/server/v2_runtime.py
+++ b/src/souwen/server/v2_runtime.py
@@ -1,0 +1,336 @@
+"""Composition root for the P4 target vertical slice."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+from souwen import __version__
+from souwen.common_runtime.observability import get_request_id, get_source_sha
+from souwen.config import SouWenConfig
+from souwen.delivery.api import (
+    ProviderCatalogItem,
+    ReadinessSnapshot,
+    RolloutMode,
+    RuntimeMetadata,
+    TargetDeliveryServices,
+)
+from souwen.delivery.browser_worker_client import BrowserWorkerClient
+from souwen.modules.fetch.api import FetchModuleService
+from souwen.modules.llm_search.api import LLMSearchModuleService
+from souwen.modules.search.api import SearchModuleService
+from souwen.modules.search.application import (
+    OrderedSearchProviderSelector,
+    SearchProviderSelection,
+)
+from souwen.paper.openalex import OpenAlexClient
+from souwen.platform.provider_manager import ProviderManager
+from souwen.platform.provider_spi import (
+    ExecutionContext,
+    ProviderError,
+    ProviderErrorCode,
+    ProviderRef,
+    Provenance,
+    RequestContext,
+)
+from souwen.providers.fetch_sources.builtin import BUILTIN_FETCH_MANIFEST, BuiltinFetchProvider
+from souwen.providers.information_sources.openalex import (
+    OPENALEX_PROVIDER_MANIFEST,
+    OpenAlexSearchProvider,
+)
+from souwen.providers.llm_sources.uniapi_ark_annotations import (
+    UNIAPI_ARK_MANIFESTS,
+    UniApiArkAnnotationsDeepSeekProvider,
+    UniApiArkAnnotationsDoubaoProvider,
+)
+from souwen.providers.llm_sources.uniapi_ark_annotations.manifest import (
+    DEEPSEEK_ADAPTER_ID,
+    DOUBAO_ADAPTER_ID,
+)
+from souwen.web.builtin import BuiltinFetcherClient
+from souwen.worker.browser_fetch.protocol import BROWSER_WORKER_PROVIDER_INVENTORY_DIGEST
+
+
+class _OpenAlexRuntimeClient:
+    """Expose the legacy client lifecycle through the injected adapter protocol."""
+
+    def __init__(self, client: OpenAlexClient) -> None:
+        self._client = client
+
+    async def search(self, *args, **kwargs):
+        return await self._client.search(*args, **kwargs)
+
+    async def close(self) -> None:
+        await self._client._client.close()
+
+
+class _UnavailableLLMSearchModule:
+    async def search(self, _request, _context, _execution):
+        raise ProviderError(ProviderErrorCode.PROVIDER_UNAVAILABLE)
+
+
+@dataclass(slots=True)
+class TargetRuntime:
+    services: TargetDeliveryServices
+    metadata: RuntimeMetadata
+    manager: ProviderManager
+    browser_client: BrowserWorkerClient | None
+
+    async def close(self) -> None:
+        failure: Exception | None = None
+        try:
+            await self.manager.close_all()
+        except Exception as exc:
+            failure = exc
+        try:
+            if self.browser_client is not None:
+                await self.browser_client.close()
+        except Exception as exc:
+            if failure is None:
+                failure = exc
+        if failure is not None:
+            raise failure
+
+
+def _configuration_resolver(config: SouWenConfig):
+    enabled_llm = set(config.enabled_uniapi_ark_source_ids())
+
+    def resolve(manifest):
+        if manifest.id == "openalex":
+            if not config.is_source_enabled("openalex", default=True):
+                raise ValueError("provider is disabled")
+            return {"enabled": True}
+        if manifest.id == "builtin-fetch":
+            if not config.is_source_enabled("builtin-fetch", default=True):
+                raise ValueError("provider is disabled")
+            return {"enabled": True}
+        if manifest.id in {DEEPSEEK_ADAPTER_ID, DOUBAO_ADAPTER_ID}:
+            if manifest.id not in enabled_llm:
+                raise ValueError("provider is disabled")
+            source = config.get_source_config(manifest.id)
+            return {
+                "enabled": True,
+                "max_keyword": source.params.get("max_keyword", 10),
+                "timeout_seconds": source.timeout or 45,
+            }
+        raise ValueError("unknown target provider")
+
+    return resolve
+
+
+def _secret_resolver(config: SouWenConfig):
+    def resolve(manifest, _references):
+        if manifest.id not in {DEEPSEEK_ADAPTER_ID, DOUBAO_ADAPTER_ID}:
+            return {}
+        gateway = config.get_llm_search_gateway("uniapi")
+        return {
+            "UNIAPI_API_KEY": gateway.api_key or "",
+            "UNIAPI_BASE_URL": gateway.base_url or "",
+        }
+
+    return resolve
+
+
+def _browser_client() -> BrowserWorkerClient | None:
+    token = os.environ.get("SOUWEN_BROWSER_WORKER_TOKEN")
+    if token is None:
+        return None
+    port = os.environ.get("SOUWEN_BROWSER_WORKER_PORT", "49266").strip()
+    config_revision = os.environ.get("SOUWEN_CONFIG_REVISION", "").strip() or None
+    return BrowserWorkerClient(
+        base_url=f"http://127.0.0.1:{port}",
+        token=token,
+        expected_source_sha=get_source_sha(),
+        expected_config_revision=config_revision,
+        expected_runtime_version=__version__,
+        expected_inventory_digest=BROWSER_WORKER_PROVIDER_INVENTORY_DIGEST,
+    )
+
+
+def _catalog_items(
+    config: SouWenConfig,
+    manager: ProviderManager,
+) -> tuple[ProviderCatalogItem, ...]:
+    eligible = set(manager.eligible_adapter_ids)
+    enabled_llm = set(config.enabled_uniapi_ark_source_ids())
+    missing_gateway = config.missing_uniapi_gateway_fields()
+    declarations = (
+        (
+            "openalex",
+            "openalex-search",
+            "search",
+            config.is_source_enabled("openalex", default=True),
+        ),
+        (
+            "builtin-fetch",
+            "builtin-fetch",
+            "fetch",
+            config.is_source_enabled("builtin-fetch", default=True),
+        ),
+        (
+            DEEPSEEK_ADAPTER_ID,
+            DEEPSEEK_ADAPTER_ID,
+            "llm_search",
+            DEEPSEEK_ADAPTER_ID in enabled_llm,
+        ),
+        (DOUBAO_ADAPTER_ID, DOUBAO_ADAPTER_ID, "llm_search", DOUBAO_ADAPTER_ID in enabled_llm),
+    )
+    items: list[ProviderCatalogItem] = []
+    for provider_id, adapter_id, capability, enabled in declarations:
+        missing_fields = (
+            missing_gateway if enabled and capability == "llm_search" and missing_gateway else ()
+        )
+        if adapter_id in eligible:
+            reason = "available"
+            status = "available"
+        elif not enabled:
+            reason = "disabled"
+            status = "unavailable"
+        elif missing_fields:
+            reason = "missing_configuration"
+            status = "unavailable"
+        else:
+            reason = "not_eligible"
+            status = "unavailable"
+        items.append(
+            ProviderCatalogItem(
+                provider=provider_id,
+                capabilities=(capability,),
+                availability=status,
+                provenance=(
+                    Provenance(
+                        provider=provider_id,
+                        outcome="success" if status == "available" else "failed",
+                    ),
+                ),
+                reason=reason,
+                missing_fields=missing_fields,
+            )
+        )
+    return tuple(items)
+
+
+def build_target_runtime(config: SouWenConfig) -> TargetRuntime:
+    manager = ProviderManager(
+        config_resolver=_configuration_resolver(config),
+        secret_resolver=_secret_resolver(config),
+    )
+    manager.register_factory(
+        package_id="openalex",
+        export="OpenAlexSearchProvider",
+        factory=lambda configuration, _secrets: OpenAlexSearchProvider(
+            _OpenAlexRuntimeClient(
+                OpenAlexClient(api_key=config.resolve_api_key("openalex", "openalex_api_key"))
+            ),
+            enabled=configuration["enabled"],
+        ),
+        provider_type=OpenAlexSearchProvider,
+    )
+    manager.register_factory(
+        package_id="builtin-fetch",
+        export="BuiltinFetchProvider",
+        factory=lambda configuration, _secrets: BuiltinFetchProvider(
+            BuiltinFetcherClient(respect_robots_txt=config.respect_robots_txt),
+            enabled=configuration["enabled"],
+        ),
+        provider_type=BuiltinFetchProvider,
+    )
+    manager.register_factory(
+        package_id=DEEPSEEK_ADAPTER_ID,
+        export="UniApiArkAnnotationsDeepSeekProvider",
+        factory=UniApiArkAnnotationsDeepSeekProvider,
+        provider_type=UniApiArkAnnotationsDeepSeekProvider,
+    )
+    manager.register_factory(
+        package_id=DOUBAO_ADAPTER_ID,
+        export="UniApiArkAnnotationsDoubaoProvider",
+        factory=UniApiArkAnnotationsDoubaoProvider,
+        provider_type=UniApiArkAnnotationsDoubaoProvider,
+    )
+    manager.discover(
+        (
+            OPENALEX_PROVIDER_MANIFEST,
+            BUILTIN_FETCH_MANIFEST,
+            *UNIAPI_ARK_MANIFESTS,
+        )
+    )
+
+    search = SearchModuleService(
+        manager,
+        OrderedSearchProviderSelector(
+            {
+                "paper": (
+                    SearchProviderSelection(
+                        provider=ProviderRef(id="openalex", kind="search"),
+                        adapter_id="openalex-search",
+                        yaml_priority=1,
+                    ),
+                )
+            }
+        ),
+    )
+    enabled_llm = config.enabled_uniapi_ark_source_ids()
+    llm_search: Any = (
+        LLMSearchModuleService(manager, enabled_llm[0])
+        if enabled_llm
+        else _UnavailableLLMSearchModule()
+    )
+    browser_client = _browser_client()
+    fetch = FetchModuleService(manager, browser_executor=browser_client)
+    required_adapters = {"openalex-search", "builtin-fetch"}
+
+    async def readiness() -> ReadinessSnapshot:
+        eligible = set(manager.eligible_adapter_ids)
+        providers_ready = required_adapters.issubset(eligible)
+        browser_ready = browser_client is None
+        browser_status = "disabled"
+        if browser_client is not None:
+            try:
+                await browser_client.readiness(
+                    RequestContext(request_id=get_request_id()),
+                    ExecutionContext.with_timeout(2),
+                )
+            except Exception:
+                browser_status = "not_ready"
+            else:
+                browser_ready = True
+                browser_status = "ready"
+        ready = providers_ready and browser_ready
+        components = {
+            "api": "ready",
+            "openalex": "ready" if "openalex-search" in eligible else "not_ready",
+            "builtin_fetch": "ready" if "builtin-fetch" in eligible else "not_ready",
+            "llm_search": (
+                "ready" if enabled_llm and enabled_llm[0] in eligible else "optional_unavailable"
+            ),
+            "browser_worker": browser_status,
+        }
+        return ReadinessSnapshot(
+            ready=ready,
+            components=components,
+            error=None if ready else "required target runtime component is not ready",
+        )
+
+    metadata = RuntimeMetadata(
+        version=__version__,
+        source_sha=get_source_sha(),
+        rollout_mode=RolloutMode.TARGET,
+        config_revision=os.environ.get("SOUWEN_CONFIG_REVISION", "").strip() or None,
+    )
+    services = TargetDeliveryServices(
+        search=search,
+        llm_search=llm_search,
+        fetch=fetch,
+        provider_items=_catalog_items(config, manager),
+        readiness=readiness,
+    )
+    return TargetRuntime(
+        services=services,
+        metadata=metadata,
+        manager=manager,
+        browser_client=browser_client,
+    )
+
+
+__all__ = ["TargetRuntime", "build_target_runtime"]

--- a/src/souwen/worker/browser_fetch/protocol.py
+++ b/src/souwen/worker/browser_fetch/protocol.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from datetime import datetime
+import hashlib
+import json
 from typing import Literal, TypeAlias
 
 from pydantic import AnyHttpUrl, BaseModel, ConfigDict, Field, model_validator
@@ -14,6 +16,10 @@ BROWSER_WORKER_MAX_DEADLINE_SECONDS = 120.0
 BROWSER_WORKER_MAX_CODE_POINTS = 1_000_000
 BROWSER_WORKER_DEFAULT_CODE_POINTS = 200_000
 BROWSER_WORKER_PAGE_SLOTS = 2
+BROWSER_WORKER_PROVIDER_INVENTORY = ("builtin-fetch:playwright",)
+BROWSER_WORKER_PROVIDER_INVENTORY_DIGEST = hashlib.sha256(
+    json.dumps(BROWSER_WORKER_PROVIDER_INVENTORY, separators=(",", ":")).encode("utf-8")
+).hexdigest()
 
 
 class WorkerModel(BaseModel):
@@ -129,6 +135,8 @@ __all__ = [
     "BROWSER_WORKER_MAX_CODE_POINTS",
     "BROWSER_WORKER_MAX_DEADLINE_SECONDS",
     "BROWSER_WORKER_PAGE_SLOTS",
+    "BROWSER_WORKER_PROVIDER_INVENTORY",
+    "BROWSER_WORKER_PROVIDER_INVENTORY_DIGEST",
     "WorkerErrorCode",
     "WorkerErrorDetail",
     "WorkerErrorResponse",

--- a/src/souwen/worker/browser_fetch/runtime.py
+++ b/src/souwen/worker/browser_fetch/runtime.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
-import json
 import os
 from dataclasses import dataclass
 
@@ -11,13 +9,11 @@ from souwen import __version__
 
 from .app import create_browser_worker_app
 from .executor import PlaywrightBrowserExecutor
-from .protocol import BROWSER_WORKER_DEFAULT_PORT, WorkerRuntimeEvidence
-
-
-_INVENTORY = ("builtin-fetch:playwright",)
-_INVENTORY_DIGEST = hashlib.sha256(
-    json.dumps(_INVENTORY, separators=(",", ":")).encode("utf-8")
-).hexdigest()
+from .protocol import (
+    BROWSER_WORKER_DEFAULT_PORT,
+    BROWSER_WORKER_PROVIDER_INVENTORY_DIGEST,
+    WorkerRuntimeEvidence,
+)
 
 
 @dataclass(frozen=True)
@@ -50,7 +46,7 @@ class BrowserWorkerSettings:
             source_sha=source_sha,
             runtime_version=__version__,
             config_revision=config_revision,
-            provider_inventory_digest=_INVENTORY_DIGEST,
+            provider_inventory_digest=BROWSER_WORKER_PROVIDER_INVENTORY_DIGEST,
         )
         return cls(host=host, port=port, token=token, evidence=evidence)
 

--- a/tests/contracts/fixtures/current_api_golden.json
+++ b/tests/contracts/fixtures/current_api_golden.json
@@ -10,12 +10,18 @@
       },
       "openapi": {
         "method": "get",
-        "response_schema": "HealthResponse"
+        "response_schema": "ProbeResponse"
       },
       "response": {
         "status": "ok",
+        "ready": true,
         "version": "2.0.0rc1",
-        "source_sha": "0000000000000000000000000000000000000000"
+        "source_sha": "0000000000000000000000000000000000000000",
+        "rollout_mode": "legacy",
+        "config_revision": null,
+        "components": {"api": "ready"},
+        "error": null,
+        "context": {"request_id": "fixture-health", "api_major": 2, "trace_id": null}
       }
     },
     "readiness": {
@@ -25,13 +31,18 @@
       },
       "openapi": {
         "method": "get",
-        "response_schema": "ReadinessResponse"
+        "response_schema": "ProbeResponse"
       },
       "response": {
+        "status": "ready",
         "ready": true,
         "version": "2.0.0rc1",
         "source_sha": "0000000000000000000000000000000000000000",
-        "error": null
+        "rollout_mode": "legacy",
+        "config_revision": null,
+        "components": {"api": "ready", "legacy_registry": "ready"},
+        "error": null,
+        "context": {"request_id": "fixture-readiness", "api_major": 2, "trace_id": null}
       }
     },
     "search_paper": {

--- a/tests/contracts/fixtures/target_api_contract_v2.json
+++ b/tests/contracts/fixtures/target_api_contract_v2.json
@@ -2,8 +2,16 @@
   "fixture_version": 1,
   "scope": "target_canonical_contract_v2",
   "target_only": true,
-  "implemented_by_current_runtime": false,
+  "implemented_by_current_runtime": true,
   "api_major": 2,
+  "runtime_activation": {
+    "switch": "SOUWEN_V2_ROLLOUT",
+    "allowed_values": ["legacy", "target"],
+    "default": "legacy",
+    "request_override": false,
+    "observable_header": "X-SouWen-Rollout-Mode",
+    "removal_phase": 8
+  },
   "approved_decisions": [
     "Q-004",
     "Q-005",

--- a/tests/contracts/fixtures/target_openapi_skeleton_v2.json
+++ b/tests/contracts/fixtures/target_openapi_skeleton_v2.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {"title": "SouWen External Data API", "version": "2.0.0-target"},
   "x-souwen-api-major": 2,
-  "x-souwen-contract-stage": "target_skeleton_not_runtime",
+  "x-souwen-contract-stage": "target_runtime_rollout_gated",
   "paths": {
     "/api/v1/search": {"post": {"operationId": "search", "security": [{"UserToken": []}], "responses": {"200": {"$ref": "#/components/responses/SearchPage"}, "400": {"$ref": "#/components/responses/ErrorResponse"}, "401": {"$ref": "#/components/responses/ErrorResponse"}, "429": {"$ref": "#/components/responses/ErrorResponse"}, "502": {"$ref": "#/components/responses/ErrorResponse"}, "504": {"$ref": "#/components/responses/ErrorResponse"}}}},
     "/api/v1/llm-search": {"post": {"operationId": "llmSearch", "security": [{"UserToken": []}], "responses": {"200": {"$ref": "#/components/responses/LLMSearchResult"}, "400": {"$ref": "#/components/responses/ErrorResponse"}, "401": {"$ref": "#/components/responses/ErrorResponse"}, "429": {"$ref": "#/components/responses/ErrorResponse"}, "502": {"$ref": "#/components/responses/ErrorResponse"}, "504": {"$ref": "#/components/responses/ErrorResponse"}}}},
@@ -30,6 +30,7 @@
     "headers": {
       "X-SouWen-API-Major": {"required": true, "schema": {"const": "2"}},
       "X-Request-ID": {"required": true, "schema": {"type": "string"}},
+      "X-SouWen-Rollout-Mode": {"required": true, "schema": {"enum": ["legacy", "target"]}},
       "Retry-After": {"required": true, "schema": {"type": "string"}},
       "X-RateLimit-Limit": {"required": true, "schema": {"type": "string"}},
       "X-RateLimit-Remaining": {"required": true, "schema": {"type": "string"}},

--- a/tests/contracts/test_current_python_dependency_graph_contract.py
+++ b/tests/contracts/test_current_python_dependency_graph_contract.py
@@ -13,6 +13,7 @@ FIXTURE_PATH = REPO_ROOT / "tests/contracts/fixtures/current_python_dependency_g
 TARGET_BOUNDARY_UNITS = frozenset(
     {"common_runtime", "delivery", "modules", "platform", "providers", "worker"}
 )
+TARGET_BOUNDARY_PATHS = frozenset({Path("server/v2_runtime.py")})
 
 
 def _is_type_checking_guard(test: ast.expr) -> bool:
@@ -77,6 +78,7 @@ def _current_graph(source_root: Path) -> tuple[list[Path], set[str], set[tuple[s
         path
         for path in source_root.rglob("*.py")
         if path.relative_to(source_root).parts[0] not in TARGET_BOUNDARY_UNITS
+        and path.relative_to(source_root) not in TARGET_BOUNDARY_PATHS
     )
     units: set[str] = set()
     edges: set[tuple[str, str]] = set()

--- a/tests/contracts/test_target_canonical_contract.py
+++ b/tests/contracts/test_target_canonical_contract.py
@@ -13,21 +13,28 @@ def _read(name: str) -> dict[str, object]:
     return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
 
 
-def test_target_fixtures_are_explicitly_non_runtime_and_deterministic() -> None:
-    for name in (
-        "target_api_contract_v2.json",
-        "target_provider_manifest_v2.json",
-    ):
-        fixture = _read(name)
+def test_target_fixtures_record_runtime_state_and_remain_deterministic() -> None:
+    api = _read("target_api_contract_v2.json")
+    provider = _read("target_provider_manifest_v2.json")
+    for fixture in (api, provider):
         assert fixture["fixture_version"] == 1
         assert fixture["target_only"] is True
-        assert fixture["implemented_by_current_runtime"] is False
         assert json.loads(json.dumps(fixture, sort_keys=True)) == fixture
+    assert api["implemented_by_current_runtime"] is True
+    assert provider["implemented_by_current_runtime"] is False
 
 
 def test_target_api_closes_approved_decisions_without_claiming_current_routes() -> None:
     contract = _read("target_api_contract_v2.json")
     assert contract["api_major"] == 2
+    assert contract["runtime_activation"] == {
+        "switch": "SOUWEN_V2_ROLLOUT",
+        "allowed_values": ["legacy", "target"],
+        "default": "legacy",
+        "request_override": False,
+        "observable_header": "X-SouWen-Rollout-Mode",
+        "removal_phase": 8,
+    }
     assert contract["approved_decisions"] == [
         "Q-004",
         "Q-005",
@@ -102,7 +109,7 @@ def test_target_openapi_skeleton_matches_the_target_fixture() -> None:
     skeleton = _read("target_openapi_skeleton_v2.json")
     assert skeleton["openapi"] == "3.1.0"
     assert skeleton["x-souwen-api-major"] == contract["api_major"]
-    assert skeleton["x-souwen-contract-stage"] == "target_skeleton_not_runtime"
+    assert skeleton["x-souwen-contract-stage"] == "target_runtime_rollout_gated"
 
     paths = skeleton["paths"]
     assert isinstance(paths, dict)
@@ -118,6 +125,7 @@ def test_target_openapi_skeleton_matches_the_target_fixture() -> None:
     schemas = skeleton["components"]["schemas"]
     headers = skeleton["components"]["headers"]
     assert headers["X-SouWen-API-Major"]["schema"] == {"const": "2"}
+    assert headers["X-SouWen-Rollout-Mode"]["schema"] == {"enum": ["legacy", "target"]}
     assert {
         "Retry-After",
         "X-RateLimit-Limit",

--- a/tests/test_browser_worker_client.py
+++ b/tests/test_browser_worker_client.py
@@ -168,6 +168,31 @@ async def test_client_fails_closed_on_worker_source_mismatch() -> None:
     assert caught.value.code is ProviderErrorCode.WORKER_PROTOCOL_MISMATCH
 
 
+@pytest.mark.asyncio
+async def test_client_readiness_fails_closed_on_worker_inventory_mismatch() -> None:
+    app = create_browser_worker_app(
+        token=TOKEN,
+        evidence=_evidence(),
+        executor=_Executor(),
+        initialize_executor=False,
+    )
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://127.0.0.1:49266") as http:
+        client = BrowserWorkerClient(
+            base_url="http://127.0.0.1:49266",
+            token=TOKEN,
+            client=http,
+            expected_inventory_digest="c" * 64,
+        )
+        with pytest.raises(ProviderError) as caught:
+            await client.readiness(
+                RequestContext(request_id="browser-readiness"),
+                ExecutionContext.with_timeout(5),
+            )
+
+    assert caught.value.code is ProviderErrorCode.WORKER_PROTOCOL_MISMATCH
+
+
 @pytest.mark.parametrize(
     "base_url",
     [

--- a/tests/test_browser_worker_runtime.py
+++ b/tests/test_browser_worker_runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from souwen.worker.browser_fetch.runtime import BrowserWorkerSettings
+from souwen.worker.browser_fetch.protocol import BROWSER_WORKER_PROVIDER_INVENTORY_DIGEST
 
 
 def _valid_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -21,7 +22,7 @@ def test_runtime_defaults_to_exact_loopback_and_fixed_port(monkeypatch) -> None:
     assert settings.host == "127.0.0.1"
     assert settings.port == 49266
     assert settings.evidence.source_sha == "a" * 40
-    assert len(settings.evidence.provider_inventory_digest) == 64
+    assert settings.evidence.provider_inventory_digest == BROWSER_WORKER_PROVIDER_INVENTORY_DIGEST
 
 
 @pytest.mark.parametrize("host", ["0.0.0.0", "::1", "localhost", "127.0.0.2"])

--- a/tests/test_delivery_api_v2.py
+++ b/tests/test_delivery_api_v2.py
@@ -593,16 +593,28 @@ def test_rollout_mode_is_strict_and_target_router_precedes_legacy_fetch(tmp_path
 
     repo_src = str(Path(__file__).resolve().parents[1] / "src")
     script = """
+import importlib
+import json
+import os
 import sys
 
 sys.path.insert(0, sys.argv[1])
 
-from souwen.server.app import app
+server_app = importlib.import_module('souwen.server.app')
+app = server_app.app
 matches = [
     route for route in app.routes
     if getattr(route, 'path', None) == '/api/v1/fetch'
     and 'POST' in getattr(route, 'methods', set())
 ]
+if not matches:
+    raise RuntimeError(json.dumps({
+        'rollout_env': os.environ.get('SOUWEN_V2_ROLLOUT'),
+        'rollout_mode': server_app._rollout_mode.value,
+        'target_runtime': server_app._target_runtime is not None,
+        'server_app_file': server_app.__file__,
+        'route_paths': [getattr(route, 'path', None) for route in app.routes],
+    }, sort_keys=True))
 print(matches[0].response_model.__name__)
 """
     env = {

--- a/tests/test_delivery_api_v2.py
+++ b/tests/test_delivery_api_v2.py
@@ -605,15 +605,17 @@ print(matches[0].response_model.__name__)
         "HOME": str(tmp_path),
         "USERPROFILE": str(tmp_path),
         "SOUWEN_PLUGIN_AUTOLOAD": "0",
+        "SOUWEN_SOURCE_SHA": "a" * 40,
         "SOUWEN_V2_ROLLOUT": "target",
     }
+    env.pop("SOUWEN_BROWSER_WORKER_TOKEN", None)
     completed = subprocess.run(
         [sys.executable, "-c", script],
-        check=True,
         capture_output=True,
         text=True,
         env=env,
     )
+    assert completed.returncode == 0, completed.stderr
     assert completed.stdout.strip() == "FetchBatch"
 
 

--- a/tests/test_delivery_api_v2.py
+++ b/tests/test_delivery_api_v2.py
@@ -1,0 +1,683 @@
+"""Deterministic target Delivery API, auth, rollout, and composition tests."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from dataclasses import dataclass
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from souwen.config import SouWenConfig
+from souwen.delivery.api import (
+    ProviderCatalogItem,
+    ReadinessSnapshot,
+    RolloutMode,
+    RuntimeMetadata,
+    TargetDeliveryServices,
+    create_target_delivery_app,
+    resolve_rollout_mode,
+)
+from souwen.modules.fetch.api import FetchBatch, FetchModuleService
+from souwen.modules.llm_search.api import LLMSearchResult
+from souwen.modules.search.api import SearchPage
+from souwen.platform.provider_spi import (
+    FetchMeta,
+    PageInfo,
+    ProviderError,
+    ProviderErrorCode,
+    Provenance,
+    SearchMeta,
+    Usage,
+)
+from souwen.providers.llm_sources.uniapi_ark_annotations.manifest import DEEPSEEK_ADAPTER_ID
+from souwen.server.auth import check_target_user_auth
+from souwen.server.limiter import rate_limit_target_data
+from souwen.server.v2_runtime import TargetRuntime, build_target_runtime
+from souwen.worker.browser_fetch.protocol import BROWSER_WORKER_PROVIDER_INVENTORY_DIGEST
+
+
+class _Search:
+    def __init__(self, error: Exception | None = None) -> None:
+        self.error = error
+        self.calls = 0
+
+    async def search(self, _request, context, _execution):
+        self.calls += 1
+        if self.error is not None:
+            raise self.error
+        return SearchPage(
+            items=(),
+            page=PageInfo(limit=10),
+            meta=SearchMeta(),
+            context=context,
+        )
+
+
+class _LLMSearch:
+    async def search(self, request, context, _execution):
+        return LLMSearchResult(
+            query=request.query,
+            items=(),
+            evidence=(),
+            meta=SearchMeta(),
+            usage=Usage(),
+            context=context,
+        )
+
+
+class _Fetch:
+    async def fetch(self, _request, context, _execution):
+        return FetchBatch(items=(), meta=FetchMeta(), context=context)
+
+
+@dataclass
+class _AppFixture:
+    client: TestClient
+    search: _Search
+
+
+def _services(
+    search: _Search | None = None,
+    fetch=None,
+    readiness=None,
+) -> TargetDeliveryServices:
+    return TargetDeliveryServices(
+        search=search or _Search(),
+        llm_search=_LLMSearch(),
+        fetch=fetch or _Fetch(),
+        provider_items=(
+            ProviderCatalogItem(
+                provider="openalex",
+                capabilities=("search",),
+                availability="available",
+                provenance=(Provenance(provider="openalex", outcome="success"),),
+                reason="available",
+            ),
+        ),
+        readiness=readiness
+        or (
+            lambda: ReadinessSnapshot(
+                ready=True,
+                components={"api": "ready", "openalex": "ready"},
+            )
+        ),
+    )
+
+
+def _app(
+    *,
+    search: _Search | None = None,
+    fetch=None,
+    require_user=lambda: None,
+    rate_limit=lambda: None,
+) -> _AppFixture:
+    search = search or _Search()
+    app = create_target_delivery_app(
+        _services(search, fetch),
+        RuntimeMetadata(
+            version="2.0.0rc2",
+            source_sha="a" * 40,
+            rollout_mode=RolloutMode.TARGET,
+            config_revision="config-r1",
+        ),
+        require_user=require_user,
+        rate_limit=rate_limit,
+    )
+    return _AppFixture(TestClient(app, raise_server_exceptions=False), search)
+
+
+def test_target_routes_emit_canonical_context_headers_and_catalog() -> None:
+    fixture = _app()
+    headers = {"X-Request-ID": "delivery-v2", "X-SouWen-API-Major": "2"}
+
+    search = fixture.client.post(
+        "/api/v1/search",
+        headers=headers,
+        json={"query": "fixture", "domains": ["paper"]},
+    )
+    llm = fixture.client.post(
+        "/api/v1/llm-search",
+        headers=headers,
+        json={
+            "query": "fixture",
+            "providers": [{"id": DEEPSEEK_ADAPTER_ID, "kind": "llm_search"}],
+            "strategy": "single",
+        },
+    )
+    fetch = fixture.client.post(
+        "/api/v1/fetch",
+        headers=headers,
+        json={"targets": ["https://example.com/page"]},
+    )
+    providers = fixture.client.get("/api/v1/providers", headers=headers)
+
+    for response in (search, llm, fetch, providers):
+        assert response.status_code == 200
+        assert response.headers["x-request-id"] == "delivery-v2"
+        assert response.headers["x-souwen-api-major"] == "2"
+        assert response.headers["x-souwen-rollout-mode"] == "target"
+        assert response.json()["context"] == {
+            "request_id": "delivery-v2",
+            "api_major": 2,
+            "trace_id": None,
+        }
+    assert set(providers.json()) == {"items", "context"}
+    assert providers.json()["items"][0]["provider"] == "openalex"
+    assert fixture.search.calls == 1
+    schema = fixture.client.app.openapi()
+    assert schema["x-souwen-api-major"] == 2
+    assert schema["x-souwen-rollout-mode"] == "target"
+    for path, method in {
+        "/api/v1/search": "post",
+        "/api/v1/llm-search": "post",
+        "/api/v1/fetch": "post",
+        "/api/v1/providers": "get",
+    }.items():
+        responses = schema["paths"][path][method]["responses"]
+        assert "400" in responses
+        assert "422" not in responses
+        assert responses["400"]["content"]["application/json"]["schema"] == {
+            "$ref": "#/components/schemas/ErrorResponse"
+        }
+        for response in responses.values():
+            assert {
+                "X-SouWen-API-Major",
+                "X-Request-ID",
+                "X-SouWen-Rollout-Mode",
+            } <= set(response["headers"])
+    assert schema["components"]["securitySchemes"]["UserToken"] == {
+        "type": "http",
+        "scheme": "bearer",
+    }
+    assert schema["paths"]["/health"]["get"]["x-souwen-alias-of"] == "/healthz"
+    assert schema["paths"]["/readiness"]["get"]["x-souwen-alias-of"] == "/readyz"
+    assert "503" in schema["paths"]["/readyz"]["get"]["responses"]
+    assert {
+        "Retry-After",
+        "X-RateLimit-Limit",
+        "X-RateLimit-Remaining",
+        "X-RateLimit-Reset",
+    } <= set(schema["paths"]["/api/v1/search"]["post"]["responses"]["429"]["headers"])
+
+
+def test_standalone_target_app_uses_canonical_404_and_excludes_admin() -> None:
+    fixture = _app()
+
+    unknown = fixture.client.get("/does-not-exist", headers={"X-Request-ID": "missing-route"})
+    admin = fixture.client.get("/api/v1/admin/config")
+
+    assert unknown.status_code == 404
+    assert unknown.json()["error"]["code"] == "not_found"
+    assert unknown.json()["context"]["request_id"] == "missing-route"
+    assert unknown.headers["x-souwen-api-major"] == "2"
+    assert admin.status_code == 404
+    assert admin.json()["error"]["code"] == "not_found"
+
+
+def test_runtime_openapi_satisfies_the_frozen_target_skeleton() -> None:
+    runtime = _app().client.app.openapi()
+    skeleton = json.loads(
+        (
+            Path(__file__).parent / "contracts" / "fixtures" / "target_openapi_skeleton_v2.json"
+        ).read_text(encoding="utf-8")
+    )
+
+    assert runtime["x-souwen-api-major"] == skeleton["x-souwen-api-major"]
+    assert runtime["x-souwen-contract-stage"] == skeleton["x-souwen-contract-stage"]
+    assert (
+        runtime["components"]["securitySchemes"]["UserToken"]
+        == skeleton["components"]["securitySchemes"]["UserToken"]
+    )
+    assert set(skeleton["components"]["headers"]) <= set(runtime["components"]["headers"])
+    assert set(skeleton["components"]["schemas"]) <= set(runtime["components"]["schemas"])
+    for path, skeleton_path in skeleton["paths"].items():
+        for method, skeleton_operation in skeleton_path.items():
+            operation = runtime["paths"][path][method]
+            assert operation["operationId"] == skeleton_operation["operationId"]
+            assert set(skeleton_operation["responses"]) <= set(operation["responses"])
+            if "security" in skeleton_operation:
+                assert operation["security"] == skeleton_operation["security"]
+            if "x-souwen-alias-of" in skeleton_operation:
+                assert operation["x-souwen-alias-of"] == skeleton_operation["x-souwen-alias-of"]
+
+
+@pytest.mark.parametrize(
+    ("error", "status_code", "code"),
+    [
+        (ProviderError(ProviderErrorCode.INVALID_REQUEST), 400, "invalid_request"),
+        (ProviderError(ProviderErrorCode.PAYLOAD_TOO_LARGE), 413, "payload_too_large"),
+        (ProviderError(ProviderErrorCode.UNSUPPORTED_MEDIA_TYPE), 415, "unsupported_media_type"),
+        (
+            ProviderError(ProviderErrorCode.WORKER_PROTOCOL_MISMATCH),
+            409,
+            "worker_protocol_mismatch",
+        ),
+        (ProviderError(ProviderErrorCode.DEADLINE_EXCEEDED), 504, "provider_timeout"),
+    ],
+)
+def test_target_provider_failures_keep_specialist_statuses(error, status_code, code) -> None:
+    fixture = _app(search=_Search(error))
+    response = fixture.client.post(
+        "/api/v1/search",
+        json={"query": "fixture", "domains": ["paper"]},
+    )
+
+    assert response.status_code == status_code
+    assert response.json()["error"]["code"] == code
+    assert response.json()["error"]["request_id"] == response.json()["context"]["request_id"]
+
+
+def test_target_validation_is_400_and_api_major_mismatch_is_409() -> None:
+    fixture = _app()
+    invalid = fixture.client.post(
+        "/api/v1/search",
+        json={"query": "fixture", "domains": ["paper"], "unknown": "secret-value"},
+    )
+    mismatch = fixture.client.post(
+        "/api/v1/search",
+        headers={"X-SouWen-API-Major": "1"},
+        json={"query": "fixture", "domains": ["paper"]},
+    )
+
+    assert invalid.status_code == 400
+    assert invalid.json()["error"]["code"] == "invalid_request"
+    assert "secret-value" not in invalid.text
+    assert mismatch.status_code == 409
+    assert mismatch.json()["error"]["code"] == "api_major_mismatch"
+    assert fixture.search.calls == 0
+
+
+def test_target_method_mismatch_is_a_canonical_client_error() -> None:
+    response = _app().client.get("/api/v1/search")
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "invalid_request"
+    assert response.headers["allow"] == "POST"
+
+
+def test_provider_rate_limit_always_carries_required_headers() -> None:
+    response = _app(
+        search=_Search(
+            ProviderError(
+                ProviderErrorCode.RATE_LIMITED,
+                provider_id="openalex",
+                retry_after_seconds=2.2,
+            )
+        )
+    ).client.post(
+        "/api/v1/search",
+        json={"query": "fixture", "domains": ["paper"]},
+    )
+
+    assert response.status_code == 429
+    assert response.json()["error"]["code"] == "rate_limited"
+    assert response.headers["retry-after"] == "3"
+    assert response.headers["x-ratelimit-limit"] == "unknown"
+    assert response.headers["x-ratelimit-remaining"] == "0"
+    assert response.headers["x-ratelimit-reset"].isdigit()
+
+
+def test_fetch_all_rate_limited_preserves_maximum_provider_retry_after() -> None:
+    class _RateLimitedManager:
+        async def execute(self, _adapter_id, request, _context, _execution):
+            retry_after = 20 if str(request.target).endswith("/slow") else 5
+            raise ProviderError(
+                ProviderErrorCode.RATE_LIMITED,
+                provider_id="builtin-fetch",
+                retry_after_seconds=retry_after,
+            )
+
+    response = _app(fetch=FetchModuleService(_RateLimitedManager())).client.post(
+        "/api/v1/fetch",
+        json={"targets": ["https://example.com/fast", "https://example.com/slow"]},
+    )
+
+    assert response.status_code == 429
+    assert response.json()["error"]["code"] == "rate_limited"
+    assert response.headers["retry-after"] == "20"
+
+
+def test_probe_aliases_share_handler_payload_and_need_no_auth() -> None:
+    fixture = _app(require_user=lambda: (_ for _ in ()).throw(HTTPException(status_code=401)))
+    headers = {"X-Request-ID": "same-probe"}
+
+    healthz = fixture.client.get("/healthz", headers=headers)
+    health = fixture.client.get("/health", headers=headers, follow_redirects=False)
+    readyz = fixture.client.get("/readyz", headers=headers)
+    readiness = fixture.client.get("/readiness", headers=headers, follow_redirects=False)
+
+    assert healthz.status_code == health.status_code == 200
+    assert healthz.json() == health.json()
+    assert readyz.status_code == readiness.status_code == 200
+    assert readyz.json() == readiness.json()
+    assert "location" not in health.headers
+    assert "location" not in readiness.headers
+
+
+def test_not_ready_probe_is_503_and_health_stays_live() -> None:
+    services = _services(
+        readiness=lambda: ReadinessSnapshot(
+            ready=False,
+            components={"api": "ready", "browser_worker": "not_ready"},
+            error="required target runtime component is not ready",
+        )
+    )
+    app = create_target_delivery_app(
+        services,
+        RuntimeMetadata(
+            version="2.0.0rc2",
+            source_sha="a" * 40,
+            rollout_mode=RolloutMode.TARGET,
+        ),
+        require_user=lambda: None,
+        rate_limit=lambda: None,
+    )
+    client = TestClient(app)
+
+    health = client.get("/healthz")
+    readiness = client.get("/readyz")
+
+    assert health.status_code == 200
+    assert readiness.status_code == 503
+    assert readiness.json()["ready"] is False
+    assert readiness.json()["components"]["browser_worker"] == "not_ready"
+
+
+@pytest.mark.parametrize(
+    ("config", "headers", "expected"),
+    [
+        (SouWenConfig(), {}, 401),
+        (SouWenConfig(guest_enabled=True), {}, 200),
+        (SouWenConfig(user_password=""), {}, 200),
+        (SouWenConfig(user_password="user"), {"Authorization": "Bearer user"}, 200),
+        (SouWenConfig(admin_password="admin"), {"Authorization": "Bearer admin"}, 200),
+        (
+            SouWenConfig(user_password="user"),
+            {"Authorization": "Bearer user", "X-SouWen-Token": "wrong"},
+            401,
+        ),
+        (
+            SouWenConfig(user_password="user"),
+            {"Authorization": "Bearer outer", "X-SouWen-Token": "user"},
+            200,
+        ),
+        (
+            SouWenConfig(user_password="user"),
+            {"Authorization": "Bearer user", "X-SouWen-Token": ""},
+            401,
+        ),
+    ],
+)
+def test_target_auth_is_fail_closed_and_custom_header_is_authoritative(
+    monkeypatch, config, headers, expected
+) -> None:
+    monkeypatch.setattr("souwen.server.auth.get_config", lambda: config)
+    fixture = _app(require_user=check_target_user_auth)
+
+    response = fixture.client.get("/api/v1/providers", headers=headers)
+
+    assert response.status_code == expected
+    if expected == 401:
+        assert response.json()["error"]["code"] == "unauthenticated"
+
+
+def test_target_rate_limit_uses_credential_digest_and_custom_header_precedence(monkeypatch) -> None:
+    identities: list[str] = []
+    monkeypatch.setattr("souwen.server.limiter._target_data_limiter.check", identities.append)
+    fixture = _app(rate_limit=rate_limit_target_data)
+
+    fixture.client.get("/api/v1/providers", headers={"Authorization": "Bearer user-token"})
+    fixture.client.get(
+        "/api/v1/providers",
+        headers={"Authorization": "Bearer ignored", "X-SouWen-Token": "user-token"},
+    )
+
+    assert identities[0] == identities[1]
+    assert identities[0].startswith("credential:")
+    assert "user-token" not in identities[0]
+
+
+def test_local_target_limiter_error_keeps_canonical_body_and_headers() -> None:
+    def limited() -> None:
+        raise HTTPException(
+            status_code=429,
+            headers={
+                "Retry-After": "5",
+                "X-RateLimit-Limit": "60",
+                "X-RateLimit-Remaining": "0",
+                "X-RateLimit-Reset": "123456",
+            },
+        )
+
+    response = _app(rate_limit=limited).client.get("/api/v1/providers")
+
+    assert response.status_code == 429
+    assert response.json()["error"]["code"] == "rate_limited"
+    assert response.headers["retry-after"] == "5"
+    assert response.headers["x-ratelimit-limit"] == "60"
+    assert response.headers["x-ratelimit-remaining"] == "0"
+    assert response.headers["x-ratelimit-reset"] == "123456"
+
+
+@pytest.mark.asyncio
+async def test_runtime_catalog_keeps_uniapi_missing_fields_safe_and_nonblocking(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("SOUWEN_BROWSER_WORKER_TOKEN", raising=False)
+    runtime = build_target_runtime(SouWenConfig(sources={DEEPSEEK_ADAPTER_ID: {"enabled": True}}))
+
+    by_id = {item.provider: item for item in runtime.services.provider_items}
+    assert {"openalex-search", "builtin-fetch"} <= set(runtime.manager.eligible_adapter_ids)
+    assert by_id[DEEPSEEK_ADAPTER_ID].availability == "unavailable"
+    assert by_id[DEEPSEEK_ADAPTER_ID].missing_fields == (
+        "llm_search_gateways.uniapi.api_key",
+        "llm_search_gateways.uniapi.base_url",
+    )
+    assert "UNIAPI_API_KEY" not in repr(runtime.services.provider_items)
+    readiness = await runtime.services.readiness()
+    assert readiness.ready is True
+    assert readiness.components["browser_worker"] == "disabled"
+
+
+@pytest.mark.asyncio
+async def test_enabled_browser_worker_is_required_for_target_readiness(monkeypatch) -> None:
+    class _Worker:
+        def __init__(self, *, fail: bool) -> None:
+            self.fail = fail
+
+        async def readiness(self, _context, _execution):
+            if self.fail:
+                raise ProviderError(ProviderErrorCode.WORKER_NOT_READY)
+
+        async def fetch(self, *_args):  # pragma: no cover - composition protocol only
+            raise AssertionError("not called")
+
+        async def close(self) -> None:
+            return None
+
+    unavailable = _Worker(fail=True)
+    monkeypatch.setattr("souwen.server.v2_runtime._browser_client", lambda: unavailable)
+    runtime = build_target_runtime(SouWenConfig())
+    snapshot = await runtime.services.readiness()
+
+    assert snapshot.ready is False
+    assert snapshot.components["browser_worker"] == "not_ready"
+
+    ready_worker = _Worker(fail=False)
+    monkeypatch.setattr("souwen.server.v2_runtime._browser_client", lambda: ready_worker)
+    runtime = build_target_runtime(SouWenConfig())
+    snapshot = await runtime.services.readiness()
+
+    assert snapshot.ready is True
+    assert snapshot.components["browser_worker"] == "ready"
+
+
+def test_composition_root_requires_the_shared_browser_inventory_digest(monkeypatch) -> None:
+    monkeypatch.setenv("SOUWEN_BROWSER_WORKER_TOKEN", "w" * 48)
+
+    runtime = build_target_runtime(SouWenConfig())
+
+    assert runtime.browser_client is not None
+    assert (
+        runtime.browser_client._expected_inventory_digest
+        == BROWSER_WORKER_PROVIDER_INVENTORY_DIGEST
+    )
+
+
+@pytest.mark.asyncio
+async def test_runtime_close_attempts_browser_after_provider_close_failure() -> None:
+    class _Manager:
+        async def close_all(self) -> None:
+            raise RuntimeError("provider close failed")
+
+    class _Worker:
+        closed = False
+
+        async def close(self) -> None:
+            self.closed = True
+
+    worker = _Worker()
+    runtime = TargetRuntime(
+        services=_services(),
+        metadata=RuntimeMetadata(
+            version="2.0.0rc2",
+            source_sha="a" * 40,
+            rollout_mode=RolloutMode.TARGET,
+        ),
+        manager=_Manager(),
+        browser_client=worker,
+    )
+
+    with pytest.raises(RuntimeError, match="provider close failed"):
+        await runtime.close()
+
+    assert worker.closed is True
+
+
+def test_standalone_app_closes_its_injected_runtime() -> None:
+    closed = False
+
+    async def close() -> None:
+        nonlocal closed
+        closed = True
+
+    app = create_target_delivery_app(
+        _services(),
+        RuntimeMetadata(
+            version="2.0.0rc2",
+            source_sha="a" * 40,
+            rollout_mode=RolloutMode.TARGET,
+        ),
+        require_user=lambda: None,
+        rate_limit=lambda: None,
+        closer=close,
+    )
+
+    with TestClient(app) as client:
+        assert client.get("/healthz").status_code == 200
+
+    assert closed is True
+
+
+def test_rollout_mode_is_strict_and_target_router_precedes_legacy_fetch(tmp_path) -> None:
+    assert resolve_rollout_mode("legacy") is RolloutMode.LEGACY
+    assert resolve_rollout_mode(" target ") is RolloutMode.TARGET
+    with pytest.raises(ValueError):
+        resolve_rollout_mode("canary")
+
+    script = """
+from souwen.server.app import app
+matches = [
+    route for route in app.routes
+    if getattr(route, 'path', None) == '/api/v1/fetch'
+    and 'POST' in getattr(route, 'methods', set())
+]
+print(matches[0].response_model.__name__)
+"""
+    env = {
+        **os.environ,
+        "HOME": str(tmp_path),
+        "USERPROFILE": str(tmp_path),
+        "SOUWEN_PLUGIN_AUTOLOAD": "0",
+        "SOUWEN_V2_ROLLOUT": "target",
+    }
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert completed.stdout.strip() == "FetchBatch"
+
+
+def test_target_host_replaces_non_ascii_request_id(tmp_path) -> None:
+    script = """
+import asyncio
+import json
+
+from souwen.server.app import app
+
+async def main():
+    messages = []
+
+    async def receive():
+        return {'type': 'http.request', 'body': b'', 'more_body': False}
+
+    async def send(message):
+        messages.append(message)
+
+    await app(
+        {
+            'type': 'http',
+            'asgi': {'version': '3.0'},
+            'http_version': '1.1',
+            'method': 'GET',
+            'scheme': 'http',
+            'path': '/healthz',
+            'raw_path': b'/healthz',
+            'query_string': b'',
+            'headers': [(b'x-request-id', b'\\xc3\\xa9')],
+            'client': ('127.0.0.1', 12345),
+            'server': ('testserver', 80),
+        },
+        receive,
+        send,
+    )
+    start = next(message for message in messages if message['type'] == 'http.response.start')
+    body = b''.join(
+        message.get('body', b'')
+        for message in messages
+        if message['type'] == 'http.response.body'
+    )
+    headers = dict(start['headers'])
+    payload = json.loads(body)
+    request_id = headers[b'x-request-id'].decode('ascii')
+    assert start['status'] == 200
+    assert request_id.isascii()
+    assert payload['context']['request_id'] == request_id
+
+asyncio.run(main())
+print('ok')
+"""
+    env = {
+        **os.environ,
+        "HOME": str(tmp_path),
+        "USERPROFILE": str(tmp_path),
+        "SOUWEN_PLUGIN_AUTOLOAD": "0",
+        "SOUWEN_V2_ROLLOUT": "target",
+    }
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert completed.stdout.strip() == "ok"

--- a/tests/test_delivery_api_v2.py
+++ b/tests/test_delivery_api_v2.py
@@ -591,7 +591,12 @@ def test_rollout_mode_is_strict_and_target_router_precedes_legacy_fetch(tmp_path
     with pytest.raises(ValueError):
         resolve_rollout_mode("canary")
 
+    repo_src = str(Path(__file__).resolve().parents[1] / "src")
     script = """
+import sys
+
+sys.path.insert(0, sys.argv[1])
+
 from souwen.server.app import app
 matches = [
     route for route in app.routes
@@ -607,10 +612,13 @@ print(matches[0].response_model.__name__)
         "SOUWEN_PLUGIN_AUTOLOAD": "0",
         "SOUWEN_SOURCE_SHA": "a" * 40,
         "SOUWEN_V2_ROLLOUT": "target",
+        "PYTHONPATH": os.pathsep.join(
+            path for path in (repo_src, os.environ.get("PYTHONPATH")) if path
+        ),
     }
     env.pop("SOUWEN_BROWSER_WORKER_TOKEN", None)
     completed = subprocess.run(
-        [sys.executable, "-c", script],
+        [sys.executable, "-c", script, repo_src],
         capture_output=True,
         text=True,
         env=env,

--- a/tests/test_delivery_api_v2.py
+++ b/tests/test_delivery_api_v2.py
@@ -593,28 +593,28 @@ def test_rollout_mode_is_strict_and_target_router_precedes_legacy_fetch(tmp_path
 
     repo_src = str(Path(__file__).resolve().parents[1] / "src")
     script = """
-import importlib
-import json
-import os
 import sys
 
 sys.path.insert(0, sys.argv[1])
 
-server_app = importlib.import_module('souwen.server.app')
-app = server_app.app
+from souwen.server.app import app
+
+def iter_routes(routes, prefix=''):
+    for route in routes:
+        original_router = getattr(route, 'original_router', None)
+        include_context = getattr(route, 'include_context', None)
+        if original_router is not None and include_context is not None:
+            yield from iter_routes(original_router.routes, prefix + include_context.prefix)
+            continue
+        path = getattr(route, 'path', None)
+        if path is not None:
+            yield prefix + path, route
+
 matches = [
-    route for route in app.routes
-    if getattr(route, 'path', None) == '/api/v1/fetch'
+    route for path, route in iter_routes(app.routes)
+    if path == '/api/v1/fetch'
     and 'POST' in getattr(route, 'methods', set())
 ]
-if not matches:
-    raise RuntimeError(json.dumps({
-        'rollout_env': os.environ.get('SOUWEN_V2_ROLLOUT'),
-        'rollout_mode': server_app._rollout_mode.value,
-        'target_runtime': server_app._target_runtime is not None,
-        'server_app_file': server_app.__file__,
-        'route_paths': [getattr(route, 'path', None) for route in app.routes],
-    }, sort_keys=True))
 print(matches[0].response_model.__name__)
 """
     env = {

--- a/tests/test_fetch_module_v2.py
+++ b/tests/test_fetch_module_v2.py
@@ -106,6 +106,25 @@ async def test_module_rejects_request_side_provider_or_fanout_override() -> None
 
 
 @pytest.mark.asyncio
+async def test_module_raises_canonical_error_when_every_target_fails() -> None:
+    service = FetchModuleService(_Manager())
+
+    with pytest.raises(ProviderError) as caught:
+        await service.fetch(
+            FetchRequest(
+                targets=(
+                    "https://example.com/blocked-one",
+                    "https://example.com/blocked-two",
+                )
+            ),
+            RequestContext(request_id="fetch-all-failed"),
+            ExecutionContext.with_timeout(5),
+        )
+
+    assert caught.value.code is ProviderErrorCode.POLICY_BLOCKED
+
+
+@pytest.mark.asyncio
 async def test_module_uses_browser_as_execution_fallback_not_another_provider() -> None:
     browser = _BrowserExecutor()
     service = FetchModuleService(_Manager(), browser_executor=browser)

--- a/tests/test_phase2_module_skeleton.py
+++ b/tests/test_phase2_module_skeleton.py
@@ -54,6 +54,7 @@ SKELETON_PACKAGES = (
 # the remaining packages must stay inert until their owning migration slice.
 IMPLEMENTED_PACKAGES = frozenset(
     {
+        "souwen.delivery.api",
         "souwen.modules.search.api",
         "souwen.modules.search.application",
         "souwen.modules.llm_search.api",


### PR DESCRIPTION
## 目标

交付 Souwen v2rc2 Phase 4 / P4-06：rollout-gated target Delivery API、USER+ 认证、canonical error/probe/OpenAPI contract 和 target composition root。

## 实现

- 新增 `POST /api/v1/search`、`POST /api/v1/llm-search`、`POST /api/v1/fetch`、`GET /api/v1/providers`。
- 新增 `/healthz`/`/readyz`，`/health`/`/readiness` 保持 same-handler、same-payload、no-redirect alias。
- `SOUWEN_V2_ROLLOUT=legacy|target`，默认 `legacy`；只有 deployment 可选择，request 不能覆盖。
- target Data API 默认 fail closed；USER 和 ADMIN token 均满足 USER+；`X-SouWen-Token` 保持代理场景优先级。
- 统一 API major/request ID/rollout headers、canonical 400/4xx/5xx envelope，不暴露 target 422。
- target composition root 装配 OpenAlex、UniAPI、builtin Fetch 和 Browser Worker client；Delivery route 不 import concrete Provider。
- Browser Worker 启用时 readiness 对 contract/source/version/config/inventory 全部 fail closed；未启用时显式报告 `disabled`。
- Fetch 部分成功保持 200/partial；全失败转 canonical error；全量 rate-limit 保留最大 typed `Retry-After`。
- runtime OpenAPI 与冻结 target skeleton 做 deterministic semantic parity 校验。

## 默认与回滚边界

- 默认仍是 `legacy`，target mode 才接管 canonical routes。
- Admin 继续位于独立 `/api/v1/admin` 权限面；standalone target app 不挂载 Admin。
- 本 PR 未执行 HFS promotion/rollback/pause，未修改 Space 运行时。
- 本 PR 不包含 P4-07 supervisor/HFS deployment、Panel、SDK、release 或 RC2 version-surface。
- 下一个独立 PR 才统一 `2.0.0rc2` / `2.0.0-rc2` 版本面，然后才进入 P4-07/M1。

## 验证

- `pytest tests/ -q`: `2630 passed, 3 skipped`
- `pytest tests/test_import_surface.py -q`: `28 passed`
- `ruff check src tests scripts tools`
- `ruff format --check src tests scripts tools`
- `python3 scripts/ci/check_architecture_dependencies.py`
- `PYTHONPATH=src python3 tools/gen_docs.py --check`
- `python3 tools/check_markdown_links.py`
- 两轮独立只读 code review 最终 verdict: `clean/proceed`
