### PR TITLE
fix(deploy): render M1 browser fixture after body exists

### DIFF
--- a/scripts/fixtures/hf-space-browser-probe.html
+++ b/scripts/fixtures/hf-space-browser-probe.html
@@ -1,1 +1,1 @@
-<script>document.body.textContent=location.search</script>
+<body><script>document.body.innerText=location.search</script>

--- a/tests/test_hf_space_smoke.py
+++ b/tests/test_hf_space_smoke.py
@@ -529,10 +529,12 @@ def test_target_m1_requires_wrapper_worker_and_three_vertical_capabilities(monke
     parsed_browser_url = urlparse(browser_url)
     browser_query = parse_qs(parsed_browser_url.query)
     browser_payload = base64.b64decode(unquote(parsed_browser_url.path.rsplit("/", 1)[-1]))
-    assert (
-        browser_payload.decode()
-        == Path(smoke.REQUIRED_BROWSER_FETCH_PROBE_PATH).read_text(encoding="utf-8").strip()
+    browser_fixture = (
+        Path(smoke.REQUIRED_BROWSER_FETCH_PROBE_PATH).read_text(encoding="utf-8").strip()
     )
+    assert browser_payload.decode() == browser_fixture
+    assert browser_fixture == "<body><script>document.body.innerText=location.search</script>"
+    assert len(browser_fixture) <= 63
     assert browser_query == {
         "candidate_sha": [source_sha],
         "marker": [smoke.REQUIRED_BROWSER_FETCH_PROBE_MARKER],


### PR DESCRIPTION
## Summary

- make the repo-owned M1 browser fixture create `<body>` before its script executes
- use the text-only `innerText` sink to render the exact candidate SHA + stable marker query
- keep the stripped fixture at 62 characters so builtin Fetch still classifies it as low quality and exercises Browser Worker fallback
- freeze the exact fixture payload and `<=63` invariant in deterministic tests

## Root cause

HFS M1 attempt 2 (`30142693729`) passed all prerequisite gates, target readiness/provenance, Admin, OpenAlex Search, builtin Fetch, and surface smoke. Browser Fetch failed with HTTP 502, canonical `provider_unavailable`, and `retryable=false`; the transaction then successfully restored the RC1 baseline.

A real browser reproduced the exact failure in the old 58-character fixture:

```html
<script>document.body.textContent=location.search</script>
```

The parser executes that script in the implicit `<head>`, where `document.body` is still `null`. It raises `TypeError` and leaves an empty body, which Browser Worker correctly rejects as invalid upstream content.

The new 62-character fixture:

```html
<body><script>document.body.innerText=location.search</script>
```

was verified in a real browser to render body text exactly equal to the canonical query without a new page error. `innerText` does not interpret query text as HTML.

## Validation

- `pytest tests/ -q --tb=short` — 2653 passed, 3 skipped
- `pytest tests/test_hf_space_smoke.py tests/test_release_candidate_workflows.py -q` — 84 passed
- `ruff check src tests scripts tools deploy` — PASS
- `ruff format --check src tests scripts tools deploy` — PASS
- `python3 scripts/ci/check_architecture_dependencies.py` — PASS
- `PYTHONPATH=src python3 tools/gen_docs.py --check` — PASS
- `python3 tools/check_markdown_links.py` — PASS
- `actionlint .github/workflows/*.yml` — PASS
- independent read-only review — `proceed`, no findings

## Deployment boundary

This PR does not deploy, publish, tag, or change the fallback/evidence contract. PR-context HFS promotion, rollback, and pause jobs must remain skipped. M1 attempt 3 is allowed only after exact-head merge and cleanup.
