### PR TITLE
fix(deploy): harden M1 browser probe evidence

### DIFF
--- a/docs/hf-space-cd.md
+++ b/docs/hf-space-cd.md
@@ -116,8 +116,12 @@ SHA。
 4. Factory rebuild，等待 Space repo SHA 与 runtime SHA 等于新的 wrapper commit。
 5. 使用 trusted verifier 完成 surface、target M1 capability、双层 auth 与 candidate/source/
    wrapper SHA smoke。Target M1 required checks 固定为 OpenAlex Search、builtin Fetch、Browser
-   Fetch；Browser fixture 的 repo-owned 短脚本经 `httpbin /base64` 以 `text/html` 返回，并把
-   candidate SHA 与 stable marker 放入 query，只有 JavaScript 执行后的正文才满足 gate。
+   Fetch；Browser fixture 的 repo-owned 短脚本依次使用 `httpbin.org /base64` 与
+   `httpbun.com /base64` 两个公开 `text/html` host。Primary 只有在返回 allowlist 内的
+   retryable transport/upstream error 时才尝试 secondary；HTTP 2xx proof mismatch、protocol、
+   policy 或其他 non-retryable error 立即失败。两个 fixture 都把 candidate SHA 与 stable
+   marker 放入 query，gate 要求 JavaScript 执行后的正文精确等于该 query，并同时具有
+   `builtin-fetch` attempt 2 success provenance；substring、URL echo 或原始脚本文本均不通过。
    普通 CI 不做付费 UniAPI live call。
 
 若 sync 已取得 rollback point，而 sync/rebuild/post-smoke 任一阶段失败：

--- a/scripts/hf_space_smoke.py
+++ b/scripts/hf_space_smoke.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import hashlib
 import json
 import os
 import re
@@ -36,8 +37,19 @@ REQUIRED_BROWSER_FETCH_PROBE_PATH = "scripts/fixtures/hf-space-browser-probe.htm
 REQUIRED_BUILTIN_FETCH_PROBE_RAW_BASE_URL = "https://raw.githubusercontent.com/BlueSkyXN/SouWen"
 REQUIRED_BUILTIN_FETCH_PROBE_MARKER = "SOUWEN_IMMUTABLE_FETCH_PROBE_V1"
 REQUIRED_BUILTIN_FETCH_MIN_CONTENT_CHARS = 600
-REQUIRED_BROWSER_FETCH_PROBE_BASE_URL = "https://httpbin.org/base64"
+REQUIRED_BROWSER_FETCH_PROBE_BASE_URLS = (
+    "https://httpbin.org/base64",
+    "https://httpbun.com/base64",
+)
+REQUIRED_BROWSER_FETCH_PROBE_BASE_URL = REQUIRED_BROWSER_FETCH_PROBE_BASE_URLS[0]
 REQUIRED_BROWSER_FETCH_PROBE_MARKER = "SOUWEN_BROWSER_RENDERED_V1"
+RETRYABLE_BROWSER_FIXTURE_ERRORS = {
+    "provider_timeout": {504},
+    "provider_unavailable": {502, 503},
+    "rate_limited": {429},
+    "worker_timeout": {504},
+    "worker_unavailable": {502},
+}
 EDITION_RANK = {
     "basic": 0,
     "pro": 1,
@@ -382,7 +394,11 @@ def immutable_builtin_fetch_probe_url(expected_source_sha: str | None) -> str | 
     )
 
 
-def immutable_browser_fetch_probe_url(expected_source_sha: str | None) -> str | None:
+def immutable_browser_fetch_probe_url(
+    expected_source_sha: str | None,
+    *,
+    base_url: str = REQUIRED_BROWSER_FETCH_PROBE_BASE_URL,
+) -> str | None:
     """Build a candidate-bound HTML response whose marker requires JavaScript execution."""
 
     candidate_sha = normalize_expected_source_sha(expected_source_sha)
@@ -392,13 +408,36 @@ def immutable_browser_fetch_probe_url(expected_source_sha: str | None) -> str | 
     if not payload or len(payload) > 63:
         raise ValueError("browser fixture must remain a non-empty low-quality builtin response")
     encoded_payload = quote(base64.b64encode(payload.encode()).decode(), safe="=")
+    rendered_content = expected_browser_fetch_probe_content(candidate_sha)
+    if rendered_content is None:  # pragma: no cover - candidate_sha is normalized above.
+        return None
+    return f"{base_url.rstrip('/')}/{encoded_payload}{rendered_content}"
+
+
+def expected_browser_fetch_probe_content(expected_source_sha: str | None) -> str | None:
+    """Return the exact body text produced by the repo-owned JavaScript fixture."""
+
+    candidate_sha = normalize_expected_source_sha(expected_source_sha)
+    if candidate_sha is None:
+        return None
     query = urlencode(
         {
             "candidate_sha": candidate_sha,
             "marker": REQUIRED_BROWSER_FETCH_PROBE_MARKER,
         }
     )
-    return f"{REQUIRED_BROWSER_FETCH_PROBE_BASE_URL}/{encoded_payload}?{query}"
+    return f"?{query}"
+
+
+def immutable_browser_fetch_probe_urls(expected_source_sha: str | None) -> tuple[str, ...]:
+    """Build redundant candidate-bound probes without weakening rendered-marker checks."""
+
+    return tuple(
+        url
+        for base_url in REQUIRED_BROWSER_FETCH_PROBE_BASE_URLS
+        if (url := immutable_browser_fetch_probe_url(expected_source_sha, base_url=base_url))
+        is not None
+    )
 
 
 def bool_or_none(value: Any) -> bool | None:
@@ -591,7 +630,11 @@ class ApiClient:
             raw = exc.read()
             response_headers = dict(exc.headers.items())
         except (TimeoutError, URLError, OSError) as exc:
-            raise SmokeError(f"{method.upper()} {path} failed: {exc}") from exc
+            reason = getattr(exc, "reason", None)
+            reason_type = type(reason).__name__ if reason is not None else type(exc).__name__
+            raise SmokeError(
+                f"{method.upper()} {path} failed: transport_error={reason_type}"
+            ) from exc
 
         elapsed = time.monotonic() - started
         return status, raw, response_headers, elapsed
@@ -617,9 +660,10 @@ class ApiClient:
         try:
             decoded = json.loads(raw.decode("utf-8"))
         except Exception as exc:  # noqa: BLE001 - report endpoint behavior in CI
-            preview = raw[:240].decode("utf-8", errors="replace")
+            digest = hashlib.sha256(raw).hexdigest()
             raise SmokeError(
-                f"{method.upper()} {path} returned non-JSON status={status} body={preview!r}"
+                f"{method.upper()} {path} returned non-JSON status={status} "
+                f"body_bytes={len(raw)} body_sha256={digest}"
             ) from exc
         if not isinstance(decoded, (dict, list)):
             raise SmokeError(
@@ -816,6 +860,22 @@ def _fetch_detail_with_diagnostic(detail: str, diagnostic: dict[str, Any]) -> st
         if key in diagnostic
     ]
     return f"{detail}, {', '.join(fields)}"
+
+
+def _target_error_diagnostic(data: Any) -> dict[str, Any]:
+    """Extract stable target API error fields without retaining messages or request IDs."""
+
+    if not isinstance(data, dict) or not isinstance(data.get("error"), dict):
+        return {}
+    error = data["error"]
+    diagnostic: dict[str, Any] = {}
+    code = error.get("code")
+    if isinstance(code, str) and re.fullmatch(r"[a-z][a-z0-9_]{0,63}", code):
+        diagnostic["error_code"] = code
+    retryable = error.get("retryable")
+    if isinstance(retryable, bool):
+        diagnostic["retryable"] = retryable
+    return diagnostic
 
 
 def run_basic_checks(client: ApiClient, config: SmokeConfig, state: RunState) -> list[ProbeResult]:
@@ -2836,7 +2896,13 @@ def run_target_m1_checks(client: ApiClient, config: SmokeConfig) -> list[ProbeRe
             )
         )
 
-    def _fetch(name: str, target: str, *, require_browser: bool) -> ProbeResult:
+    def _fetch(
+        name: str,
+        target: str,
+        *,
+        require_browser: bool,
+        fixture_index: int | None = None,
+    ) -> ProbeResult:
         response = client.post(
             "/api/v1/fetch",
             body={"targets": [target]},
@@ -2854,11 +2920,11 @@ def run_target_m1_checks(client: ApiClient, config: SmokeConfig) -> list[ProbeRe
             for entry in provenance
         )
         content = item.get("content")
-        marker_ok = isinstance(content, str) and (
-            REQUIRED_BROWSER_FETCH_PROBE_MARKER in content and config.expected_source_sha in content
-            if require_browser and config.expected_source_sha is not None
-            else REQUIRED_BUILTIN_FETCH_PROBE_MARKER in content
-        )
+        if require_browser:
+            expected_content = expected_browser_fetch_probe_content(config.expected_source_sha)
+            marker_ok = isinstance(content, str) and content == expected_content
+        else:
+            marker_ok = isinstance(content, str) and REQUIRED_BUILTIN_FETCH_PROBE_MARKER in content
         ok = (
             response.status == 200
             and item.get("status") == "success"
@@ -2870,15 +2936,91 @@ def run_target_m1_checks(client: ApiClient, config: SmokeConfig) -> list[ProbeRe
             f"provenance_count={len(provenance)}, browser_attempt={browser_attempt}, "
             f"content_chars={len(content) if isinstance(content, str) else 0}"
         )
+        diagnostic = _target_error_diagnostic(response.data)
+        if diagnostic:
+            detail = f"{detail}, " + ", ".join(
+                f"{key}={value!r}" for key, value in diagnostic.items()
+            )
+        meta: dict[str, Any] = {"status": response.status}
+        if fixture_index is not None:
+            meta["fixture"] = fixture_index
+        meta.update(diagnostic)
         return (
-            pass_result("target-m1", name, detail, required=True, elapsed=response.elapsed)
+            pass_result(
+                "target-m1",
+                name,
+                detail,
+                required=True,
+                elapsed=response.elapsed,
+                meta=meta,
+            )
             if ok
-            else fail_result("target-m1", name, detail, required=True, elapsed=response.elapsed)
+            else fail_result(
+                "target-m1",
+                name,
+                detail,
+                required=True,
+                elapsed=response.elapsed,
+                meta=meta,
+            )
+        )
+
+    def _browser_fetch() -> ProbeResult:
+        attempts: list[dict[str, Any]] = []
+        elapsed = 0.0
+        for fixture_index, target in enumerate(browser_urls, start=1):
+            result = _fetch(
+                "browser-fetch",
+                target,
+                require_browser=True,
+                fixture_index=fixture_index,
+            )
+            elapsed += result.elapsed or 0.0
+            attempts.append(
+                {
+                    "fixture": fixture_index,
+                    "outcome": result.outcome,
+                    **result.meta,
+                }
+            )
+            if result.outcome == "pass":
+                prior_failures = sum(attempt["outcome"] != "pass" for attempt in attempts[:-1])
+                return pass_result(
+                    "target-m1",
+                    "browser-fetch",
+                    f"fixture={fixture_index}, prior_failures={prior_failures}, {result.detail}",
+                    required=True,
+                    elapsed=elapsed,
+                    meta={"fixture_attempts": attempts},
+                )
+            retryable_fixture_failure = result.meta.get("retryable") is True and result.meta.get(
+                "status"
+            ) in RETRYABLE_BROWSER_FIXTURE_ERRORS.get(
+                result.meta.get("error_code"),
+                set(),
+            )
+            if not retryable_fixture_failure:
+                break
+        summary = "; ".join(
+            "fixture={fixture}, status={status}, error_code={error_code!r}".format(
+                fixture=attempt["fixture"],
+                status=attempt.get("status"),
+                error_code=attempt.get("error_code"),
+            )
+            for attempt in attempts
+        )
+        return fail_result(
+            "target-m1",
+            "browser-fetch",
+            f"candidate-bound browser fixture validation failed: {summary}",
+            required=True,
+            elapsed=elapsed,
+            meta={"fixture_attempts": attempts},
         )
 
     builtin_url = immutable_builtin_fetch_probe_url(config.expected_source_sha)
-    browser_url = immutable_browser_fetch_probe_url(config.expected_source_sha)
-    if builtin_url is None or browser_url is None:
+    browser_urls = immutable_browser_fetch_probe_urls(config.expected_source_sha)
+    if builtin_url is None or not browser_urls:
         return [
             fail_result(
                 "target-m1",
@@ -2901,7 +3043,7 @@ def run_target_m1_checks(client: ApiClient, config: SmokeConfig) -> list[ProbeRe
         safe_call(
             "target-m1",
             "browser-fetch",
-            lambda: _fetch("browser-fetch", browser_url, require_browser=True),
+            _browser_fetch,
             required=True,
         )
     )

--- a/tests/test_hf_space_smoke.py
+++ b/tests/test_hf_space_smoke.py
@@ -107,6 +107,62 @@ def test_private_space_uses_separate_outer_and_application_auth_headers(monkeypa
     assert captured["timeout"] == 3
 
 
+def test_api_client_non_json_error_records_only_length_and_digest(monkeypatch):
+    raw = b"Authorization: secret at https://private.invalid/request-id"
+
+    class FakeResponse:
+        status = 502
+        headers = SimpleNamespace(items=lambda: [])
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return raw
+
+    monkeypatch.setattr(smoke, "urlopen", lambda *_args, **_kwargs: FakeResponse())
+    client = smoke.ApiClient(
+        smoke.SmokeConfig(
+            base_url="https://private-space.example",
+            expected_version="2.0.0rc2",
+            request_timeout=3,
+        )
+    )
+
+    with pytest.raises(smoke.SmokeError) as caught:
+        client.request("POST", "/api/v1/fetch", body={"targets": ["https://example.test"]})
+
+    message = str(caught.value)
+    assert "status=502" in message
+    assert f"body_bytes={len(raw)}" in message
+    assert "body_sha256=" in message
+    assert "Authorization" not in message
+    assert "private.invalid" not in message
+    assert "request-id" not in message
+
+
+def test_api_client_transport_error_does_not_record_raw_exception(monkeypatch):
+    def fail_urlopen(*_args, **_kwargs):
+        raise OSError("token=secret https://private.invalid/request-id")
+
+    monkeypatch.setattr(smoke, "urlopen", fail_urlopen)
+    client = smoke.ApiClient(
+        smoke.SmokeConfig(
+            base_url="https://private-space.example",
+            expected_version="2.0.0rc2",
+            request_timeout=3,
+        )
+    )
+
+    with pytest.raises(smoke.SmokeError) as caught:
+        client.request("POST", "/api/v1/fetch", body={"targets": ["https://example.test"]})
+
+    assert str(caught.value) == "POST /api/v1/fetch failed: transport_error=OSError"
+
+
 def test_builtin_fetch_failure_records_sanitized_item_diagnostic():
     class FakeFetchClient:
         def post(self, _path, **_kwargs):
@@ -481,6 +537,7 @@ def test_target_m1_requires_wrapper_worker_and_three_vertical_capabilities(monke
         "candidate_sha": [source_sha],
         "marker": [smoke.REQUIRED_BROWSER_FETCH_PROBE_MARKER],
     }
+    assert f"?{parsed_browser_url.query}" == smoke.expected_browser_fetch_probe_content(source_sha)
 
     class TargetClient(FakeSmokeClient):
         def __init__(self):
@@ -525,10 +582,7 @@ def test_target_m1_requires_wrapper_worker_and_three_vertical_capabilities(monke
                 provenance = [{"provider": "builtin-fetch", "attempt": 1}]
             else:
                 assert target == browser_url
-                content = (
-                    f"?candidate_sha={source_sha}"
-                    f"&marker={smoke.REQUIRED_BROWSER_FETCH_PROBE_MARKER}"
-                )
+                content = smoke.expected_browser_fetch_probe_content(source_sha)
                 provenance = [
                     {"provider": "builtin-fetch", "attempt": 1, "outcome": "success"},
                     {"provider": "builtin-fetch", "attempt": 2, "outcome": "success"},
@@ -569,19 +623,35 @@ def test_target_m1_requires_wrapper_worker_and_three_vertical_capabilities(monke
     assert smoke.required_failures(results) == []
 
 
-def test_target_m1_browser_attempt_without_rendered_candidate_marker_fails():
+@pytest.mark.parametrize("invalid_kind", ["fixture-script", "wrapped-query", "url-echo"])
+def test_target_m1_browser_exact_rendered_proof_failure_is_not_hidden_by_secondary(
+    invalid_kind,
+):
     source_sha = "a" * 40
+    browser_urls = smoke.immutable_browser_fetch_probe_urls(source_sha)
+    expected_content = smoke.expected_browser_fetch_probe_content(source_sha)
+    assert expected_content is not None
+    browser_calls: list[str] = []
 
     class FalsePositiveClient:
         def post(self, path, *, body=None, **_kwargs):
             if path == "/api/v1/search":
                 return smoke.ResponseData(200, {"items": [{"id": "W1"}]}, 0.1)
             target = body["targets"][0]
-            content = (
-                smoke.REQUIRED_BUILTIN_FETCH_PROBE_MARKER + " evidence" * 80
-                if target == smoke.immutable_builtin_fetch_probe_url(source_sha)
-                else Path(smoke.REQUIRED_BROWSER_FETCH_PROBE_PATH).read_text(encoding="utf-8")
-            )
+            if target == smoke.immutable_builtin_fetch_probe_url(source_sha):
+                content = smoke.REQUIRED_BUILTIN_FETCH_PROBE_MARKER + " evidence" * 80
+            else:
+                browser_calls.append(target)
+                if target == browser_urls[1]:
+                    content = expected_content
+                elif invalid_kind == "fixture-script":
+                    content = Path(smoke.REQUIRED_BROWSER_FETCH_PROBE_PATH).read_text(
+                        encoding="utf-8"
+                    )
+                elif invalid_kind == "wrapped-query":
+                    content = f"prefix{expected_content}suffix"
+                else:
+                    content = browser_urls[0]
             return smoke.ResponseData(
                 200,
                 {
@@ -613,6 +683,220 @@ def test_target_m1_browser_attempt_without_rendered_candidate_marker_fails():
     results = smoke.run_target_m1_checks(FalsePositiveClient(), config)  # type: ignore[arg-type]
 
     assert {item.name: item.outcome for item in results}["browser-fetch"] == "fail"
+    assert browser_calls == [browser_urls[0]]
+
+
+def test_target_m1_browser_probe_uses_secondary_fixture_after_safe_primary_failure():
+    source_sha = "a" * 40
+    browser_urls = smoke.immutable_browser_fetch_probe_urls(source_sha)
+    assert len(browser_urls) == 2
+    browser_calls: list[str] = []
+
+    class RedundantFixtureClient:
+        def post(self, path, *, body=None, **_kwargs):
+            if path == "/api/v1/search":
+                return smoke.ResponseData(200, {"items": [{"id": "W1"}]}, 0.1)
+            target = body["targets"][0]
+            if target == smoke.immutable_builtin_fetch_probe_url(source_sha):
+                return smoke.ResponseData(
+                    200,
+                    {
+                        "items": [
+                            {
+                                "status": "success",
+                                "content": smoke.REQUIRED_BUILTIN_FETCH_PROBE_MARKER
+                                + " evidence" * 80,
+                                "provenance": [
+                                    {
+                                        "provider": "builtin-fetch",
+                                        "attempt": 1,
+                                        "outcome": "success",
+                                    }
+                                ],
+                            }
+                        ]
+                    },
+                    0.1,
+                )
+            browser_calls.append(target)
+            if target == browser_urls[0]:
+                return smoke.ResponseData(
+                    502,
+                    {
+                        "error": {
+                            "code": "worker_unavailable",
+                            "message": "Authorization: secret at https://private.invalid",
+                            "retryable": True,
+                            "request_id": "private-request-id",
+                        }
+                    },
+                    0.1,
+                )
+            assert target == browser_urls[1]
+            return smoke.ResponseData(
+                200,
+                {
+                    "items": [
+                        {
+                            "status": "success",
+                            "content": smoke.expected_browser_fetch_probe_content(source_sha),
+                            "provenance": [
+                                {
+                                    "provider": "builtin-fetch",
+                                    "attempt": 1,
+                                    "outcome": "success",
+                                },
+                                {
+                                    "provider": "builtin-fetch",
+                                    "attempt": 2,
+                                    "outcome": "success",
+                                },
+                            ],
+                        }
+                    ]
+                },
+                0.1,
+            )
+
+    config = smoke.SmokeConfig(
+        base_url="https://example.test",
+        expected_version="2.0.0rc2",
+        expected_source_sha=source_sha,
+        require_target_runtime=True,
+        request_timeout=1,
+    )
+
+    results = smoke.run_target_m1_checks(RedundantFixtureClient(), config)  # type: ignore[arg-type]
+    browser = {item.name: item for item in results}["browser-fetch"]
+
+    assert browser.outcome == "pass"
+    assert browser_calls == list(browser_urls)
+    assert "fixture=2" in browser.detail
+    assert "prior_failures=1" in browser.detail
+    assert browser.meta == {
+        "fixture_attempts": [
+            {
+                "fixture": 1,
+                "outcome": "fail",
+                "status": 502,
+                "error_code": "worker_unavailable",
+                "retryable": True,
+            },
+            {"fixture": 2, "outcome": "pass", "status": 200},
+        ]
+    }
+    serialized = json.dumps({"detail": browser.detail, "meta": browser.meta})
+    assert "private.invalid" not in serialized
+    assert "private-request-id" not in serialized
+    assert "Authorization" not in serialized
+
+
+def test_target_m1_browser_probe_reports_all_fixture_error_codes_without_raw_detail():
+    source_sha = "a" * 40
+    browser_urls = smoke.immutable_browser_fetch_probe_urls(source_sha)
+
+    class FailedFixtureClient:
+        def post(self, path, *, body=None, **_kwargs):
+            if path == "/api/v1/search":
+                return smoke.ResponseData(200, {"items": [{"id": "W1"}]}, 0.1)
+            target = body["targets"][0]
+            if target == smoke.immutable_builtin_fetch_probe_url(source_sha):
+                content = smoke.REQUIRED_BUILTIN_FETCH_PROBE_MARKER + " evidence" * 80
+                return smoke.ResponseData(
+                    200,
+                    {"items": [{"status": "success", "content": content, "provenance": []}]},
+                    0.1,
+                )
+            assert target in browser_urls
+            code = "worker_unavailable" if target == browser_urls[0] else "provider_timeout"
+            return smoke.ResponseData(
+                502 if code == "worker_unavailable" else 504,
+                {
+                    "error": {
+                        "code": code,
+                        "message": "secret raw detail",
+                        "retryable": True,
+                    }
+                },
+                0.1,
+            )
+
+    config = smoke.SmokeConfig(
+        base_url="https://example.test",
+        expected_version="2.0.0rc2",
+        expected_source_sha=source_sha,
+        require_target_runtime=True,
+        request_timeout=1,
+    )
+
+    results = smoke.run_target_m1_checks(FailedFixtureClient(), config)  # type: ignore[arg-type]
+    browser = {item.name: item for item in results}["browser-fetch"]
+
+    assert browser.outcome == "fail"
+    assert "fixture=1, status=502, error_code='worker_unavailable'" in browser.detail
+    assert "fixture=2, status=504, error_code='provider_timeout'" in browser.detail
+    assert "secret raw detail" not in browser.detail
+
+
+@pytest.mark.parametrize(
+    ("error", "expected_code"),
+    [
+        (
+            {
+                "code": "worker_protocol_mismatch",
+                "message": "must not be copied into evidence",
+                "retryable": False,
+            },
+            "worker_protocol_mismatch",
+        ),
+        ({"code": "worker_unavailable", "message": "missing retryability"}, "worker_unavailable"),
+        ({"code": "INVALID-CODE", "message": "invalid code", "retryable": True}, None),
+    ],
+)
+def test_target_m1_browser_probe_does_not_hide_nonretryable_contract_failure(
+    error,
+    expected_code,
+):
+    source_sha = "a" * 40
+    browser_urls = smoke.immutable_browser_fetch_probe_urls(source_sha)
+    browser_calls: list[str] = []
+
+    class ContractFailureClient:
+        def post(self, path, *, body=None, **_kwargs):
+            if path == "/api/v1/search":
+                return smoke.ResponseData(200, {"items": [{"id": "W1"}]}, 0.1)
+            target = body["targets"][0]
+            if target == smoke.immutable_builtin_fetch_probe_url(source_sha):
+                content = smoke.REQUIRED_BUILTIN_FETCH_PROBE_MARKER + " evidence" * 80
+                return smoke.ResponseData(
+                    200,
+                    {"items": [{"status": "success", "content": content, "provenance": []}]},
+                    0.1,
+                )
+            browser_calls.append(target)
+            return smoke.ResponseData(
+                409,
+                {"error": error},
+                0.1,
+            )
+
+    config = smoke.SmokeConfig(
+        base_url="https://example.test",
+        expected_version="2.0.0rc2",
+        expected_source_sha=source_sha,
+        require_target_runtime=True,
+        request_timeout=1,
+    )
+
+    results = smoke.run_target_m1_checks(ContractFailureClient(), config)  # type: ignore[arg-type]
+    browser = {item.name: item for item in results}["browser-fetch"]
+
+    assert browser.outcome == "fail"
+    assert browser_calls == [browser_urls[0]]
+    assert browser.meta["fixture_attempts"][0].get("error_code") == expected_code
+    assert "must not be copied" not in browser.detail
+    assert "missing retryability" not in browser.detail
+    assert "invalid code" not in browser.detail
 
 
 def test_target_m1_readiness_fails_when_worker_or_wrapper_provenance_drifts():


### PR DESCRIPTION
## Summary

- make the candidate-bound Browser Fetch M1 probe resilient to a single public fixture outage by adding an ordered secondary `text/html` host
- allow fallback only for an exact canonical retryable error/status pair; proof, protocol, policy, malformed, and non-retryable failures remain fail-closed
- require the rendered body to exactly equal the candidate SHA + stable marker query and retain the `builtin-fetch` attempt 2 success provenance gate
- prevent non-JSON bodies and transport exception text from entering deployment reports; retain only status, length/digest, stable error code, retryability, and fixture index
- document the dual-host evidence semantics

## Why

HFS M1 deployment run `30141289075` promoted exact candidate `85459e48e37f8615ce1a99eed0fb1e9bc9a7a332`. Surface, readiness/provenance, auth, OpenAlex Search, and builtin Fetch passed; the primary Browser Fetch fixture returned HTTP 502. The transaction then automatically restored the RC1 baseline and independently verified repo/runtime/source provenance. This PR fixes the evidence single point and improves safe diagnostics; it does not deploy, publish, tag, or change product routing.

## Validation

- `pytest tests/ -q --tb=short` — 2653 passed, 3 skipped
- `pytest tests/test_hf_space_smoke.py tests/test_release_candidate_workflows.py tests/test_functional_common.py -q` — 97 passed
- `python3 scripts/ci/run_profile.py --profile pro-cli --profile basic-cli` — PASS
- `ruff check src tests scripts tools deploy` — PASS
- `ruff format --check src tests scripts tools deploy` — PASS
- `python3 scripts/ci/check_architecture_dependencies.py` — PASS
- `PYTHONPATH=src python3 tools/gen_docs.py --check` — PASS
- `python3 tools/check_markdown_links.py` — PASS
- `actionlint .github/workflows/*.yml` — PASS
- independent read-only review — `proceed with notes`, no blocking findings

## Deployment boundary

This PR must use ordinary PR-context gates only. HFS promotion, rollback, pause, tag, Release, and publication jobs must remain skipped. A new M1 deployment transaction is permitted only after exact-head merge and readback on the resulting `main` candidate.
