### PR TITLE
feat(provider): migrate ERIC to Provider v2

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -196,6 +196,43 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
+  provider_v2_conformance:
+    name: v2 Provider v2 conformance
+    needs: bootstrap
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      PYTHONPATH: src
+      SOUWEN_PLUGIN_AUTOLOAD: "0"
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.candidate_sha || github.sha }}
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install deterministic test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,edition-pro]"
+
+      - name: Run Provider v2 conformance
+        run: |
+          pytest \
+            tests/test_provider_spi.py \
+            tests/test_manifest_registry_v2.py \
+            tests/test_provider_manager_v2.py \
+            tests/test_openalex_provider_v2.py \
+            tests/test_openalex_search_vertical_v2.py \
+            tests/test_builtin_fetch_provider_v2.py \
+            tests/test_uniapi_ark_provider_v2.py \
+            tests/test_paper/test_eric.py \
+            tests/test_eric_provider_v2.py \
+            -q
+
   server_profile:
     name: v2 pro-cli + basic-cli profile
     needs: bootstrap
@@ -360,7 +397,14 @@ jobs:
 
   release_readiness_summary:
     name: V2 CI / v2 release readiness summary
-    needs: [bootstrap, matrix_tests, server_profile, full_profile, plugin_profile, panel_build]
+    needs:
+      - bootstrap
+      - matrix_tests
+      - provider_v2_conformance
+      - server_profile
+      - full_profile
+      - plugin_profile
+      - panel_build
     if: ${{ always() }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -369,6 +413,7 @@ jobs:
         env:
           BOOTSTRAP_RESULT: ${{ needs.bootstrap.result }}
           MATRIX_RESULT: ${{ needs.matrix_tests.result }}
+          PROVIDER_V2_RESULT: ${{ needs.provider_v2_conformance.result }}
           SERVER_RESULT: ${{ needs.server_profile.result }}
           FULL_RESULT: ${{ needs.full_profile.result }}
           PLUGIN_RESULT: ${{ needs.plugin_profile.result }}
@@ -381,6 +426,7 @@ jobs:
           |---|---|---|
           | Bootstrap / import / wheel surface | $BOOTSTRAP_RESULT | v2 import surface, docs, registry baseline |
           | Full pytest matrix | $MATRIX_RESULT | Python 3.10-3.13 on Ubuntu, plus macOS/Windows 3.11 |
+          | Provider v2 conformance | $PROVIDER_V2_RESULT | deterministic SPI, manifest, manager, OpenAlex, builtin Fetch, UniAPI, and ERIC contracts |
           | pro-cli + basic-cli profile | $SERVER_RESULT | local API surface and CLI smoke |
           | full-cli runtime profile | $FULL_RESULT | edition-full source, doctor, plugin, fetch handler, and feature matrix surface |
           | Plugin profile | $PLUGIN_RESULT | example plugin install, contract tests, entry point discovery |
@@ -391,7 +437,7 @@ jobs:
           before cutting a release candidate tag.
           EOF
 
-          for result in "$BOOTSTRAP_RESULT" "$MATRIX_RESULT" "$SERVER_RESULT" "$FULL_RESULT" "$PLUGIN_RESULT" "$PANEL_RESULT"; do
+          for result in "$BOOTSTRAP_RESULT" "$MATRIX_RESULT" "$PROVIDER_V2_RESULT" "$SERVER_RESULT" "$FULL_RESULT" "$PLUGIN_RESULT" "$PANEL_RESULT"; do
             if [ "$result" != "success" ]; then
               echo "V2 release readiness gate failed: $result" >&2
               exit 1

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,6 +71,7 @@ Public docs 不要求读者理解历史路径；需要保留背景材料时，�
 | [internal/zero-key-benchmark.md](./internal/zero-key-benchmark.md) | 无 API Key 场景的时间点实测报告 |
 | [internal/spec-01-external-api-canonical-dto.md](./internal/spec-01-external-api-canonical-dto.md) | Proposed External API、Canonical DTO 与 current-to-target mapping |
 | [internal/spec-05-provider-spi-manifest-conformance.md](./internal/spec-05-provider-spi-manifest-conformance.md) | Proposed Provider SPI、Manifest 与 Conformance contract |
+| [internal/provider-migrations/eric-current-to-target.md](./internal/provider-migrations/eric-current-to-target.md) | ERIC Provider v2 的 current-to-target 字段边界、共存与 rollback 记录 |
 | [internal/spec-08-directory-dependency.md](./internal/spec-08-directory-dependency.md) | Proposed target directory、dependency rules 与 migration gate |
 | [internal/phase1/current-api-golden-fixtures.md](./internal/phase1/current-api-golden-fixtures.md) | Phase 1B current-only API behavior 与 language-neutral fixture 说明 |
 | [internal/phase1/provider-directory-current-behavior.md](./internal/phase1/provider-directory-current-behavior.md) | Phase 1B current-only Provider、config 与 directory dependency 事实基线 |

--- a/docs/internal/development-branching.md
+++ b/docs/internal/development-branching.md
@@ -79,6 +79,9 @@ dedicated v2 public-surface gate and runs on `main`.
   freshness, removed v1 import-surface leak check, and required v2 module check.
 - full pytest matrix: Python 3.10, 3.11, 3.12, and 3.13 on Ubuntu, plus Python
   3.11 on macOS and Windows.
+- Provider v2 conformance: deterministic SPI, manifest registry, Provider
+  Manager, OpenAlex, builtin Fetch, UniAPI, and ERIC tests without network,
+  browser runtime, or secrets.
 - `pro-cli` + `basic-cli` profile: local API surface tests and CLI smoke through
   `scripts/ci/run_profile.py`; legacy `server` / `minimal` aliases remain
   accepted during transition.

--- a/docs/internal/provider-migrations/eric-current-to-target.md
+++ b/docs/internal/provider-migrations/eric-current-to-target.md
@@ -1,0 +1,81 @@
+# ERIC Provider v2 current-to-target mapping and rollback
+
+Status: Phase 5 single-Provider migration record. This document describes the
+reviewed canonical projection and rollback boundary; it is not a claim of full
+legacy parity, release readiness, deployment, or live ERIC availability.
+
+## Current and target surfaces
+
+| Concern | Current surface | Target surface |
+|---|---|---|
+| Source declaration | `src/souwen/registry/sources/paper.py` (`eric`) | `ERIC_PROVIDER_MANIFEST` (`eric` / `eric-search`) |
+| Client | `souwen.paper.eric.EricClient` | Injected behind `EricSearchProvider` |
+| Capability | Legacy `search(query, rows, start)` | Provider SPI `search(SearchRequest, RequestContext, ExecutionContext)` |
+| Selection | Legacy registry dispatch | `ProviderManager` plus explicit target provider selection |
+| Authentication | Anonymous official API | No secret references |
+| Transport configuration | Legacy source channel can resolve `base_url`, proxy, headers, timeout, and retries | Fixed official base URL, no Provider-level proxy or header override; only `enabled`, `timeout_seconds`, and `max_retries` are accepted |
+
+The legacy declaration and client remain present during coexistence. Target
+execution must go through `ProviderManager`; the target adapter does not call
+another Provider or register another legacy source.
+
+## Canonical request and result mapping
+
+The target adapter accepts only the `paper` domain. It maps the normalized
+canonical query unchanged, maps `SearchPageRequest.limit` to ERIC `rows`, and
+uses `start=0`. ERIC offset pagination is not exposed as a target cursor in this
+slice. A supplied cursor, non-paper or mixed domains, and non-empty canonical
+filters fail closed before the client call.
+
+| Legacy normalized value | Canonical DTO value |
+|---|---|
+| `raw.eric_id` | `SearchItem.id = "eric:<ID>"` and `SearchIdentifier(scheme="eric", value=<ID>)` |
+| validated ERIC record URL | `SearchItem.url` |
+| `title` | `SearchItem.title` |
+| `abstract` | `SearchItem.snippet` |
+| `authors[].name` | `SearchAttributes.authors` |
+| `year` | `SearchAttributes.year` |
+| first `raw.publication_types` value | `SearchAttributes.resource_type` |
+| first `raw.language` value | `SearchAttributes.language` |
+| `raw.fulltext_authorized` | `SearchAttributes.open_access` for this bounded projection |
+| source identity and local rank | `Provenance(provider="eric", ...)` and `SearchItem.rank` |
+| `total_results` | `PageInfo.total` |
+
+The adapter deliberately does **not** expose the legacy `journal`, `pdf_url`,
+`raw.subjects`, `raw.isbn`, `raw.issn`, `raw.peer_reviewed`, `raw.publisher`,
+`raw.citation`, `raw.external_url`, or arbitrary upstream/raw payload fields.
+It also does not expose legacy offset pagination, upstream ordering guarantees,
+or a continuation cursor. Dropping these fields is an intentional canonical
+boundary, not proof that the target response is field-for-field equivalent to
+the legacy response. The `open_access` projection records the legacy boolean
+only; it does not establish a license, rights grant, or redistribution permission.
+
+## Default selection, coexistence, and rollback
+
+- OpenAlex remains the default target `paper` Search Provider. ERIC is not a
+  default fallback and is reached only by explicit target provider selection.
+- ERIC is not part of target runtime required readiness. Its absence or disabled
+  state must not make OpenAlex, builtin Fetch, or the overall required Provider
+  readiness fail.
+- Set `sources.eric.enabled: false` and reload/rebuild the target runtime to make
+  the ERIC target manifest ineligible. Read back the target Provider catalog and
+  verify that ERIC is unavailable, then verify that an omitted-provider paper
+  search still selects OpenAlex.
+- `sources.eric.enabled: false` is an eligibility rollback, not an automatic
+  route-to-legacy switch. Because the legacy and target declarations share the
+  `eric` source name, operators must not claim that this flag preserves legacy
+  ERIC dispatch. A code/deployment rollback uses the prior known-good candidate
+  while the legacy declaration and client remain in the source tree.
+- Do not remove the legacy declaration, change OpenAlex priority, or add ERIC to
+  required readiness as part of this slice.
+
+## Deterministic evidence boundary
+
+The `provider_v2_conformance` V2 CI job covers the SPI, manifest registry,
+Provider Manager, existing OpenAlex/builtin Fetch/UniAPI adapters, the ERIC
+legacy characterization, and ERIC Provider v2 conformance. It uses repository
+fixtures and fakes only: no network, browser runtime, or secret is required.
+
+Passing that job proves deterministic contract conformance for the checked
+candidate. It does not prove live ERIC behavior, complete legacy parity,
+deployment, release publication, or runtime promotion.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -192,6 +192,9 @@ v2 release candidate 已合回 `main`。`V2 CI` 继续作为 v2 public surface �
 - full pytest matrix：安装 `.[dev,edition-pro]`，覆盖 Ubuntu Python
   3.10/3.11/3.12/3.13，以及 macOS/Windows Python 3.11；避免把缺少 Server、MCP
   或 scraper runtime 误报成产品行为回归。
+- Provider v2 conformance：单独运行 SPI、manifest registry、Provider Manager、
+  OpenAlex、builtin Fetch、UniAPI 与 ERIC 的 deterministic tests；不访问网络、
+  browser runtime 或 secret，并由 V2 readiness summary fail closed 汇总。
 - pro-cli + basic-cli profile：安装 API 测试依赖后运行 `pro-cli` 和 `basic-cli`
   profile，并上传 JSON/Markdown report；`server` / `minimal` alias 仅用于过渡兼容。
 - full runtime profile：安装 `.[dev,edition-full]` 后运行 `full-cli` profile，覆盖核心

--- a/src/souwen/paper/eric.py
+++ b/src/souwen/paper/eric.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from souwen.common_runtime.transport import HttpTransport
 from souwen.core.exceptions import ParseError
 from souwen.core.http_client import SouWenHttpClient
 from souwen.models import Author, PaperResult, SearchResponse
@@ -21,8 +22,10 @@ _FULLTEXT_URL = "https://files.eric.ed.gov/fulltext/"
 class EricClient:
     """Search the official ERIC education-research metadata API without credentials."""
 
-    def __init__(self) -> None:
-        self._client = SouWenHttpClient(base_url=_BASE_URL, source_name="eric")
+    def __init__(self, transport: HttpTransport | None = None) -> None:
+        # Legacy callers retain source-channel config resolution. Provider v2
+        # injects an explicit Common Runtime transport from its resolved namespace.
+        self._client = transport or SouWenHttpClient(base_url=_BASE_URL, source_name="eric")
 
     async def __aenter__(self) -> EricClient:
         await self._client.__aenter__()
@@ -35,6 +38,10 @@ class EricClient:
         exc_tb: Any,
     ) -> None:
         await self._client.__aexit__(exc_type, exc_val, exc_tb)
+
+    async def close(self) -> None:
+        """Close the owned transport through a public lifecycle operation."""
+        await self._client.close()
 
     @staticmethod
     def _as_strings(value: object) -> list[str]:

--- a/src/souwen/providers/information_sources/eric/__init__.py
+++ b/src/souwen/providers/information_sources/eric/__init__.py
@@ -1,0 +1,6 @@
+"""Built-in ERIC Provider v2 package."""
+
+from .adapter import EricClientProtocol, EricSearchProvider
+from .manifest import ERIC_PROVIDER_MANIFEST
+
+__all__ = ["ERIC_PROVIDER_MANIFEST", "EricClientProtocol", "EricSearchProvider"]

--- a/src/souwen/providers/information_sources/eric/adapter.py
+++ b/src/souwen/providers/information_sources/eric/adapter.py
@@ -1,0 +1,298 @@
+"""Provider v2 adapter for the injected anonymous ERIC client."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import re
+from collections.abc import Mapping, Sequence
+from contextlib import suppress
+from typing import Any, Protocol
+from urllib.parse import urlsplit
+
+from souwen.common_runtime.errors import SouWenError
+from souwen.common_runtime.transport.errors import RateLimitError, SourceUnavailableError
+from souwen.platform.provider_spi import (
+    ExecutionContext,
+    PageInfo,
+    ProviderError,
+    ProviderErrorCode,
+    ProviderProbe,
+    Provenance,
+    RequestContext,
+    SearchAttributes,
+    SearchIdentifier,
+    SearchItem,
+    SearchMeta,
+    SearchPage,
+    SearchRequest,
+)
+
+
+_PROVIDER_ID = "eric"
+_ERIC_ID_PATTERN = re.compile(r"^[A-Z]{2}[0-9]+$")
+
+
+class EricClientProtocol(Protocol):
+    """Minimal legacy ERIC client surface injected by the composition root."""
+
+    async def search(self, query: str, rows: int = 10, start: int = 0) -> Any:
+        """Return a normalized legacy ``SearchResponse`` compatible object."""
+
+    async def close(self) -> None:
+        """Close the explicitly injected transport."""
+
+
+class EricSearchProvider:
+    """Search-only Provider v2 adapter for official ERIC metadata."""
+
+    capability = "search"
+
+    def __init__(self, client: EricClientProtocol, *, enabled: bool = True) -> None:
+        self._client = client
+        self._enabled = enabled
+        self._closed = False
+
+    async def search(
+        self,
+        request: SearchRequest,
+        context: RequestContext,
+        execution: ExecutionContext,
+    ) -> SearchPage:
+        """Execute one bounded first-page ERIC search and canonicalize the response."""
+        execution.raise_if_cancelled_or_expired()
+        if self._closed or not self._enabled:
+            raise ProviderError(ProviderErrorCode.INVALID_CONFIG, provider_id=_PROVIDER_ID)
+        if request.domains != ("paper",):
+            raise ProviderError(ProviderErrorCode.INVALID_REQUEST, provider_id=_PROVIDER_ID)
+        if request.page is not None and request.page.cursor is not None:
+            raise ProviderError(ProviderErrorCode.INVALID_REQUEST, provider_id=_PROVIDER_ID)
+        if request.filters is not None and request.filters.model_dump(exclude_none=True):
+            raise ProviderError(ProviderErrorCode.INVALID_REQUEST, provider_id=_PROVIDER_ID)
+
+        limit = request.page.limit if request.page is not None else 10
+        try:
+            response = await _await_with_execution(
+                self._client.search(request.query, rows=limit, start=0),
+                execution,
+            )
+            execution.raise_if_cancelled_or_expired()
+            return _to_search_page(response, limit=limit, context=context)
+        except asyncio.CancelledError:
+            raise
+        except ProviderError:
+            raise
+        except RateLimitError as exc:
+            raise ProviderError(
+                ProviderErrorCode.RATE_LIMITED,
+                provider_id=_PROVIDER_ID,
+                retry_after_seconds=getattr(exc, "retry_after", None),
+            ) from None
+        except TimeoutError:
+            raise ProviderError(
+                ProviderErrorCode.DEADLINE_EXCEEDED, provider_id=_PROVIDER_ID
+            ) from None
+        except SourceUnavailableError:
+            raise ProviderError(
+                ProviderErrorCode.PROVIDER_UNAVAILABLE, provider_id=_PROVIDER_ID
+            ) from None
+        except SouWenError as exc:
+            code = (
+                ProviderErrorCode.INVALID_CONFIG
+                if type(exc).__name__ == "ConfigError"
+                else ProviderErrorCode.INVALID_UPSTREAM_RESPONSE
+            )
+            raise ProviderError(code, provider_id=_PROVIDER_ID) from None
+        except (AttributeError, TypeError, ValueError):
+            raise ProviderError(
+                ProviderErrorCode.INVALID_UPSTREAM_RESPONSE, provider_id=_PROVIDER_ID
+            ) from None
+        except Exception:
+            raise ProviderError(
+                ProviderErrorCode.PROVIDER_UNAVAILABLE, provider_id=_PROVIDER_ID
+            ) from None
+
+    async def probe(self, execution: ExecutionContext) -> ProviderProbe:
+        """Report local eligibility without issuing a network request."""
+        execution.raise_if_cancelled_or_expired()
+        return ProviderProbe(
+            provider=_PROVIDER_ID,
+            capability="search",
+            status="unavailable" if self._closed or not self._enabled else "available",
+        )
+
+    async def close(self) -> None:
+        """Close the injected client once and remain retryable if cancellation interrupts close."""
+        if self._closed:
+            return
+        self._closed = True
+        closer = getattr(self._client, "aclose", None) or getattr(self._client, "close", None)
+        if closer is None:
+            return
+        try:
+            result = closer()
+            if inspect.isawaitable(result):
+                await result
+        except asyncio.CancelledError:
+            self._closed = False
+            raise
+
+
+async def _await_with_execution(value: Any, execution: ExecutionContext) -> Any:
+    provider_task = asyncio.ensure_future(value)
+    cancellation_task = asyncio.create_task(execution.cancel_event.wait())
+    try:
+        done, _pending = await asyncio.wait(
+            {provider_task, cancellation_task},
+            timeout=execution.remaining_seconds,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if provider_task in done:
+            return await provider_task
+        provider_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await provider_task
+        code = (
+            ProviderErrorCode.CANCELLED
+            if cancellation_task in done
+            else ProviderErrorCode.DEADLINE_EXCEEDED
+        )
+        raise ProviderError(code, provider_id=_PROVIDER_ID)
+    finally:
+        cancellation_task.cancel()
+        if not provider_task.done():
+            provider_task.cancel()
+        await asyncio.gather(provider_task, cancellation_task, return_exceptions=True)
+
+
+def _to_search_page(response: Any, *, limit: int, context: RequestContext) -> SearchPage:
+    if getattr(response, "source", None) != _PROVIDER_ID:
+        raise ValueError("unexpected legacy response source")
+    results = getattr(response, "results", None)
+    total = getattr(response, "total_results", None)
+    response_page = getattr(response, "page", None)
+    response_limit = getattr(response, "per_page", None)
+    if not isinstance(results, Sequence) or isinstance(results, (str, bytes)):
+        raise ValueError("invalid legacy search results")
+    if total is not None and (not isinstance(total, int) or isinstance(total, bool) or total < 0):
+        raise ValueError("invalid legacy result total")
+    if response_page != 1 or response_limit != limit:
+        raise ValueError("legacy page does not match canonical request")
+    if len(results) > limit:
+        raise ValueError("legacy result count exceeds canonical limit")
+    if total is not None and total < len(results):
+        raise ValueError("legacy result total is smaller than the returned page")
+
+    items = tuple(_to_search_item(item, rank=index) for index, item in enumerate(results, 1))
+    return SearchPage(
+        items=items,
+        page=PageInfo(limit=limit, next_cursor=None, total=total),
+        meta=SearchMeta(requested=(_PROVIDER_ID,), succeeded=(_PROVIDER_ID,)),
+        context=context,
+    )
+
+
+def _to_search_item(paper: Any, *, rank: int) -> SearchItem:
+    if getattr(paper, "source", None) != _PROVIDER_ID:
+        raise ValueError("unexpected legacy paper source")
+    raw = getattr(paper, "raw", None)
+    if not isinstance(raw, Mapping):
+        raise ValueError("invalid legacy paper attributes")
+    eric_id = _eric_id(raw.get("eric_id"))
+    source_url = _eric_url(getattr(paper, "source_url", None), eric_id)
+
+    publication_types = _string_tuple(raw.get("publication_types"))
+    languages = _string_tuple(raw.get("language"))
+    fulltext = raw.get("fulltext_authorized")
+    if fulltext is not None and not isinstance(fulltext, bool):
+        raise ValueError("invalid ERIC fulltext flag")
+
+    return SearchItem(
+        id=f"eric:{eric_id}",
+        title=_required_text(getattr(paper, "title", None)),
+        url=source_url,
+        snippet=_optional_text(getattr(paper, "abstract", None)),
+        rank=rank,
+        provenance=(Provenance(provider=_PROVIDER_ID, attempt=1, outcome="success"),),
+        attributes=SearchAttributes(
+            year=_optional_int(getattr(paper, "year", None)),
+            authors=_author_names(getattr(paper, "authors", None)),
+            identifiers=(SearchIdentifier(scheme="eric", value=eric_id),),
+            resource_type=publication_types[0] if publication_types else None,
+            language=languages[0] if languages else None,
+            open_access=fulltext,
+        ),
+    )
+
+
+def _eric_id(value: Any) -> str:
+    identifier = _required_text(value).upper()
+    if _ERIC_ID_PATTERN.fullmatch(identifier) is None:
+        raise ValueError("invalid ERIC identifier")
+    return identifier
+
+
+def _eric_url(value: Any, eric_id: str) -> str:
+    url = _required_text(value)
+    parsed = urlsplit(url)
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname != "eric.ed.gov"
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.port is not None
+        or parsed.path != "/"
+        or parsed.fragment
+        or parsed.query != f"id={eric_id}"
+    ):
+        raise ValueError("invalid ERIC record URL")
+    return f"https://eric.ed.gov/?id={eric_id}"
+
+
+def _required_text(value: Any) -> str:
+    normalized = _optional_text(value)
+    if normalized is None:
+        raise ValueError("missing required text")
+    return normalized
+
+
+def _optional_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError("invalid text")
+    normalized = value.strip()
+    return normalized or None
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool) or not 0 <= value <= 9999:
+        raise ValueError("invalid integer")
+    return value
+
+
+def _string_tuple(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise ValueError("invalid string sequence")
+    normalized = tuple(_required_text(item) for item in value)
+    if len(normalized) != len(set(normalized)):
+        raise ValueError("duplicate string sequence")
+    return normalized
+
+
+def _author_names(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise ValueError("invalid author sequence")
+    names = tuple(_required_text(getattr(author, "name", None)) for author in value)
+    if len(names) != len(set(names)):
+        raise ValueError("duplicate authors")
+    return names
+
+
+__all__ = ["EricClientProtocol", "EricSearchProvider"]

--- a/src/souwen/providers/information_sources/eric/manifest.py
+++ b/src/souwen/providers/information_sources/eric/manifest.py
@@ -1,0 +1,44 @@
+"""Static Provider v2 declaration for the anonymous ERIC search API."""
+
+from __future__ import annotations
+
+from souwen.platform.manifest_registry import ProviderManifest
+
+
+ERIC_PROVIDER_MANIFEST = ProviderManifest.model_validate(
+    {
+        "schema_version": 2,
+        "id": "eric",
+        "version": "2.0.0rc2",
+        "contract_version": "provider-v2",
+        "capabilities": ["search"],
+        "adapters": [
+            {
+                "id": "eric-search",
+                "capability": "search",
+                "export": "EricSearchProvider",
+                "availability": "configured",
+            }
+        ],
+        "configuration": {
+            "schema_reference": "eric-provider-config-v1",
+            "unknown_key_policy": "reject",
+            "non_secret_keys": ["enabled", "max_retries", "timeout_seconds"],
+        },
+        "secrets": {"references": []},
+        "network": {
+            "egress_hosts": ["api.ies.ed.gov"],
+            "proxy_supported": False,
+            "browser_required": False,
+        },
+        "risk": {"authenticated": False, "costed": False},
+        "observability": {"dimensions": ["provider", "adapter", "capability", "outcome"]},
+        "compatibility": {
+            "contract_versions": ["provider-v2"],
+            "config_schema_versions": ["eric-provider-config-v1"],
+        },
+    }
+)
+
+
+__all__ = ["ERIC_PROVIDER_MANIFEST"]

--- a/src/souwen/server/v2_runtime.py
+++ b/src/souwen/server/v2_runtime.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from souwen import __version__
 from souwen.common_runtime.observability import get_request_id, get_source_sha
+from souwen.common_runtime.transport import HttpTransport
 from souwen.config import SouWenConfig
 from souwen.delivery.api import (
     ProviderCatalogItem,
@@ -24,6 +25,7 @@ from souwen.modules.search.application import (
     OrderedSearchProviderSelector,
     SearchProviderSelection,
 )
+from souwen.paper.eric import EricClient
 from souwen.paper.openalex import OpenAlexClient
 from souwen.platform.provider_manager import ProviderManager
 from souwen.platform.provider_spi import (
@@ -39,6 +41,7 @@ from souwen.providers.information_sources.openalex import (
     OPENALEX_PROVIDER_MANIFEST,
     OpenAlexSearchProvider,
 )
+from souwen.providers.information_sources.eric import ERIC_PROVIDER_MANIFEST, EricSearchProvider
 from souwen.providers.llm_sources.uniapi_ark_annotations import (
     UNIAPI_ARK_MANIFESTS,
     UniApiArkAnnotationsDeepSeekProvider,
@@ -101,6 +104,17 @@ def _configuration_resolver(config: SouWenConfig):
             if not config.is_source_enabled("openalex", default=True):
                 raise ValueError("provider is disabled")
             return {"enabled": True}
+        if manifest.id == "eric":
+            if not config.is_source_enabled("eric", default=True):
+                raise ValueError("provider is disabled")
+            source = config.get_source_config("eric")
+            configuration = {
+                "enabled": True,
+                "max_retries": config.max_retries,
+                "timeout_seconds": source.timeout or config.timeout,
+            }
+            _validate_eric_configuration(configuration)
+            return configuration
         if manifest.id == "builtin-fetch":
             if not config.is_source_enabled("builtin-fetch", default=True):
                 raise ValueError("provider is disabled")
@@ -148,6 +162,38 @@ def _browser_client() -> BrowserWorkerClient | None:
     )
 
 
+def _validate_eric_configuration(configuration) -> None:
+    """Validate ERIC transport options during Provider Manager preflight."""
+    timeout = configuration.get("timeout_seconds")
+    max_retries = configuration.get("max_retries")
+    if (
+        not isinstance(timeout, (int, float))
+        or isinstance(timeout, bool)
+        or not 0 < timeout <= 120
+        or not isinstance(max_retries, int)
+        or isinstance(max_retries, bool)
+        or not 0 <= max_retries <= 10
+    ):
+        raise ValueError("invalid ERIC transport configuration")
+
+
+def _build_eric_provider(configuration, _secrets) -> EricSearchProvider:
+    """Build ERIC only from the Provider Manager's resolved namespace."""
+    _validate_eric_configuration(configuration)
+    transport = HttpTransport(
+        base_url="https://api.ies.ed.gov",
+        headers={"User-Agent": f"SouWen/{__version__}"},
+        timeout=configuration["timeout_seconds"],
+        max_retries=configuration["max_retries"],
+        proxy=None,
+        follow_redirects=False,
+    )
+    return EricSearchProvider(
+        EricClient(transport=transport),
+        enabled=configuration["enabled"],
+    )
+
+
 def _catalog_items(
     config: SouWenConfig,
     manager: ProviderManager,
@@ -161,6 +207,12 @@ def _catalog_items(
             "openalex-search",
             "search",
             config.is_source_enabled("openalex", default=True),
+        ),
+        (
+            "eric",
+            "eric-search",
+            "search",
+            config.is_source_enabled("eric", default=True),
         ),
         (
             "builtin-fetch",
@@ -228,6 +280,12 @@ def build_target_runtime(config: SouWenConfig) -> TargetRuntime:
         provider_type=OpenAlexSearchProvider,
     )
     manager.register_factory(
+        package_id="eric",
+        export="EricSearchProvider",
+        factory=_build_eric_provider,
+        provider_type=EricSearchProvider,
+    )
+    manager.register_factory(
         package_id="builtin-fetch",
         export="BuiltinFetchProvider",
         factory=lambda configuration, _secrets: BuiltinFetchProvider(
@@ -251,6 +309,7 @@ def build_target_runtime(config: SouWenConfig) -> TargetRuntime:
     manager.discover(
         (
             OPENALEX_PROVIDER_MANIFEST,
+            ERIC_PROVIDER_MANIFEST,
             BUILTIN_FETCH_MANIFEST,
             *UNIAPI_ARK_MANIFESTS,
         )
@@ -265,6 +324,11 @@ def build_target_runtime(config: SouWenConfig) -> TargetRuntime:
                         provider=ProviderRef(id="openalex", kind="search"),
                         adapter_id="openalex-search",
                         yaml_priority=1,
+                    ),
+                    SearchProviderSelection(
+                        provider=ProviderRef(id="eric", kind="search"),
+                        adapter_id="eric-search",
+                        yaml_priority=2,
                     ),
                 )
             }

--- a/tests/test_eric_provider_v2.py
+++ b/tests/test_eric_provider_v2.py
@@ -1,0 +1,797 @@
+"""Deterministic conformance and runtime integration for ERIC Provider v2."""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from souwen.common_runtime.transport.errors import RateLimitError, SourceUnavailableError
+from souwen.config import SouWenConfig
+from souwen.core.exceptions import ConfigError, ParseError
+from souwen.delivery.api import create_target_delivery_app
+from souwen.models import Author, PaperResult, SearchResponse
+from souwen.platform.provider_manager import ProviderManager, ProviderManagerError
+from souwen.platform.provider_spi import (
+    ExecutionContext,
+    ProviderError,
+    ProviderErrorCode,
+    ProviderRef,
+    RequestContext,
+    SearchFilters,
+    SearchPageRequest,
+    SearchRequest,
+)
+from souwen.providers.information_sources.eric import (
+    ERIC_PROVIDER_MANIFEST,
+    EricSearchProvider,
+)
+from souwen.providers.information_sources.openalex import (
+    OPENALEX_PROVIDER_MANIFEST,
+    OpenAlexSearchProvider,
+)
+from souwen.registry import get
+from souwen.server.v2_runtime import build_target_runtime
+
+
+class FakeEricClient:
+    def __init__(self, response: SearchResponse | Exception) -> None:
+        self.response = response
+        self.calls: list[dict[str, object]] = []
+        self.close_count = 0
+
+    async def search(self, query: str, rows: int = 10, start: int = 0):
+        self.calls.append({"query": query, "rows": rows, "start": start})
+        if isinstance(self.response, Exception):
+            raise self.response
+        return self.response
+
+    async def close(self) -> None:
+        self.close_count += 1
+
+
+class FakeOpenAlexClient:
+    def __init__(self) -> None:
+        self.close_count = 0
+
+    async def search(self, _query, filters=None, sort=None, page=1, per_page=10):
+        del filters, sort
+        response = _openalex_response()
+        response.page = page
+        response.per_page = per_page
+        return response
+
+    async def close(self) -> None:
+        self.close_count += 1
+
+
+def _paper(**overrides: object) -> PaperResult:
+    values: dict[str, object] = {
+        "source": "eric",
+        "title": "Teaching Machine Learning in Secondary Schools",
+        "authors": [Author(name="Ada Teacher"), Author(name="Grace Researcher")],
+        "abstract": "A bounded education-research fixture.",
+        "year": 2024,
+        "source_url": "https://eric.ed.gov/?id=EJ1234567",
+        "raw": {
+            "eric_id": "EJ1234567",
+            "publication_types": ["Journal Articles"],
+            "language": ["English"],
+            "fulltext_authorized": True,
+        },
+    }
+    values.update(overrides)
+    return PaperResult(**values)
+
+
+def _response(*papers: PaperResult, per_page: int = 10) -> SearchResponse:
+    return SearchResponse(
+        query="machine learning",
+        source="eric",
+        total_results=len(papers),
+        page=1,
+        per_page=per_page,
+        results=list(papers),
+    )
+
+
+def _openalex_response() -> SearchResponse:
+    return SearchResponse(
+        query="machine learning",
+        source="openalex",
+        total_results=1,
+        page=1,
+        per_page=10,
+        results=[
+            PaperResult(
+                source="openalex",
+                title="OpenAlex fallback",
+                authors=[Author(name="Fallback Author")],
+                doi="10.1000/fallback",
+                year=2024,
+                source_url="https://openalex.org/W1234567890",
+                raw={"type": "article", "is_oa": True},
+            )
+        ],
+    )
+
+
+def _request(**overrides: object) -> SearchRequest:
+    values: dict[str, object] = {
+        "query": "machine learning",
+        "domains": ("paper",),
+    }
+    values.update(overrides)
+    return SearchRequest(**values)
+
+
+def _context() -> RequestContext:
+    return RequestContext(request_id="eric-provider-v2")
+
+
+def _execution() -> ExecutionContext:
+    return ExecutionContext.with_timeout(5)
+
+
+def test_manifest_matches_legacy_registry_without_creating_a_second_catalog() -> None:
+    legacy = get("eric")
+
+    assert ERIC_PROVIDER_MANIFEST.id == legacy.name == "eric"
+    assert ERIC_PROVIDER_MANIFEST.version == "2.0.0rc2"
+    assert ERIC_PROVIDER_MANIFEST.contract_version == "provider-v2"
+    assert ERIC_PROVIDER_MANIFEST.capabilities == ("search",)
+    assert ERIC_PROVIDER_MANIFEST.adapters[0].id == "eric-search"
+    assert ERIC_PROVIDER_MANIFEST.adapters[0].export == "EricSearchProvider"
+    assert ERIC_PROVIDER_MANIFEST.configuration.non_secret_keys == (
+        "enabled",
+        "max_retries",
+        "timeout_seconds",
+    )
+    assert ERIC_PROVIDER_MANIFEST.secrets.references == ()
+    assert ERIC_PROVIDER_MANIFEST.network.egress_hosts == ("api.ies.ed.gov",)
+    assert ERIC_PROVIDER_MANIFEST.network.proxy_supported is False
+    assert ERIC_PROVIDER_MANIFEST.network.browser_required is False
+    assert legacy.domain == "paper"
+    assert legacy.integration == "official_api"
+    assert legacy.resolved_auth_requirement == "none"
+    assert legacy.capabilities == {"search"}
+
+
+@pytest.mark.asyncio
+async def test_search_maps_official_response_to_canonical_page() -> None:
+    client = FakeEricClient(_response(_paper(), per_page=7))
+    provider = EricSearchProvider(client)
+
+    page = await provider.search(
+        _request(page=SearchPageRequest(limit=7)),
+        _context(),
+        _execution(),
+    )
+
+    assert client.calls == [{"query": "machine learning", "rows": 7, "start": 0}]
+    assert page.page.limit == 7
+    assert page.page.next_cursor is None
+    assert page.page.total == 1
+    assert page.meta.requested == ("eric",)
+    assert page.meta.succeeded == ("eric",)
+    assert page.meta.failed == ()
+    item = page.items[0]
+    assert item.id == "eric:EJ1234567"
+    assert str(item.url) == "https://eric.ed.gov/?id=EJ1234567"
+    assert item.rank == 1
+    assert item.provenance[0].provider == "eric"
+    assert item.attributes is not None
+    assert item.attributes.identifiers[0].model_dump() == {
+        "scheme": "eric",
+        "value": "EJ1234567",
+    }
+    assert item.attributes.authors == ("Ada Teacher", "Grace Researcher")
+    assert item.attributes.year == 2024
+    assert item.attributes.resource_type == "Journal Articles"
+    assert item.attributes.language == "English"
+    assert item.attributes.open_access is True
+
+
+@pytest.mark.asyncio
+async def test_record_url_host_casing_is_normalized_to_one_canonical_url() -> None:
+    page = await EricSearchProvider(
+        FakeEricClient(_response(_paper(source_url="https://ERIC.ED.GOV/?id=EJ1234567")))
+    ).search(_request(), _context(), _execution())
+
+    assert str(page.items[0].url) == "https://eric.ed.gov/?id=EJ1234567"
+
+
+@pytest.mark.asyncio
+async def test_empty_response_is_canonical_success() -> None:
+    page = await EricSearchProvider(FakeEricClient(_response())).search(
+        _request(), _context(), _execution()
+    )
+
+    assert page.items == ()
+    assert page.page.total == 0
+    assert page.meta.succeeded == ("eric",)
+
+
+@pytest.mark.asyncio
+async def test_unsupported_domain_cursor_and_filters_fail_before_client_call() -> None:
+    client = FakeEricClient(_response(_paper()))
+    provider = EricSearchProvider(client)
+    requests = (
+        _request(domains=("web",)),
+        _request(domains=("paper", "web")),
+        _request(page=SearchPageRequest(limit=10, cursor="opaque")),
+        _request(filters=SearchFilters(year_from=2020)),
+    )
+
+    for request in requests:
+        with pytest.raises(ProviderError) as exc_info:
+            await provider.search(request, _context(), _execution())
+        assert exc_info.value.code is ProviderErrorCode.INVALID_REQUEST
+
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("failure", "expected"),
+    [
+        (RateLimitError("token=not-exposed", retry_after=4), ProviderErrorCode.RATE_LIMITED),
+        (TimeoutError("token=not-exposed"), ProviderErrorCode.DEADLINE_EXCEEDED),
+        (ConfigError("private", "ERIC"), ProviderErrorCode.INVALID_CONFIG),
+        (SourceUnavailableError("token=not-exposed"), ProviderErrorCode.PROVIDER_UNAVAILABLE),
+        (ParseError("token=not-exposed"), ProviderErrorCode.INVALID_UPSTREAM_RESPONSE),
+        (RuntimeError("token=not-exposed"), ProviderErrorCode.PROVIDER_UNAVAILABLE),
+    ],
+)
+async def test_error_categories_are_safe_and_distinct(failure: Exception, expected) -> None:
+    provider = EricSearchProvider(FakeEricClient(failure))
+
+    with pytest.raises(ProviderError) as exc_info:
+        await provider.search(_request(), _context(), _execution())
+
+    assert exc_info.value.code is expected
+    assert "not-exposed" not in str(exc_info.value)
+    if expected is ProviderErrorCode.RATE_LIMITED:
+        assert exc_info.value.retry_after_seconds == 4
+
+
+@pytest.mark.asyncio
+async def test_policy_blocked_provider_error_is_preserved() -> None:
+    provider = EricSearchProvider(
+        FakeEricClient(ProviderError(ProviderErrorCode.POLICY_BLOCKED, provider_id="eric"))
+    )
+
+    with pytest.raises(ProviderError) as exc_info:
+        await provider.search(_request(), _context(), _execution())
+
+    assert exc_info.value.code is ProviderErrorCode.POLICY_BLOCKED
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "response",
+    [
+        SearchResponse(
+            query="machine learning",
+            source="wrong",
+            total_results=1,
+            page=1,
+            per_page=10,
+            results=[_paper()],
+        ),
+        _response(_paper(raw={"eric_id": "invalid"})),
+        _response(_paper(source_url="https://example.com/?id=EJ1234567")),
+        _response(_paper(source_url="https://eric.ed.gov/?id=EJ7654321")),
+        _response(_paper(source_url="https://user:password@eric.ed.gov/?id=EJ1234567")),
+        _response(_paper(source_url="https://eric.ed.gov:443/?id=EJ1234567")),
+        _response(_paper(source_url="https://eric.ed.gov/?id=EJ1234567#fragment")),
+        _response(_paper(source_url="https://eric.ed.gov/?id=EJ1234567&extra=value")),
+        _response(_paper(source_url="https://eric.ed.gov/?id=EJ1234567&unused=")),
+        _response(_paper(source_url="https://eric.ed.gov/?id=EJ1234567&id=EJ1234567")),
+        _response(_paper(source_url="https://eric.ed.gov/?%69d=EJ1234567")),
+    ],
+)
+async def test_invalid_upstream_identity_and_url_fail_closed(response: SearchResponse) -> None:
+    provider = EricSearchProvider(FakeEricClient(response))
+
+    with pytest.raises(ProviderError) as exc_info:
+        await provider.search(_request(), _context(), _execution())
+
+    assert exc_info.value.code is ProviderErrorCode.INVALID_UPSTREAM_RESPONSE
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("page", 2),
+        ("per_page", 9),
+        ("total_results", -1),
+    ],
+)
+async def test_invalid_upstream_page_metadata_fails_closed(field: str, value: int) -> None:
+    response = _response(_paper())
+    setattr(response, field, value)
+
+    with pytest.raises(ProviderError) as exc_info:
+        await EricSearchProvider(FakeEricClient(response)).search(
+            _request(), _context(), _execution()
+        )
+
+    assert exc_info.value.code is ProviderErrorCode.INVALID_UPSTREAM_RESPONSE
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("response", "limit"),
+    [
+        (_response(_paper(), _paper(), per_page=1), 1),
+        (_response(_paper(), _paper()), 10),
+    ],
+)
+async def test_inconsistent_result_count_or_total_fails_closed(
+    response: SearchResponse,
+    limit: int,
+) -> None:
+    if limit == 10:
+        response.total_results = 1
+
+    with pytest.raises(ProviderError) as exc_info:
+        await EricSearchProvider(FakeEricClient(response)).search(
+            _request(page=SearchPageRequest(limit=limit)),
+            _context(),
+            _execution(),
+        )
+
+    assert exc_info.value.code is ProviderErrorCode.INVALID_UPSTREAM_RESPONSE
+
+
+@pytest.mark.asyncio
+async def test_in_flight_cancellation_cancels_and_awaits_client_task() -> None:
+    entered = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    class BlockingClient:
+        async def search(self, *_args, **_kwargs):
+            entered.set()
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+    cancel_event = asyncio.Event()
+    task = asyncio.create_task(
+        EricSearchProvider(BlockingClient()).search(
+            _request(),
+            _context(),
+            ExecutionContext.with_timeout(5, cancel_event=cancel_event),
+        )
+    )
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    cancel_event.set()
+
+    with pytest.raises(ProviderError) as exc_info:
+        await asyncio.wait_for(task, timeout=1)
+
+    assert exc_info.value.code is ProviderErrorCode.CANCELLED
+    assert cancelled.is_set()
+
+
+@pytest.mark.asyncio
+async def test_in_flight_deadline_cancels_and_awaits_client_task() -> None:
+    entered = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    class BlockingClient:
+        async def search(self, *_args, **_kwargs):
+            entered.set()
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+    task = asyncio.create_task(
+        EricSearchProvider(BlockingClient()).search(
+            _request(),
+            _context(),
+            ExecutionContext.with_timeout(0.05),
+        )
+    )
+    await asyncio.wait_for(entered.wait(), timeout=1)
+
+    with pytest.raises(ProviderError) as exc_info:
+        await asyncio.wait_for(task, timeout=1)
+
+    assert exc_info.value.code is ProviderErrorCode.DEADLINE_EXCEEDED
+    assert cancelled.is_set()
+
+
+@pytest.mark.asyncio
+async def test_outer_task_cancellation_propagates_and_cleans_client_task() -> None:
+    entered = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    class BlockingClient:
+        async def search(self, *_args, **_kwargs):
+            entered.set()
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+    provider = EricSearchProvider(BlockingClient())
+    task = asyncio.create_task(provider.search(_request(), _context(), _execution()))
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert cancelled.is_set()
+    await provider.close()
+    assert (await provider.probe(_execution())).status == "unavailable"
+
+
+@pytest.mark.asyncio
+async def test_pre_cancelled_execution_does_not_call_client() -> None:
+    client = FakeEricClient(_response(_paper()))
+    event = asyncio.Event()
+    event.set()
+
+    with pytest.raises(ProviderError) as exc_info:
+        await EricSearchProvider(client).search(
+            _request(),
+            _context(),
+            ExecutionContext.with_timeout(5, cancel_event=event),
+        )
+
+    assert exc_info.value.code is ProviderErrorCode.CANCELLED
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_probe_is_local_and_close_is_idempotent() -> None:
+    client = FakeEricClient(_response(_paper()))
+    provider = EricSearchProvider(client)
+
+    available = await provider.probe(_execution())
+    await provider.close()
+    await provider.close()
+    unavailable = await provider.probe(_execution())
+
+    assert available.provider == unavailable.provider == "eric"
+    assert available.capability == unavailable.capability == "search"
+    assert available.status == "available"
+    assert unavailable.status == "unavailable"
+    assert client.calls == []
+    assert client.close_count == 1
+
+    with pytest.raises(ProviderError) as exc_info:
+        await provider.search(_request(), _context(), _execution())
+    assert exc_info.value.code is ProviderErrorCode.INVALID_CONFIG
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_disabled_provider_is_locally_unavailable_and_never_calls_client() -> None:
+    client = FakeEricClient(_response(_paper()))
+    provider = EricSearchProvider(client, enabled=False)
+
+    probe = await provider.probe(_execution())
+    with pytest.raises(ProviderError) as exc_info:
+        await provider.search(_request(), _context(), _execution())
+
+    assert probe.status == "unavailable"
+    assert exc_info.value.code is ProviderErrorCode.INVALID_CONFIG
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_cancelled_close_can_be_retried() -> None:
+    class CancellingCloser(FakeEricClient):
+        async def close(self) -> None:
+            self.close_count += 1
+            if self.close_count == 1:
+                raise asyncio.CancelledError
+
+    client = CancellingCloser(_response(_paper()))
+    provider = EricSearchProvider(client)
+
+    with pytest.raises(asyncio.CancelledError):
+        await provider.close()
+    assert (await provider.probe(_execution())).status == "available"
+
+    await provider.close()
+
+    assert client.close_count == 2
+    assert (await provider.probe(_execution())).status == "unavailable"
+
+
+@pytest.mark.asyncio
+async def test_manager_config_failure_is_local_and_diagnostics_are_safe() -> None:
+    constructed = 0
+
+    def resolve(manifest):
+        if manifest.id == "eric":
+            raise RuntimeError("token=manager-config-canary")
+        return {"enabled": True}
+
+    manager = ProviderManager(config_resolver=resolve)
+
+    def eric_factory(_configuration, _secrets):
+        nonlocal constructed
+        constructed += 1
+        return EricSearchProvider(FakeEricClient(_response(_paper())))
+
+    openalex_client = FakeOpenAlexClient()
+    manager.register_factory(
+        package_id="eric",
+        export="EricSearchProvider",
+        factory=eric_factory,
+        provider_type=EricSearchProvider,
+    )
+    manager.register_factory(
+        package_id="openalex",
+        export="OpenAlexSearchProvider",
+        factory=lambda _configuration, _secrets: OpenAlexSearchProvider(openalex_client),
+        provider_type=OpenAlexSearchProvider,
+    )
+    manager.discover((ERIC_PROVIDER_MANIFEST, OPENALEX_PROVIDER_MANIFEST))
+
+    assert constructed == 0
+    assert "eric-search" not in manager.eligible_adapter_ids
+    assert "openalex-search" in manager.eligible_adapter_ids
+    diagnostic = next(item for item in manager.diagnostics if item.package_id == "eric")
+    assert diagnostic.reason_code == "config_invalid"
+    assert "canary" not in repr(diagnostic)
+
+    page = await manager.execute("openalex-search", _request(), _context(), _execution())
+    assert page.items[0].id == "doi:10.1000/fallback"
+    await manager.close_all()
+
+
+@pytest.mark.asyncio
+async def test_manager_close_failure_is_safe_and_other_provider_still_closes() -> None:
+    class FailingCloseClient(FakeEricClient):
+        async def close(self) -> None:
+            self.close_count += 1
+            raise RuntimeError("token=close-canary")
+
+    eric_client = FailingCloseClient(_response(_paper()))
+    openalex_client = FakeOpenAlexClient()
+    manager = ProviderManager(config_resolver=lambda _manifest: {"enabled": True})
+    manager.register_factory(
+        package_id="eric",
+        export="EricSearchProvider",
+        factory=lambda _configuration, _secrets: EricSearchProvider(eric_client),
+        provider_type=EricSearchProvider,
+    )
+    manager.register_factory(
+        package_id="openalex",
+        export="OpenAlexSearchProvider",
+        factory=lambda _configuration, _secrets: OpenAlexSearchProvider(openalex_client),
+        provider_type=OpenAlexSearchProvider,
+    )
+    manager.discover((ERIC_PROVIDER_MANIFEST, OPENALEX_PROVIDER_MANIFEST))
+    await manager.execute("eric-search", _request(), _context(), _execution())
+    await manager.execute("openalex-search", _request(), _context(), _execution())
+
+    with pytest.raises(ProviderManagerError) as exc_info:
+        await manager.close_all()
+
+    assert exc_info.value.code == "close_failed"
+    assert "canary" not in str(exc_info.value)
+    assert eric_client.close_count == 1
+    assert openalex_client.close_count == 1
+    diagnostic = next(
+        item
+        for item in manager.diagnostics
+        if item.package_id == "eric" and item.reason_code == "close_failed"
+    )
+    assert "canary" not in repr(diagnostic)
+
+
+def test_delivery_routes_use_lazy_explicit_eric_transport_and_safe_catalog(monkeypatch) -> None:
+    transport_options: list[dict[str, object]] = []
+    transport_calls: list[dict[str, object]] = []
+    transports = []
+
+    class RuntimeTransport:
+        def __init__(self, **options) -> None:
+            transport_options.append(options)
+            transports.append(self)
+            self.close_count = 0
+
+        async def get(self, url, params=None, **_kwargs):
+            transport_calls.append({"url": url, "params": params})
+            return httpx.Response(
+                200,
+                json={
+                    "response": {
+                        "numFound": 1,
+                        "docs": [
+                            {
+                                "id": "EJ1234567",
+                                "title": "Teaching Machine Learning in Secondary Schools",
+                                "author": ["Ada Teacher"],
+                                "description": "A bounded education-research fixture.",
+                                "publicationdateyear": "2024",
+                                "publicationtype": ["Journal Articles"],
+                                "language": ["English"],
+                                "e_fulltextauth": 1,
+                            }
+                        ],
+                    }
+                },
+            )
+
+        async def close(self) -> None:
+            self.close_count += 1
+
+    monkeypatch.delenv("SOUWEN_BROWSER_WORKER_TOKEN", raising=False)
+    monkeypatch.setattr("souwen.server.v2_runtime.HttpTransport", RuntimeTransport)
+    runtime = build_target_runtime(
+        SouWenConfig(
+            timeout=30,
+            max_retries=2,
+            sources={"eric": {"timeout": 7}},
+        )
+    )
+
+    assert transport_options == []
+    assert "eric-search" in runtime.manager.eligible_adapter_ids
+    app = create_target_delivery_app(
+        runtime.services,
+        runtime.metadata,
+        require_user=lambda: None,
+        rate_limit=lambda: None,
+        closer=runtime.close,
+    )
+    headers = {"X-Request-ID": "eric-delivery-v2", "X-SouWen-API-Major": "2"}
+    with TestClient(app, raise_server_exceptions=False) as client:
+        providers = client.get("/api/v1/providers", headers=headers)
+        search = client.post(
+            "/api/v1/search",
+            headers=headers,
+            json={
+                "query": "machine learning",
+                "domains": ["paper"],
+                "providers": [{"id": "eric", "kind": "search"}],
+                "page": {"limit": 6},
+            },
+        )
+
+        assert providers.status_code == 200
+        by_id = {item["provider"]: item for item in providers.json()["items"]}
+        assert by_id["eric"] == {
+            "provider": "eric",
+            "capabilities": ["search"],
+            "availability": "available",
+            "provenance": [
+                {
+                    "provider": "eric",
+                    "attempt": None,
+                    "outcome": "success",
+                    "retrieved_at": None,
+                }
+            ],
+            "reason": "available",
+            "missing_fields": [],
+        }
+        assert search.status_code == 200
+        payload = search.json()
+        assert payload["items"][0]["id"] == "eric:EJ1234567"
+        assert payload["meta"]["requested"] == ["eric"]
+        assert payload["meta"]["succeeded"] == ["eric"]
+        assert payload["context"]["request_id"] == "eric-delivery-v2"
+
+    assert transport_options == [
+        {
+            "base_url": "https://api.ies.ed.gov",
+            "headers": {"User-Agent": "SouWen/2.0.0rc2"},
+            "timeout": 7,
+            "max_retries": 2,
+            "proxy": None,
+            "follow_redirects": False,
+        }
+    ]
+    assert transport_calls == [
+        {
+            "url": "/eric/",
+            "params": {
+                "search": "machine learning",
+                "format": "json",
+                "start": "0",
+                "rows": "6",
+            },
+        }
+    ]
+    assert transports[0].close_count == 1
+
+
+@pytest.mark.asyncio
+async def test_disabled_eric_keeps_openalex_default_and_never_constructs_eric(monkeypatch) -> None:
+    eric_transport_constructions = 0
+    openalex_calls = 0
+
+    class _Http:
+        async def close(self) -> None:
+            return None
+
+    class RuntimeOpenAlexClient:
+        def __init__(self, *_args, **_kwargs) -> None:
+            self._client = _Http()
+
+        async def search(self, *_args, **_kwargs):
+            nonlocal openalex_calls
+            openalex_calls += 1
+            return _openalex_response()
+
+    def forbidden_eric_transport(**_options):
+        nonlocal eric_transport_constructions
+        eric_transport_constructions += 1
+        raise AssertionError("disabled ERIC must not construct transport")
+
+    monkeypatch.delenv("SOUWEN_BROWSER_WORKER_TOKEN", raising=False)
+    monkeypatch.setattr("souwen.server.v2_runtime.OpenAlexClient", RuntimeOpenAlexClient)
+    monkeypatch.setattr("souwen.server.v2_runtime.HttpTransport", forbidden_eric_transport)
+    runtime = build_target_runtime(SouWenConfig(sources={"eric": {"enabled": False}}))
+
+    by_id = {item.provider: item for item in runtime.services.provider_items}
+    assert by_id["eric"].availability == "unavailable"
+    assert by_id["eric"].reason == "disabled"
+    assert "eric-search" not in runtime.manager.eligible_adapter_ids
+
+    default_page = await runtime.services.search.search(_request(), _context(), _execution())
+    assert default_page.meta.requested == ("openalex",)
+    assert default_page.items[0].id == "doi:10.1000/fallback"
+
+    with pytest.raises(ProviderError) as exc_info:
+        await runtime.services.search.search(
+            _request(providers=(ProviderRef(id="eric", kind="search"),)),
+            _context(),
+            _execution(),
+        )
+    assert exc_info.value.code is ProviderErrorCode.PROVIDER_UNAVAILABLE
+    assert openalex_calls == 1
+    assert eric_transport_constructions == 0
+    await runtime.close()
+
+
+@pytest.mark.asyncio
+async def test_invalid_eric_transport_config_is_ineligible_before_factory_construction(
+    monkeypatch,
+) -> None:
+    transport_constructions = 0
+
+    def forbidden_transport(**_options):
+        nonlocal transport_constructions
+        transport_constructions += 1
+        raise AssertionError("invalid ERIC config must fail during preflight")
+
+    monkeypatch.delenv("SOUWEN_BROWSER_WORKER_TOKEN", raising=False)
+    monkeypatch.setattr("souwen.server.v2_runtime.HttpTransport", forbidden_transport)
+    runtime = build_target_runtime(SouWenConfig(sources={"eric": {"timeout": 121}}))
+
+    by_id = {item.provider: item for item in runtime.services.provider_items}
+    assert "eric-search" not in runtime.manager.eligible_adapter_ids
+    assert by_id["eric"].availability == "unavailable"
+    assert by_id["eric"].reason == "not_eligible"
+    diagnostic = next(item for item in runtime.manager.diagnostics if item.package_id == "eric")
+    assert diagnostic.reason_code == "config_invalid"
+
+    with pytest.raises(ProviderError) as exc_info:
+        await runtime.services.search.search(
+            _request(providers=(ProviderRef(id="eric", kind="search"),)),
+            _context(),
+            _execution(),
+        )
+
+    assert exc_info.value.code is ProviderErrorCode.PROVIDER_UNAVAILABLE
+    assert transport_constructions == 0
+    await runtime.close()


### PR DESCRIPTION
## Summary

- add the anonymous ERIC `search` Provider v2 manifest and adapter
- assemble ERIC lazily through `ProviderManager` with fixed official egress and preflight-validated config
- expose ERIC only through explicit target selection while keeping OpenAlex as the default and ERIC outside required readiness
- add deterministic conformance, Delivery API, cancellation, lifecycle, rollback, and redaction coverage
- add an independent Provider v2 conformance job to V2 CI and document the current-to-target field boundary

## Compatibility and rollback

- legacy ERIC registry/client remain available for deployment rollback
- `sources.eric.enabled: false` disables only target eligibility; it does not silently route target calls to legacy
- no deployment, tag, Release, or publication workflow behavior is changed

## Validation

- `2693 passed, 3 skipped` from full `pytest tests/`
- Provider v2 targeted suite passed
- `ruff check src tests scripts tools`
- `ruff format --check src tests scripts tools`
- `python3 scripts/ci/check_architecture_dependencies.py`
- `python3 scripts/ci/check_no_legacy_terms.py`
- `PYTHONPATH=src python3 tools/gen_docs.py --check`
- `python3 tools/check_markdown_links.py`
- `actionlint .github/workflows/v2-ci.yml`
- `PYTHONPATH=src python3 scripts/ci/run_profile.py --profile pro-cli --profile basic-cli`
