### PR TITLE
fix(ci): clear panel production advisories

### DIFF
--- a/panel/package-lock.json
+++ b/panel/package-lock.json
@@ -12,12 +12,12 @@
         "@uiw/react-codemirror": "^4.25.9",
         "framer-motion": "^12.38.0",
         "i18next": "^26.0.7",
-        "js-yaml": "^5.2.0",
+        "js-yaml": "^5.2.2",
         "lucide-react": "^1.11.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.6",
         "react-i18next": "^17.0.7",
-        "react-router-dom": "^7.15.1",
+        "react-router-dom": "^7.18.1",
         "zustand": "^5.0.13"
       },
       "devDependencies": {
@@ -2882,9 +2882,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.0.tgz",
-      "integrity": "sha512-YeLUMlvR4Ou1B119LIaM0r65JvbOBooJDc9yEu0dClb/uSC5P4FrLU8OCCz/HXWvtPoIrR0dRzABTjo1sTN9Bw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
       "funding": [
         {
           "type": "github",
@@ -3296,9 +3296,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.15.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.1.tgz",
-      "integrity": "sha512-R8rl9HhgikFYoPJymnUtPXWbnDb3oget6lQnfIoupbt61aT9aOhRkDsY2XRhZRyX1Z/8a5sL74fXmFNm3NRK5A==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -3318,12 +3318,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.15.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.1.tgz",
-      "integrity": "sha512-AzF62gjY6U9rkMq4RfP/r2EVtQ7DMfNMjyOp/flLTCrtRylLiK4wT4pSq6O8rOXZ2eXdZYJPEYe+ifomiv+Igg==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.15.1"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/panel/package.json
+++ b/panel/package.json
@@ -25,12 +25,12 @@
     "@uiw/react-codemirror": "^4.25.9",
     "framer-motion": "^12.38.0",
     "i18next": "^26.0.7",
-    "js-yaml": "^5.2.0",
+    "js-yaml": "^5.2.2",
     "lucide-react": "^1.11.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.6",
     "react-i18next": "^17.0.7",
-    "react-router-dom": "^7.15.1",
+    "react-router-dom": "^7.18.1",
     "zustand": "^5.0.13"
   },
   "devDependencies": {


### PR DESCRIPTION
## 变更

- 将 `react-router-dom` 从 `7.15.1` 升级到 `7.18.1`，关闭新增的 React Router 高危 advisory。
- 将 `js-yaml` 从 `5.2.0` 升级到 `5.2.2`，关闭新增的 YAML DoS advisory。
- 仅更新 Panel package metadata 与 lockfile，不改业务代码。

## 原因

PR #211 的 exact-head `Dependency audit` 在 2026-07-24 因 npm advisory 数据更新确定性失败；该失败可在当前 `main` 依赖基线上复现，与 P4-06 Delivery API diff 无关，因此作为独立 prerequisite 修复。

## 验证

- `npm audit --omit=dev --audit-level=high --json`: 0 vulnerabilities
- `npm test`: 64 files / 212 tests passed
- `npm run build`: passed
- `git diff --check`: passed

## 边界

不发布、不部署、不处理无关 Dependabot PR；合并后由 #211 merge 最新 `main` 并重新跑 exact-head gates。