### PR TITLE
fix(panel): 迁移到已修复的 React Router 8.3

### DIFF
--- a/panel/package-lock.json
+++ b/panel/package-lock.json
@@ -17,7 +17,7 @@
         "react": "^19.2.5",
         "react-dom": "^19.2.6",
         "react-i18next": "^17.0.7",
-        "react-router-dom": "^7.18.1",
+        "react-router": "8.3.0",
         "zustand": "^5.0.13"
       },
       "devDependencies": {
@@ -2458,18 +2458,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/crelt": {
       "version": "1.0.6",
@@ -3230,24 +3223,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.6"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-i18next": {
@@ -3296,41 +3289,24 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/readdirp": {
@@ -3825,12 +3801,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/siginfo": {
       "version": "2.0.0",

--- a/panel/package.json
+++ b/panel/package.json
@@ -30,7 +30,7 @@
     "react": "^19.2.5",
     "react-dom": "^19.2.6",
     "react-i18next": "^17.0.7",
-    "react-router-dom": "^7.18.1",
+    "react-router": "8.3.0",
     "zustand": "^5.0.13"
   },
   "devDependencies": {

--- a/panel/src/App.tsx
+++ b/panel/src/App.tsx
@@ -20,14 +20,14 @@
  *
  * 模块依赖：
  *     - react: 核心 React 库，用于组件与状态管理
- *     - react-router-dom: 客户端路由管理（HashRouter、Routes、Navigate）
+ *     - react-router: 客户端路由管理（HashRouter、Routes、Navigate）
  *     - framer-motion: 动画库（LazyMotion、AnimatePresence）
  *     - @core/stores/authStore: 认证全局状态存储
  *     - @core/skin-registry: 皮肤主题注册与管理系统
  */
 
 import { useEffect, useState } from 'react'
-import { HashRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom'
+import { HashRouter, Routes, Route, Navigate, useLocation } from 'react-router'
 import { LazyMotion, domAnimation, AnimatePresence } from 'framer-motion'
 import { useAuthStore } from '@core/stores/authStore'
 import { getActiveSkin } from '@core/skin-registry'

--- a/panel/src/skins/apple/components/layout/MainLayout.tsx
+++ b/panel/src/skins/apple/components/layout/MainLayout.tsx
@@ -10,7 +10,7 @@
  *     - 关键常量：NAV_ITEMS 导航菜单项数组, pageVariants 页面进出动画配置, pageTransition 页面过渡动画配置
  *
  * 模块依赖：
- *   - react-router-dom: 路由导航与 Outlet 出口
+ *   - react-router: 路由导航与 Outlet 出口
  *   - react-i18next: 国际化翻译
  *   - framer-motion: 动画库（导航、菜单、页面过渡）
  *   - lucide-react: 图标库
@@ -21,7 +21,7 @@
  */
 
 import { useState, useCallback, useEffect, useRef, useId } from 'react'
-import { NavLink, Outlet, useLocation } from 'react-router-dom'
+import { NavLink, Outlet, useLocation } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { m, AnimatePresence } from 'framer-motion'
 import {

--- a/panel/src/skins/apple/pages/LoginPage.tsx
+++ b/panel/src/skins/apple/pages/LoginPage.tsx
@@ -17,7 +17,7 @@
  *     - 关键逻辑：自动登录、手动表单提交、眼睛图标切换密码可见性、成功后延迟导航
  *
  * 模块依赖：
- *   - react-router-dom: useNavigate 路由导航
+ *   - react-router: useNavigate 路由导航
  *   - react-i18next: useTranslation 国际化
  *   - framer-motion: 动画库（表单进入、加载中、成功状态）
  *   - lucide-react: Eye/EyeOff/Loader2 图标
@@ -27,7 +27,7 @@
  */
 
 import { useState, useEffect, useCallback, type FormEvent } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { AnimatePresence, m } from 'framer-motion'
 import { Eye, EyeOff, Loader2 } from 'lucide-react'

--- a/panel/src/skins/apple/pages/SearchPage.tsx
+++ b/panel/src/skins/apple/pages/SearchPage.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useEffect, useRef, useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { m } from 'framer-motion'
 import {

--- a/panel/src/skins/apple/routes.tsx
+++ b/panel/src/skins/apple/routes.tsx
@@ -10,11 +10,11 @@
  *   /config - ConfigPage（应用配置页面）
  *
  * 模块依赖：
- *   - react-router-dom: Route 组件用于定义路由
+ *   - react-router: Route 组件用于定义路由
  *   - 各 page 组件：每个页面组件
  */
 
-import { Route, Navigate } from 'react-router-dom'
+import { Route, Navigate } from 'react-router'
 import { DashboardPage } from './pages/DashboardPage'
 import { SearchPage } from './pages/SearchPage'
 import { FetchPage } from './pages/FetchPage'

--- a/panel/src/skins/carbon/components/layout/MainLayout.tsx
+++ b/panel/src/skins/carbon/components/layout/MainLayout.tsx
@@ -4,7 +4,7 @@
  */
 
 import { useState, useCallback, useEffect, useRef, useId } from 'react'
-import { NavLink, Outlet, useLocation } from 'react-router-dom'
+import { NavLink, Outlet, useLocation } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { m, AnimatePresence } from 'framer-motion'
 import {

--- a/panel/src/skins/carbon/pages/LoginPage.tsx
+++ b/panel/src/skins/carbon/pages/LoginPage.tsx
@@ -18,7 +18,7 @@
  *     - 关键逻辑：自动登录、手动表单提交、眼睛图标切换密码可见性、成功后延迟导航
  *
  * 模块依赖：
- *   - react-router-dom: useNavigate 路由导航
+ *   - react-router: useNavigate 路由导航
  *   - react-i18next: useTranslation 国际化
  *   - framer-motion: 动画库（表单进入、加载中、成功状态）
  *   - lucide-react: Eye/EyeOff/Loader2 图标
@@ -28,7 +28,7 @@
  */
 
 import { useState, useEffect, useCallback, type FormEvent } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { AnimatePresence, m } from 'framer-motion'
 import { Terminal, Eye, EyeOff, Loader2 } from 'lucide-react'

--- a/panel/src/skins/carbon/pages/SearchPage.tsx
+++ b/panel/src/skins/carbon/pages/SearchPage.tsx
@@ -4,7 +4,7 @@
  */
 
 import { useEffect, useRef, useState, type ComponentType } from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { m } from 'framer-motion'
 import {

--- a/panel/src/skins/carbon/routes.tsx
+++ b/panel/src/skins/carbon/routes.tsx
@@ -10,11 +10,11 @@
  *   /config - ConfigPage（应用配置页面）
  *
  * 模块依赖：
- *   - react-router-dom: Route 组件用于定义路由
+ *   - react-router: Route 组件用于定义路由
  *   - 各 page 组件：每个页面组件
  */
 
-import { Route, Navigate } from 'react-router-dom'
+import { Route, Navigate } from 'react-router'
 import { DashboardPage } from './pages/DashboardPage'
 import { SearchPage } from './pages/SearchPage'
 import { FetchPage } from './pages/FetchPage'

--- a/panel/src/skins/ios/components/layout/MainLayout.tsx
+++ b/panel/src/skins/ios/components/layout/MainLayout.tsx
@@ -10,7 +10,7 @@
  *     - 关键常量：NAV_ITEMS 导航菜单项数组, pageVariants 页面进出动画配置, pageTransition 页面过渡动画配置
  *
  * 模块依赖：
- *   - react-router-dom: 路由导航与 Outlet 出口
+ *   - react-router: 路由导航与 Outlet 出口
  *   - react-i18next: 国际化翻译
  *   - framer-motion: 动画库（导航、菜单、页面过渡）
  *   - lucide-react: 图标库
@@ -21,7 +21,7 @@
  */
 
 import { useState, useCallback, useEffect, useRef, useId } from 'react'
-import { NavLink, Outlet, useLocation } from 'react-router-dom'
+import { NavLink, Outlet, useLocation } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { m, AnimatePresence } from 'framer-motion'
 import {

--- a/panel/src/skins/ios/pages/LoginPage.tsx
+++ b/panel/src/skins/ios/pages/LoginPage.tsx
@@ -17,7 +17,7 @@
  *     - 关键逻辑：自动登录、手动表单提交、眼睛图标切换密码可见性、成功后延迟导航
  *
  * 模块依赖：
- *   - react-router-dom: useNavigate 路由导航
+ *   - react-router: useNavigate 路由导航
  *   - react-i18next: useTranslation 国际化
  *   - framer-motion: 动画库（表单进入、加载中、成功状态）
  *   - lucide-react: Eye/EyeOff/Loader2 图标
@@ -27,7 +27,7 @@
  */
 
 import { useState, useCallback, useEffect, type FormEvent } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { AnimatePresence, m } from 'framer-motion'
 import { Eye, EyeOff, Loader2 } from 'lucide-react'

--- a/panel/src/skins/ios/pages/SearchPage.tsx
+++ b/panel/src/skins/ios/pages/SearchPage.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useEffect, useRef, useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { m } from 'framer-motion'
 import {

--- a/panel/src/skins/ios/routes.tsx
+++ b/panel/src/skins/ios/routes.tsx
@@ -10,11 +10,11 @@
  *   /config - ConfigPage（应用配置页面）
  *
  * 模块依赖：
- *   - react-router-dom: Route 组件用于定义路由
+ *   - react-router: Route 组件用于定义路由
  *   - 各 page 组件：每个页面组件
  */
 
-import { Route, Navigate } from 'react-router-dom'
+import { Route, Navigate } from 'react-router'
 import { DashboardPage } from './pages/DashboardPage'
 import { SearchPage } from './pages/SearchPage'
 import { FetchPage } from './pages/FetchPage'

--- a/panel/src/skins/souwen-google/components/layout/MainLayout.tsx
+++ b/panel/src/skins/souwen-google/components/layout/MainLayout.tsx
@@ -26,7 +26,7 @@
  */
 
 import { useState, useCallback, useEffect, useRef, useId } from 'react'
-import { NavLink, Outlet, useLocation } from 'react-router-dom'
+import { NavLink, Outlet, useLocation } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { m, AnimatePresence } from 'framer-motion'
 import {

--- a/panel/src/skins/souwen-google/pages/LoginPage.tsx
+++ b/panel/src/skins/souwen-google/pages/LoginPage.tsx
@@ -21,7 +21,7 @@
  */
 
 import { useState, useEffect, useCallback, type FormEvent } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { AnimatePresence, m } from 'framer-motion'
 import { Search, Moon, Sun, Eye, EyeOff, Loader2 } from 'lucide-react'

--- a/panel/src/skins/souwen-google/pages/SearchPage.tsx
+++ b/panel/src/skins/souwen-google/pages/SearchPage.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useEffect, useRef, useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { m } from 'framer-motion'
 import {

--- a/panel/src/skins/souwen-google/routes.tsx
+++ b/panel/src/skins/souwen-google/routes.tsx
@@ -14,7 +14,7 @@
  * 导出格式：JSX Fragment 包含 <Route> 元素，由父 Router 组件加载
  */
 
-import { Route, Navigate } from 'react-router-dom'
+import { Route, Navigate } from 'react-router'
 import { DashboardPage } from './pages/DashboardPage'
 import { SearchPage } from './pages/SearchPage'
 import { FetchPage } from './pages/FetchPage'

--- a/panel/src/skins/souwen-nebula/components/layout/MainLayout.tsx
+++ b/panel/src/skins/souwen-nebula/components/layout/MainLayout.tsx
@@ -26,7 +26,7 @@
  */
 
 import { useState, useCallback, useEffect, useRef, useId } from 'react'
-import { NavLink, Outlet, useLocation } from 'react-router-dom'
+import { NavLink, Outlet, useLocation } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { m, AnimatePresence } from 'framer-motion'
 import {

--- a/panel/src/skins/souwen-nebula/pages/LoginPage.tsx
+++ b/panel/src/skins/souwen-nebula/pages/LoginPage.tsx
@@ -21,7 +21,7 @@
  */
 
 import { useState, useEffect, useCallback, type FormEvent } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { AnimatePresence, m } from 'framer-motion'
 import { Search, Moon, Sun, Eye, EyeOff, Loader2 } from 'lucide-react'

--- a/panel/src/skins/souwen-nebula/pages/NetworkPage.tsx
+++ b/panel/src/skins/souwen-nebula/pages/NetworkPage.tsx
@@ -22,7 +22,7 @@
  */
 
 import { useEffect, useState, useCallback } from 'react'
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { m } from 'framer-motion'
 import {

--- a/panel/src/skins/souwen-nebula/pages/SearchPage.tsx
+++ b/panel/src/skins/souwen-nebula/pages/SearchPage.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useEffect, useRef, useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { m } from 'framer-motion'
 import {

--- a/panel/src/skins/souwen-nebula/pages/WarpPage.tsx
+++ b/panel/src/skins/souwen-nebula/pages/WarpPage.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { m } from 'framer-motion'
 import {

--- a/panel/src/skins/souwen-nebula/routes.tsx
+++ b/panel/src/skins/souwen-nebula/routes.tsx
@@ -14,7 +14,7 @@
  * 导出格式：JSX Fragment 包含 <Route> 元素，由父 Router 组件加载
  */
 
-import { Route, Navigate } from 'react-router-dom'
+import { Route, Navigate } from 'react-router'
 import { DashboardPage } from './pages/DashboardPage'
 import { SearchPage } from './pages/SearchPage'
 import { FetchPage } from './pages/FetchPage'

--- a/panel/src/skins/souwen-nebula/test/NetworkPage.test.tsx
+++ b/panel/src/skins/souwen-nebula/test/NetworkPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import type { HTMLAttributes, ReactNode } from 'react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { api } from '@core/services/api'
 import { useNotificationStore } from '@core/stores/notificationStore'

--- a/panel/src/skins/souwen-nebula/test/WarpPage.test.tsx
+++ b/panel/src/skins/souwen-nebula/test/WarpPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import type { HTMLAttributes, ReactNode } from 'react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { api } from '@core/services/api'
 import { useNotificationStore } from '@core/stores/notificationStore'


### PR DESCRIPTION
## 结果

修复 2026-07-25 新披露的 React Router high severity advisory，恢复 Panel production dependency audit。React Router 7 当前不存在同时避开旧 XSS/DoS advisories 与新 CSRF advisory 的安全版本，因此迁移到已修复的 `react-router@8.3.0`。

## 改动

- 移除 v8 已退役的 `react-router-dom` package，固定 `react-router=8.3.0`。
- 将 Panel 路由组件、hooks 和测试的 import source 机械迁移到 `react-router`；HashRouter/Routes/Route/Navigate/Link 等使用方式不变。
- 使用 npm 更新 `package-lock.json`，未手工编辑 lockfile。

## 验证

- `npm audit --omit=dev --audit-level=high --json`：production vulnerabilities `0`
- `npm test`：`64 files / 212 tests passed`
- `git diff --check`：通过

未在本地执行 Panel build；TypeScript/Vite build 由本 PR exact-head CI 验证。此 PR 只处理 dependency prerequisite，不包含 P4-07 Supervisor/M1 代码，也不触发 HFS promotion、tag 或 Release。
