### PR TITLE
feat(provider): migrate PatentsView to Provider v2

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -231,6 +231,8 @@ jobs:
             tests/test_uniapi_ark_provider_v2.py \
             tests/test_paper/test_eric.py \
             tests/test_eric_provider_v2.py \
+            tests/test_patent/test_patentsview.py \
+            tests/test_patentsview_provider_v2.py \
             -q
 
   server_profile:
@@ -426,7 +428,7 @@ jobs:
           |---|---|---|
           | Bootstrap / import / wheel surface | $BOOTSTRAP_RESULT | v2 import surface, docs, registry baseline |
           | Full pytest matrix | $MATRIX_RESULT | Python 3.10-3.13 on Ubuntu, plus macOS/Windows 3.11 |
-          | Provider v2 conformance | $PROVIDER_V2_RESULT | deterministic SPI, manifest, manager, OpenAlex, builtin Fetch, UniAPI, and ERIC contracts |
+          | Provider v2 conformance | $PROVIDER_V2_RESULT | deterministic SPI, manifest, manager, OpenAlex, builtin Fetch, UniAPI, ERIC, and PatentsView contracts |
           | pro-cli + basic-cli profile | $SERVER_RESULT | local API surface and CLI smoke |
           | full-cli runtime profile | $FULL_RESULT | edition-full source, doctor, plugin, fetch handler, and feature matrix surface |
           | Plugin profile | $PLUGIN_RESULT | example plugin install, contract tests, entry point discovery |

--- a/docs/README.md
+++ b/docs/README.md
@@ -72,6 +72,7 @@ Public docs 不要求读者理解历史路径；需要保留背景材料时，�
 | [internal/spec-01-external-api-canonical-dto.md](./internal/spec-01-external-api-canonical-dto.md) | Proposed External API、Canonical DTO 与 current-to-target mapping |
 | [internal/spec-05-provider-spi-manifest-conformance.md](./internal/spec-05-provider-spi-manifest-conformance.md) | Proposed Provider SPI、Manifest 与 Conformance contract |
 | [internal/provider-migrations/eric-current-to-target.md](./internal/provider-migrations/eric-current-to-target.md) | ERIC Provider v2 的 current-to-target 字段边界、共存与 rollback 记录 |
+| [internal/provider-migrations/patentsview-current-to-target.md](./internal/provider-migrations/patentsview-current-to-target.md) | PatentsView Provider v2 的 secret、显式选择、字段边界与 rollback 记录 |
 | [internal/spec-08-directory-dependency.md](./internal/spec-08-directory-dependency.md) | Proposed target directory、dependency rules 与 migration gate |
 | [internal/phase1/current-api-golden-fixtures.md](./internal/phase1/current-api-golden-fixtures.md) | Phase 1B current-only API behavior 与 language-neutral fixture 说明 |
 | [internal/phase1/provider-directory-current-behavior.md](./internal/phase1/provider-directory-current-behavior.md) | Phase 1B current-only Provider、config 与 directory dependency 事实基线 |

--- a/docs/internal/development-branching.md
+++ b/docs/internal/development-branching.md
@@ -80,7 +80,7 @@ dedicated v2 public-surface gate and runs on `main`.
 - full pytest matrix: Python 3.10, 3.11, 3.12, and 3.13 on Ubuntu, plus Python
   3.11 on macOS and Windows.
 - Provider v2 conformance: deterministic SPI, manifest registry, Provider
-  Manager, OpenAlex, builtin Fetch, UniAPI, and ERIC tests without network,
+  Manager, OpenAlex, builtin Fetch, UniAPI, ERIC, and PatentsView tests without network,
   browser runtime, or secrets.
 - `pro-cli` + `basic-cli` profile: local API surface tests and CLI smoke through
   `scripts/ci/run_profile.py`; legacy `server` / `minimal` aliases remain

--- a/docs/internal/provider-migrations/patentsview-current-to-target.md
+++ b/docs/internal/provider-migrations/patentsview-current-to-target.md
@@ -1,0 +1,66 @@
+# PatentsView Provider v2 current-to-target mapping and rollback
+
+Status: Phase 5 single-Provider migration record. This is a bounded canonical
+projection and coexistence contract, not a claim of complete legacy parity,
+live credential validity, deployment, or release readiness.
+
+## Runtime and configuration boundary
+
+| Concern | Current surface | Target surface |
+|---|---|---|
+| Declaration | Legacy `patentsview` registry source | `PATENTSVIEW_PROVIDER_MANIFEST` / `patentsview-search` |
+| Client | `PatentsViewClient` resolves global/source config | Explicit transport injected by the composition root |
+| Secret | `patentsview_api_key` / source `api_key` | Resolved reference `PATENTSVIEW_API_KEY`; value never enters catalog or diagnostics |
+| Network | Legacy source channel may resolve transport overrides | Fixed `https://search.patentsview.org/api/v1`, no Provider-level proxy/base URL/header override |
+| Edition | Legacy minimum edition `pro` | Coexistence runtime derives the same gate from the legacy source policy |
+| Selection | Not a legacy default patent source | Target explicit selection only; it is not registered as a patent default |
+
+Target eligibility requires the `pro` or `full` edition, explicit
+`sources.patentsview.enabled: true`, and a resolved API key. Missing credentials
+produce a safe `unavailable/missing_configuration` catalog item naming only
+`patentsview_api_key`. PatentsView is optional and is not part of required
+readiness.
+
+## Canonical request and result mapping
+
+The target adapter accepts only the `patent` domain, first-page requests, and
+no non-empty canonical filters. It converts the canonical query to the fixed
+legacy-compatible title query:
+
+```python
+{"_contains": {"patent_title": request.query}}
+```
+
+It does not expose the PatentsView JSON DSL, caller-selected fields, sort,
+numbered pages, convenience methods, or an invented continuation cursor.
+
+| Legacy normalized value | Canonical DTO value |
+|---|---|
+| `patent_id` | `SearchItem.id = "patentsview:<ID>"` and `SearchIdentifier(scheme="patentsview", ...)` |
+| validated record URL | rebuilt `SearchItem.url` |
+| `title` | required `SearchItem.title` |
+| `abstract` | optional `SearchItem.snippet` |
+| `publication_date.year` | `SearchAttributes.year` |
+| patent domain | `SearchAttributes.resource_type = "patent"` |
+| local rank/source | `SearchItem.rank` and PatentsView provenance |
+| `total_results` | `PageInfo.total` |
+
+This slice deliberately does not expose `application_number`, filing date,
+applicants, inventors, IPC/CPC codes, claims, family ID, legal status, PDF URL,
+or arbitrary raw fields. Inventors are not relabeled as generic `authors`.
+Future patent-specific metadata requires an additive canonical contract rather
+than raw payload leakage.
+
+## Coexistence and rollback
+
+- The legacy registry declaration and client remain in place as rollback truth.
+- Target requests execute only through `ProviderManager`; there is no target to
+  legacy double dispatch.
+- Disabling `sources.patentsview.enabled` removes target eligibility. It does
+  not silently route the request to the legacy dispatcher.
+- Operational rollback uses the prior known-good candidate. Removing the
+  legacy declaration or changing patent defaults is outside this slice.
+
+The deterministic Provider v2 conformance job uses fake transports and secret
+canaries only. It proves checked contract behavior, not the validity of a real
+PatentsView account, quota, price, live endpoint, deployment, or publication.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -193,7 +193,7 @@ v2 release candidate 已合回 `main`。`V2 CI` 继续作为 v2 public surface �
   3.10/3.11/3.12/3.13，以及 macOS/Windows Python 3.11；避免把缺少 Server、MCP
   或 scraper runtime 误报成产品行为回归。
 - Provider v2 conformance：单独运行 SPI、manifest registry、Provider Manager、
-  OpenAlex、builtin Fetch、UniAPI 与 ERIC 的 deterministic tests；不访问网络、
+  OpenAlex、builtin Fetch、UniAPI、ERIC 与 PatentsView 的 deterministic tests；不访问网络、
   browser runtime 或 secret，并由 V2 readiness summary fail closed 汇总。
 - pro-cli + basic-cli profile：安装 API 测试依赖后运行 `pro-cli` 和 `basic-cli`
   profile，并上传 JSON/Markdown report；`server` / `minimal` alias 仅用于过渡兼容。

--- a/src/souwen/config/models.py
+++ b/src/souwen/config/models.py
@@ -243,7 +243,7 @@ class SouWenConfig(BaseModel):
     zotero_library_type: str | None = None  # "user" (默认) 或 "group"
 
     # ===== 专利数据源 =====
-    patentsview_api_key: str | None = None
+    patentsview_api_key: str | None = Field(default=None, repr=False)
     pqai_api_token: str | None = None
     uspto_api_key: str | None = None
     epo_consumer_key: str | None = None

--- a/src/souwen/modules/search/application/orchestration.py
+++ b/src/souwen/modules/search/application/orchestration.py
@@ -66,7 +66,10 @@ class OrderedSearchProviderSelector:
     """Immutable projection of YAML domain/capability provider priority."""
 
     def __init__(
-        self, selections_by_domain: Mapping[str, tuple[SearchProviderSelection, ...]]
+        self,
+        selections_by_domain: Mapping[str, tuple[SearchProviderSelection, ...]],
+        *,
+        explicit_selections: tuple[SearchProviderSelection, ...] = (),
     ) -> None:
         ordered: dict[str, tuple[SearchProviderSelection, ...]] = {}
         by_provider: dict[str, SearchProviderSelection] = {}
@@ -91,6 +94,14 @@ class OrderedSearchProviderSelector:
                         "a provider ID must resolve to one immutable adapter selection"
                     )
                 by_provider[selection.provider.id] = selection
+        explicit_ids = tuple(selection.provider.id for selection in explicit_selections)
+        if len(explicit_ids) != len(set(explicit_ids)):
+            raise ValueError("explicit-only provider selection IDs must be unique")
+        for selection in explicit_selections:
+            existing = by_provider.get(selection.provider.id)
+            if existing is not None and existing != selection:
+                raise ValueError("a provider ID must resolve to one immutable adapter selection")
+            by_provider[selection.provider.id] = selection
         self._by_domain = ordered
         self._by_provider = by_provider
 

--- a/src/souwen/patent/patentsview.py
+++ b/src/souwen/patent/patentsview.py
@@ -55,12 +55,14 @@ import logging
 from typing import Any
 
 import httpx
+
+from souwen.common_runtime.transport import HttpTransport
 from souwen.config import get_config
-from souwen.core.parsing import safe_parse_date
 from souwen.core.exceptions import ConfigError, NotFoundError, ParseError
 from souwen.core.http_client import SouWenHttpClient
-from souwen.models import Applicant, PatentResult, SearchResponse
+from souwen.core.parsing import safe_parse_date
 from souwen.core.rate_limiter import TokenBucketLimiter
+from souwen.models import Applicant, PatentResult, SearchResponse
 
 logger = logging.getLogger(__name__)
 
@@ -94,27 +96,33 @@ class PatentsViewClient:
     BASE_URL = "https://search.patentsview.org/api/v1"
     RATE_LIMIT = 0.75  # 45 req/min
 
-    def __init__(self, api_key: str | None = None) -> None:
+    def __init__(
+        self,
+        api_key: str | None = None,
+        *,
+        transport: HttpTransport | None = None,
+    ) -> None:
         """初始化 PatentsView 客户端
 
         从参数或配置读取 API Key，初始化 HTTP 客户端和限流器。
         """
-        cfg = get_config()
-        resolved_key = api_key or cfg.resolve_api_key("patentsview", "patentsview_api_key")
-        if not resolved_key:
-            raise ConfigError(
-                key="patentsview_api_key",
-                service="PatentsView Search API",
-                register_url=(
-                    "https://search.patentsview.org/docs/docs/Search%20API/SearchAPIReference/"
-                ),
+        if transport is None:
+            cfg = get_config()
+            resolved_key = api_key or cfg.resolve_api_key("patentsview", "patentsview_api_key")
+            if not resolved_key:
+                raise ConfigError(
+                    key="patentsview_api_key",
+                    service="PatentsView Search API",
+                    register_url=(
+                        "https://search.patentsview.org/docs/docs/Search%20API/SearchAPIReference/"
+                    ),
+                )
+            transport = SouWenHttpClient(
+                base_url=self.BASE_URL,
+                headers={"X-Api-Key": resolved_key},
+                source_name="patentsview",
             )
-        self._api_key = resolved_key
-        self._http = SouWenHttpClient(
-            base_url=self.BASE_URL,
-            headers={"X-Api-Key": self._api_key},
-            source_name="patentsview",
-        )
+        self._http = transport
         # 45 req/min 限制，约 0.75 req/s
         self._limiter = TokenBucketLimiter(rate=self.RATE_LIMIT, burst=3)
 

--- a/src/souwen/providers/information_sources/patentsview/__init__.py
+++ b/src/souwen/providers/information_sources/patentsview/__init__.py
@@ -1,0 +1,10 @@
+"""Built-in PatentsView Provider v2 package."""
+
+from .adapter import PatentsViewClientProtocol, PatentsViewSearchProvider
+from .manifest import PATENTSVIEW_PROVIDER_MANIFEST
+
+__all__ = [
+    "PATENTSVIEW_PROVIDER_MANIFEST",
+    "PatentsViewClientProtocol",
+    "PatentsViewSearchProvider",
+]

--- a/src/souwen/providers/information_sources/patentsview/adapter.py
+++ b/src/souwen/providers/information_sources/patentsview/adapter.py
@@ -1,0 +1,288 @@
+"""Provider v2 adapter for the injected authenticated PatentsView client."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import re
+from collections.abc import Mapping, Sequence
+from contextlib import suppress
+from typing import Any, Protocol
+from urllib.parse import urlsplit
+
+from souwen.common_runtime.errors import SouWenError
+from souwen.common_runtime.transport.errors import (
+    AuthError,
+    RateLimitError,
+    SourceUnavailableError,
+)
+from souwen.platform.provider_spi import (
+    ExecutionContext,
+    PageInfo,
+    ProviderError,
+    ProviderErrorCode,
+    ProviderProbe,
+    Provenance,
+    RequestContext,
+    SearchAttributes,
+    SearchIdentifier,
+    SearchItem,
+    SearchMeta,
+    SearchPage,
+    SearchRequest,
+)
+
+
+_PROVIDER_ID = "patentsview"
+_PATENT_ID_PATTERN = re.compile(r"^[A-Z0-9]+$")
+
+
+class PatentsViewClientProtocol(Protocol):
+    """Minimal PatentsView client surface injected by the composition root."""
+
+    async def search(
+        self,
+        query: dict[str, Any],
+        fields: list[str] | None = None,
+        per_page: int = 10,
+        page: int = 1,
+        sort: list[dict[str, str]] | None = None,
+    ) -> Any:
+        """Return a normalized legacy ``SearchResponse`` compatible object."""
+
+    async def close(self) -> None:
+        """Close the explicitly injected transport."""
+
+
+class PatentsViewSearchProvider:
+    """Search-only Provider v2 adapter for authenticated USPTO patent metadata."""
+
+    capability = "search"
+
+    def __init__(self, client: PatentsViewClientProtocol, *, enabled: bool = True) -> None:
+        self._client = client
+        self._enabled = enabled
+        self._closed = False
+
+    async def search(
+        self,
+        request: SearchRequest,
+        context: RequestContext,
+        execution: ExecutionContext,
+    ) -> SearchPage:
+        """Execute one bounded first-page title search and canonicalize the response."""
+        execution.raise_if_cancelled_or_expired()
+        if self._closed or not self._enabled:
+            raise ProviderError(ProviderErrorCode.INVALID_CONFIG, provider_id=_PROVIDER_ID)
+        if request.domains != ("patent",):
+            raise ProviderError(ProviderErrorCode.INVALID_REQUEST, provider_id=_PROVIDER_ID)
+        if request.page is not None and request.page.cursor is not None:
+            raise ProviderError(ProviderErrorCode.INVALID_REQUEST, provider_id=_PROVIDER_ID)
+        if request.filters is not None and request.filters.model_dump(exclude_none=True):
+            raise ProviderError(ProviderErrorCode.INVALID_REQUEST, provider_id=_PROVIDER_ID)
+
+        limit = request.page.limit if request.page is not None else 10
+        query = {"_contains": {"patent_title": request.query}}
+        try:
+            response = await _await_with_execution(
+                self._client.search(query, per_page=limit, page=1),
+                execution,
+            )
+            execution.raise_if_cancelled_or_expired()
+            return _to_search_page(response, limit=limit, context=context)
+        except asyncio.CancelledError:
+            raise
+        except ProviderError:
+            raise
+        except RateLimitError as exc:
+            raise ProviderError(
+                ProviderErrorCode.RATE_LIMITED,
+                provider_id=_PROVIDER_ID,
+                retry_after_seconds=getattr(exc, "retry_after", None),
+            ) from None
+        except TimeoutError:
+            raise ProviderError(
+                ProviderErrorCode.DEADLINE_EXCEEDED,
+                provider_id=_PROVIDER_ID,
+            ) from None
+        except AuthError:
+            raise ProviderError(
+                ProviderErrorCode.INVALID_CONFIG, provider_id=_PROVIDER_ID
+            ) from None
+        except SourceUnavailableError:
+            raise ProviderError(
+                ProviderErrorCode.PROVIDER_UNAVAILABLE,
+                provider_id=_PROVIDER_ID,
+            ) from None
+        except SouWenError as exc:
+            code = (
+                ProviderErrorCode.INVALID_CONFIG
+                if type(exc).__name__ == "ConfigError"
+                else ProviderErrorCode.INVALID_UPSTREAM_RESPONSE
+            )
+            raise ProviderError(code, provider_id=_PROVIDER_ID) from None
+        except (AttributeError, TypeError, ValueError):
+            raise ProviderError(
+                ProviderErrorCode.INVALID_UPSTREAM_RESPONSE,
+                provider_id=_PROVIDER_ID,
+            ) from None
+        except Exception:
+            raise ProviderError(
+                ProviderErrorCode.PROVIDER_UNAVAILABLE,
+                provider_id=_PROVIDER_ID,
+            ) from None
+
+    async def probe(self, execution: ExecutionContext) -> ProviderProbe:
+        """Report local eligibility without issuing a network request."""
+        execution.raise_if_cancelled_or_expired()
+        return ProviderProbe(
+            provider=_PROVIDER_ID,
+            capability="search",
+            status="unavailable" if self._closed or not self._enabled else "available",
+        )
+
+    async def close(self) -> None:
+        """Close the injected client once and remain retryable after cancellation."""
+        if self._closed:
+            return
+        self._closed = True
+        closer = getattr(self._client, "aclose", None) or getattr(self._client, "close", None)
+        if closer is None:
+            return
+        try:
+            result = closer()
+            if inspect.isawaitable(result):
+                await result
+        except asyncio.CancelledError:
+            self._closed = False
+            raise
+
+
+async def _await_with_execution(value: Any, execution: ExecutionContext) -> Any:
+    provider_task = asyncio.ensure_future(value)
+    cancellation_task = asyncio.create_task(execution.cancel_event.wait())
+    try:
+        done, _pending = await asyncio.wait(
+            {provider_task, cancellation_task},
+            timeout=execution.remaining_seconds,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if provider_task in done:
+            return await provider_task
+        provider_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await provider_task
+        code = (
+            ProviderErrorCode.CANCELLED
+            if cancellation_task in done
+            else ProviderErrorCode.DEADLINE_EXCEEDED
+        )
+        raise ProviderError(code, provider_id=_PROVIDER_ID)
+    finally:
+        cancellation_task.cancel()
+        if not provider_task.done():
+            provider_task.cancel()
+        await asyncio.gather(provider_task, cancellation_task, return_exceptions=True)
+
+
+def _to_search_page(response: Any, *, limit: int, context: RequestContext) -> SearchPage:
+    if getattr(response, "source", None) != _PROVIDER_ID:
+        raise ValueError("unexpected legacy response source")
+    results = getattr(response, "results", None)
+    total = getattr(response, "total_results", None)
+    response_page = getattr(response, "page", None)
+    response_limit = getattr(response, "per_page", None)
+    if not isinstance(results, Sequence) or isinstance(results, (str, bytes)):
+        raise ValueError("invalid legacy search results")
+    if total is not None and (not isinstance(total, int) or isinstance(total, bool) or total < 0):
+        raise ValueError("invalid legacy result total")
+    if response_page != 1 or response_limit != limit:
+        raise ValueError("legacy page does not match canonical request")
+    if len(results) > limit:
+        raise ValueError("legacy result count exceeds canonical limit")
+    if total is not None and total < len(results):
+        raise ValueError("legacy result total is smaller than the returned page")
+
+    items = tuple(_to_search_item(item, rank=index) for index, item in enumerate(results, 1))
+    return SearchPage(
+        items=items,
+        page=PageInfo(limit=limit, next_cursor=None, total=total),
+        meta=SearchMeta(requested=(_PROVIDER_ID,), succeeded=(_PROVIDER_ID,)),
+        context=context,
+    )
+
+
+def _to_search_item(patent: Any, *, rank: int) -> SearchItem:
+    if getattr(patent, "source", None) != _PROVIDER_ID:
+        raise ValueError("unexpected legacy patent source")
+    raw = getattr(patent, "raw", None)
+    if not isinstance(raw, Mapping):
+        raise ValueError("invalid legacy patent attributes")
+    patent_id = _patent_id(getattr(patent, "patent_id", None))
+    source_url = _patent_url(getattr(patent, "source_url", None), patent_id)
+    publication_date = getattr(patent, "publication_date", None)
+    year = getattr(publication_date, "year", None) if publication_date is not None else None
+
+    return SearchItem(
+        id=f"patentsview:{patent_id}",
+        title=_required_text(getattr(patent, "title", None)),
+        url=source_url,
+        snippet=_optional_text(getattr(patent, "abstract", None)),
+        rank=rank,
+        provenance=(Provenance(provider=_PROVIDER_ID, attempt=1, outcome="success"),),
+        attributes=SearchAttributes(
+            year=_optional_year(year),
+            identifiers=(SearchIdentifier(scheme="patentsview", value=patent_id),),
+            resource_type="patent",
+        ),
+    )
+
+
+def _patent_id(value: Any) -> str:
+    identifier = _required_text(value).upper()
+    if _PATENT_ID_PATTERN.fullmatch(identifier) is None:
+        raise ValueError("invalid USPTO patent identifier")
+    return identifier
+
+
+def _patent_url(value: Any, patent_id: str) -> str:
+    parsed = urlsplit(_required_text(value))
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname != "search.patentsview.org"
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.port is not None
+        or parsed.path != f"/patent/{patent_id}"
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError("invalid PatentsView record URL")
+    return f"https://search.patentsview.org/patent/{patent_id}"
+
+
+def _required_text(value: Any) -> str:
+    normalized = _optional_text(value)
+    if normalized is None:
+        raise ValueError("missing required text")
+    return normalized
+
+
+def _optional_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError("invalid text")
+    normalized = value.strip()
+    return normalized or None
+
+
+def _optional_year(value: Any) -> int | None:
+    if value is None:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool) or not 0 <= value <= 9999:
+        raise ValueError("invalid publication year")
+    return value
+
+
+__all__ = ["PatentsViewClientProtocol", "PatentsViewSearchProvider"]

--- a/src/souwen/providers/information_sources/patentsview/manifest.py
+++ b/src/souwen/providers/information_sources/patentsview/manifest.py
@@ -1,0 +1,44 @@
+"""Static Provider v2 declaration for the authenticated PatentsView Search API."""
+
+from __future__ import annotations
+
+from souwen.platform.manifest_registry import ProviderManifest
+
+
+PATENTSVIEW_PROVIDER_MANIFEST = ProviderManifest.model_validate(
+    {
+        "schema_version": 2,
+        "id": "patentsview",
+        "version": "2.0.0rc2",
+        "contract_version": "provider-v2",
+        "capabilities": ["search"],
+        "adapters": [
+            {
+                "id": "patentsview-search",
+                "capability": "search",
+                "export": "PatentsViewSearchProvider",
+                "availability": "configured",
+            }
+        ],
+        "configuration": {
+            "schema_reference": "patentsview-provider-config-v1",
+            "unknown_key_policy": "reject",
+            "non_secret_keys": ["enabled", "max_retries", "timeout_seconds"],
+        },
+        "secrets": {"references": ["PATENTSVIEW_API_KEY"]},
+        "network": {
+            "egress_hosts": ["search.patentsview.org"],
+            "proxy_supported": False,
+            "browser_required": False,
+        },
+        "risk": {"authenticated": True, "costed": False},
+        "observability": {"dimensions": ["provider", "adapter", "capability", "outcome"]},
+        "compatibility": {
+            "contract_versions": ["provider-v2"],
+            "config_schema_versions": ["patentsview-provider-config-v1"],
+        },
+    }
+)
+
+
+__all__ = ["PATENTSVIEW_PROVIDER_MANIFEST"]

--- a/src/souwen/server/v2_runtime.py
+++ b/src/souwen/server/v2_runtime.py
@@ -18,6 +18,7 @@ from souwen.delivery.api import (
     TargetDeliveryServices,
 )
 from souwen.delivery.browser_worker_client import BrowserWorkerClient
+from souwen.editions import source_policy
 from souwen.modules.fetch.api import FetchModuleService
 from souwen.modules.llm_search.api import LLMSearchModuleService
 from souwen.modules.search.api import SearchModuleService
@@ -27,6 +28,7 @@ from souwen.modules.search.application import (
 )
 from souwen.paper.eric import EricClient
 from souwen.paper.openalex import OpenAlexClient
+from souwen.patent.patentsview import PatentsViewClient
 from souwen.platform.provider_manager import ProviderManager
 from souwen.platform.provider_spi import (
     ExecutionContext,
@@ -41,6 +43,10 @@ from souwen.providers.information_sources.openalex import (
     OPENALEX_PROVIDER_MANIFEST,
     OpenAlexSearchProvider,
 )
+from souwen.providers.information_sources.patentsview import (
+    PATENTSVIEW_PROVIDER_MANIFEST,
+    PatentsViewSearchProvider,
+)
 from souwen.providers.information_sources.eric import ERIC_PROVIDER_MANIFEST, EricSearchProvider
 from souwen.providers.llm_sources.uniapi_ark_annotations import (
     UNIAPI_ARK_MANIFESTS,
@@ -51,6 +57,7 @@ from souwen.providers.llm_sources.uniapi_ark_annotations.manifest import (
     DEEPSEEK_ADAPTER_ID,
     DOUBAO_ADAPTER_ID,
 )
+from souwen.registry import get as get_legacy_source
 from souwen.web.builtin import BuiltinFetcherClient
 from souwen.worker.browser_fetch.protocol import BROWSER_WORKER_PROVIDER_INVENTORY_DIGEST
 
@@ -115,6 +122,20 @@ def _configuration_resolver(config: SouWenConfig):
             }
             _validate_eric_configuration(configuration)
             return configuration
+        if manifest.id == "patentsview":
+            legacy = get_legacy_source("patentsview")
+            if not source_policy(legacy, config.edition).available or not config.is_source_enabled(
+                "patentsview", default=False
+            ):
+                raise ValueError("provider is disabled")
+            source = config.get_source_config("patentsview")
+            configuration = {
+                "enabled": True,
+                "max_retries": config.max_retries,
+                "timeout_seconds": source.timeout or config.timeout,
+            }
+            _validate_transport_configuration(configuration, provider_id="PatentsView")
+            return configuration
         if manifest.id == "builtin-fetch":
             if not config.is_source_enabled("builtin-fetch", default=True):
                 raise ValueError("provider is disabled")
@@ -135,6 +156,8 @@ def _configuration_resolver(config: SouWenConfig):
 
 def _secret_resolver(config: SouWenConfig):
     def resolve(manifest, _references):
+        if manifest.id == "patentsview":
+            return {"PATENTSVIEW_API_KEY": _patentsview_api_key(config)}
         if manifest.id not in {DEEPSEEK_ADAPTER_ID, DOUBAO_ADAPTER_ID}:
             return {}
         gateway = config.get_llm_search_gateway("uniapi")
@@ -144,6 +167,11 @@ def _secret_resolver(config: SouWenConfig):
         }
 
     return resolve
+
+
+def _patentsview_api_key(config: SouWenConfig) -> str:
+    value = config.resolve_api_key("patentsview", "patentsview_api_key")
+    return value.strip() if isinstance(value, str) else ""
 
 
 def _browser_client() -> BrowserWorkerClient | None:
@@ -162,8 +190,8 @@ def _browser_client() -> BrowserWorkerClient | None:
     )
 
 
-def _validate_eric_configuration(configuration) -> None:
-    """Validate ERIC transport options during Provider Manager preflight."""
+def _validate_transport_configuration(configuration, *, provider_id: str) -> None:
+    """Validate bounded transport options during Provider Manager preflight."""
     timeout = configuration.get("timeout_seconds")
     max_retries = configuration.get("max_retries")
     if (
@@ -174,7 +202,11 @@ def _validate_eric_configuration(configuration) -> None:
         or isinstance(max_retries, bool)
         or not 0 <= max_retries <= 10
     ):
-        raise ValueError("invalid ERIC transport configuration")
+        raise ValueError(f"invalid {provider_id} transport configuration")
+
+
+def _validate_eric_configuration(configuration) -> None:
+    _validate_transport_configuration(configuration, provider_id="ERIC")
 
 
 def _build_eric_provider(configuration, _secrets) -> EricSearchProvider:
@@ -194,6 +226,30 @@ def _build_eric_provider(configuration, _secrets) -> EricSearchProvider:
     )
 
 
+def _build_patentsview_provider(configuration, secrets) -> PatentsViewSearchProvider:
+    """Build PatentsView only from resolved config and secret namespaces."""
+    _validate_transport_configuration(configuration, provider_id="PatentsView")
+    api_key = secrets.get("PATENTSVIEW_API_KEY")
+    if not isinstance(api_key, str) or not api_key.strip():
+        raise ValueError("missing PatentsView credential")
+    api_key = api_key.strip()
+    transport = HttpTransport(
+        base_url="https://search.patentsview.org/api/v1",
+        headers={
+            "User-Agent": f"SouWen/{__version__}",
+            "X-Api-Key": api_key,
+        },
+        timeout=configuration["timeout_seconds"],
+        max_retries=configuration["max_retries"],
+        proxy=None,
+        follow_redirects=False,
+    )
+    return PatentsViewSearchProvider(
+        PatentsViewClient(transport=transport),
+        enabled=configuration["enabled"],
+    )
+
+
 def _catalog_items(
     config: SouWenConfig,
     manager: ProviderManager,
@@ -201,6 +257,15 @@ def _catalog_items(
     eligible = set(manager.eligible_adapter_ids)
     enabled_llm = set(config.enabled_uniapi_ark_source_ids())
     missing_gateway = config.missing_uniapi_gateway_fields()
+    patentsview_enabled = config.is_source_enabled("patentsview", default=False)
+    patentsview_policy_available = source_policy(
+        get_legacy_source("patentsview"), config.edition
+    ).available
+    missing_patentsview = (
+        ("patentsview_api_key",)
+        if patentsview_policy_available and not _patentsview_api_key(config)
+        else ()
+    )
     declarations = (
         (
             "openalex",
@@ -213,6 +278,12 @@ def _catalog_items(
             "eric-search",
             "search",
             config.is_source_enabled("eric", default=True),
+        ),
+        (
+            "patentsview",
+            "patentsview-search",
+            "search",
+            patentsview_enabled,
         ),
         (
             "builtin-fetch",
@@ -230,9 +301,12 @@ def _catalog_items(
     )
     items: list[ProviderCatalogItem] = []
     for provider_id, adapter_id, capability, enabled in declarations:
-        missing_fields = (
-            missing_gateway if enabled and capability == "llm_search" and missing_gateway else ()
-        )
+        if enabled and provider_id == "patentsview" and missing_patentsview:
+            missing_fields = missing_patentsview
+        elif enabled and capability == "llm_search" and missing_gateway:
+            missing_fields = missing_gateway
+        else:
+            missing_fields = ()
         if adapter_id in eligible:
             reason = "available"
             status = "available"
@@ -286,6 +360,12 @@ def build_target_runtime(config: SouWenConfig) -> TargetRuntime:
         provider_type=EricSearchProvider,
     )
     manager.register_factory(
+        package_id="patentsview",
+        export="PatentsViewSearchProvider",
+        factory=_build_patentsview_provider,
+        provider_type=PatentsViewSearchProvider,
+    )
+    manager.register_factory(
         package_id="builtin-fetch",
         export="BuiltinFetchProvider",
         factory=lambda configuration, _secrets: BuiltinFetchProvider(
@@ -310,6 +390,7 @@ def build_target_runtime(config: SouWenConfig) -> TargetRuntime:
         (
             OPENALEX_PROVIDER_MANIFEST,
             ERIC_PROVIDER_MANIFEST,
+            PATENTSVIEW_PROVIDER_MANIFEST,
             BUILTIN_FETCH_MANIFEST,
             *UNIAPI_ARK_MANIFESTS,
         )
@@ -330,8 +411,15 @@ def build_target_runtime(config: SouWenConfig) -> TargetRuntime:
                         adapter_id="eric-search",
                         yaml_priority=2,
                     ),
-                )
-            }
+                ),
+            },
+            explicit_selections=(
+                SearchProviderSelection(
+                    provider=ProviderRef(id="patentsview", kind="search"),
+                    adapter_id="patentsview-search",
+                    yaml_priority=1,
+                ),
+            ),
         ),
     )
     enabled_llm = config.enabled_uniapi_ark_source_ids()

--- a/tests/test_patentsview_provider_v2.py
+++ b/tests/test_patentsview_provider_v2.py
@@ -1,0 +1,344 @@
+"""Deterministic conformance and runtime integration for PatentsView Provider v2."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import date
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from souwen.common_runtime.transport.errors import AuthError, RateLimitError
+from souwen.config import SouWenConfig
+from souwen.delivery.api import create_target_delivery_app
+from souwen.models import Applicant, PatentResult, SearchResponse
+from souwen.modules.search.application import OrderedSearchProviderSelector, SearchProviderSelection
+from souwen.platform.provider_spi import (
+    ExecutionContext,
+    ProviderError,
+    ProviderErrorCode,
+    ProviderRef,
+    RequestContext,
+    SearchFilters,
+    SearchPageRequest,
+    SearchRequest,
+)
+from souwen.providers.information_sources.patentsview import (
+    PATENTSVIEW_PROVIDER_MANIFEST,
+    PatentsViewSearchProvider,
+)
+from souwen.registry import get
+from souwen.server.v2_runtime import build_target_runtime
+
+
+class FakeClient:
+    def __init__(self, response: SearchResponse | Exception) -> None:
+        self.response = response
+        self.calls: list[dict[str, object]] = []
+        self.close_count = 0
+
+    async def search(self, query, fields=None, per_page=10, page=1, sort=None):
+        self.calls.append(
+            {
+                "query": query,
+                "fields": fields,
+                "per_page": per_page,
+                "page": page,
+                "sort": sort,
+            }
+        )
+        if isinstance(self.response, Exception):
+            raise self.response
+        return self.response
+
+    async def close(self) -> None:
+        self.close_count += 1
+
+
+def _patent(**overrides) -> PatentResult:
+    values = {
+        "source": "patentsview",
+        "title": "Bounded neural-network patent",
+        "patent_id": "11234567",
+        "application_number": "US17/123456",
+        "publication_date": date(2023, 1, 31),
+        "filing_date": date(2021, 6, 15),
+        "applicants": [Applicant(name="Example Corp", country="US")],
+        "inventors": ["Ada Inventor", "Grace Engineer"],
+        "abstract": "A deterministic patent fixture.",
+        "cpc_codes": ["G06N3/08"],
+        "ipc_codes": ["G06N3/00"],
+        "source_url": "https://search.patentsview.org/patent/11234567",
+        "raw": {"patent_type": "utility"},
+    }
+    values.update(overrides)
+    return PatentResult(**values)
+
+
+def _response(*patents: PatentResult, per_page: int = 10) -> SearchResponse:
+    return SearchResponse(
+        query="fixture",
+        source="patentsview",
+        total_results=len(patents),
+        page=1,
+        per_page=per_page,
+        results=list(patents),
+    )
+
+
+def _request(**overrides) -> SearchRequest:
+    values = {"query": "neural network", "domains": ("patent",)}
+    values.update(overrides)
+    return SearchRequest(**values)
+
+
+def _context() -> RequestContext:
+    return RequestContext(request_id="patentsview-provider-v2")
+
+
+def _execution(timeout: float = 5) -> ExecutionContext:
+    return ExecutionContext.with_timeout(timeout)
+
+
+def test_manifest_matches_legacy_registry_and_required_secret_contract() -> None:
+    legacy = get("patentsview")
+
+    assert PATENTSVIEW_PROVIDER_MANIFEST.id == legacy.name == "patentsview"
+    assert PATENTSVIEW_PROVIDER_MANIFEST.adapters[0].id == "patentsview-search"
+    assert PATENTSVIEW_PROVIDER_MANIFEST.capabilities == ("search",)
+    assert PATENTSVIEW_PROVIDER_MANIFEST.secrets.references == ("PATENTSVIEW_API_KEY",)
+    assert PATENTSVIEW_PROVIDER_MANIFEST.network.egress_hosts == ("search.patentsview.org",)
+    assert PATENTSVIEW_PROVIDER_MANIFEST.network.proxy_supported is False
+    assert legacy.domain == "patent"
+    assert legacy.resolved_auth_requirement == "required"
+    assert legacy.default_for == frozenset()
+
+
+def test_legacy_flat_secret_is_excluded_from_config_repr() -> None:
+    config = SouWenConfig(patentsview_api_key="flat-secret-canary")
+
+    assert config.resolve_api_key("patentsview", "patentsview_api_key") == "flat-secret-canary"
+    assert "flat-secret-canary" not in repr(config)
+
+
+def test_selector_registers_patentsview_for_explicit_selection_only() -> None:
+    selection = SearchProviderSelection(
+        provider=ProviderRef(id="patentsview", kind="search"),
+        adapter_id="patentsview-search",
+        yaml_priority=1,
+    )
+    selector = OrderedSearchProviderSelector({}, explicit_selections=(selection,))
+
+    assert selector.select_explicit((selection.provider,)) == (selection,)
+    with pytest.raises(ProviderError) as exc_info:
+        selector.select_default(_request())
+    assert exc_info.value.code is ProviderErrorCode.PROVIDER_UNAVAILABLE
+
+
+@pytest.mark.asyncio
+async def test_search_maps_bounded_patent_projection_and_dict_query() -> None:
+    client = FakeClient(_response(_patent(), per_page=7))
+    page = await PatentsViewSearchProvider(client).search(
+        _request(page=SearchPageRequest(limit=7)), _context(), _execution()
+    )
+
+    assert client.calls == [
+        {
+            "query": {"_contains": {"patent_title": "neural network"}},
+            "fields": None,
+            "per_page": 7,
+            "page": 1,
+            "sort": None,
+        }
+    ]
+    item = page.items[0]
+    assert item.id == "patentsview:11234567"
+    assert str(item.url) == "https://search.patentsview.org/patent/11234567"
+    assert item.attributes is not None
+    assert item.attributes.year == 2023
+    assert item.attributes.identifiers[0].model_dump() == {
+        "scheme": "patentsview",
+        "value": "11234567",
+    }
+    assert item.attributes.authors == ()
+    assert item.attributes.resource_type == "patent"
+    assert "application_number" not in item.model_dump()
+    assert page.meta.succeeded == ("patentsview",)
+
+
+@pytest.mark.asyncio
+async def test_invalid_domain_cursor_and_filters_fail_before_client_call() -> None:
+    client = FakeClient(_response(_patent()))
+    provider = PatentsViewSearchProvider(client)
+    requests = (
+        _request(domains=("paper",)),
+        _request(page=SearchPageRequest(limit=10, cursor="opaque")),
+        _request(filters=SearchFilters(year_from=2020)),
+    )
+
+    for request in requests:
+        with pytest.raises(ProviderError) as exc_info:
+            await provider.search(request, _context(), _execution())
+        assert exc_info.value.code is ProviderErrorCode.INVALID_REQUEST
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("failure", "code"),
+    [
+        (AuthError("secret-canary"), ProviderErrorCode.INVALID_CONFIG),
+        (RateLimitError("secret-canary", retry_after=3), ProviderErrorCode.RATE_LIMITED),
+        (RuntimeError("secret-canary"), ProviderErrorCode.PROVIDER_UNAVAILABLE),
+    ],
+)
+async def test_error_mapping_is_typed_and_redacted(failure: Exception, code) -> None:
+    with pytest.raises(ProviderError) as exc_info:
+        await PatentsViewSearchProvider(FakeClient(failure)).search(
+            _request(), _context(), _execution()
+        )
+
+    assert exc_info.value.code is code
+    assert "secret-canary" not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_deadline_cancels_child_and_close_is_idempotent() -> None:
+    cancelled = asyncio.Event()
+
+    class BlockingClient(FakeClient):
+        async def search(self, *_args, **_kwargs):
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+    client = BlockingClient(_response())
+    provider = PatentsViewSearchProvider(client)
+    with pytest.raises(ProviderError) as exc_info:
+        await provider.search(_request(), _context(), _execution(0.03))
+    assert exc_info.value.code is ProviderErrorCode.DEADLINE_EXCEEDED
+    assert cancelled.is_set()
+
+    probe = await provider.probe(_execution())
+    assert (probe.provider, probe.capability, probe.status) == (
+        "patentsview",
+        "search",
+        "available",
+    )
+    await provider.close()
+    await provider.close()
+    assert client.close_count == 1
+
+
+@pytest.mark.parametrize("api_key", [None, "   "])
+def test_missing_secret_is_safe_and_does_not_become_patent_default(monkeypatch, api_key) -> None:
+    monkeypatch.delenv("SOUWEN_BROWSER_WORKER_TOKEN", raising=False)
+    source = {"enabled": True}
+    if api_key is not None:
+        source["api_key"] = api_key
+    runtime = build_target_runtime(SouWenConfig(sources={"patentsview": source}))
+    by_id = {item.provider: item for item in runtime.services.provider_items}
+
+    assert "patentsview-search" not in runtime.manager.eligible_adapter_ids
+    assert by_id["patentsview"].availability == "unavailable"
+    assert by_id["patentsview"].reason == "missing_configuration"
+    assert by_id["patentsview"].missing_fields == ("patentsview_api_key",)
+    assert "PATENTSVIEW_API_KEY" not in repr(runtime.services.provider_items)
+
+    with pytest.raises(ProviderError) as exc_info:
+        asyncio.run(runtime.services.search.search(_request(), _context(), _execution()))
+    assert exc_info.value.code is ProviderErrorCode.PROVIDER_UNAVAILABLE
+    asyncio.run(runtime.close())
+
+
+def test_delivery_explicit_patentsview_uses_lazy_secret_transport(monkeypatch) -> None:
+    options: list[dict[str, object]] = []
+    calls = 0
+
+    class RuntimeTransport:
+        def __init__(self, **kwargs) -> None:
+            options.append(kwargs)
+
+        async def post(self, _url, json=None, **_kwargs):
+            nonlocal calls
+            calls += 1
+            assert json["q"] == {"_contains": {"patent_title": "neural network"}}
+            return httpx.Response(
+                200,
+                json={
+                    "patents": [
+                        {
+                            "patent_id": "11234567",
+                            "patent_title": "Bounded neural-network patent",
+                            "patent_abstract": "A deterministic patent fixture.",
+                            "patent_date": "2023-01-31",
+                            "inventors": [],
+                            "assignees": [],
+                            "cpcs": [],
+                            "ipcs": [],
+                            "patent_type": "utility",
+                        }
+                    ],
+                    "total_patent_count": 1,
+                },
+            )
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.delenv("SOUWEN_BROWSER_WORKER_TOKEN", raising=False)
+    monkeypatch.setattr("souwen.server.v2_runtime.HttpTransport", RuntimeTransport)
+    runtime = build_target_runtime(
+        SouWenConfig(sources={"patentsview": {"enabled": True, "api_key": "secret-canary"}})
+    )
+    assert options == []
+    app = create_target_delivery_app(
+        runtime.services,
+        runtime.metadata,
+        require_user=lambda: None,
+        rate_limit=lambda: None,
+        closer=runtime.close,
+    )
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.post(
+            "/api/v1/search",
+            headers={"X-Request-ID": "patentsview-delivery", "X-SouWen-API-Major": "2"},
+            json={
+                "query": "neural network",
+                "domains": ["patent"],
+                "providers": [{"id": "patentsview", "kind": "search"}],
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["items"][0]["id"] == "patentsview:11234567"
+    assert calls == 1
+    assert options[0]["base_url"] == "https://search.patentsview.org/api/v1"
+    assert options[0]["headers"]["X-Api-Key"] == "secret-canary"
+    assert "secret-canary" not in response.text
+
+
+def test_basic_edition_never_makes_patentsview_eligible(monkeypatch) -> None:
+    monkeypatch.delenv("SOUWEN_BROWSER_WORKER_TOKEN", raising=False)
+    runtime = build_target_runtime(
+        SouWenConfig(
+            edition="basic",
+            sources={"patentsview": {"enabled": True, "api_key": "secret-canary"}},
+        )
+    )
+
+    assert "patentsview-search" not in runtime.manager.eligible_adapter_ids
+    assert "secret-canary" not in repr(runtime.manager.diagnostics)
+
+    without_key = build_target_runtime(
+        SouWenConfig(edition="basic", sources={"patentsview": {"enabled": True}})
+    )
+    item = next(
+        item for item in without_key.services.provider_items if item.provider == "patentsview"
+    )
+    assert item.reason == "not_eligible"
+    assert item.missing_fields == ()


### PR DESCRIPTION
## Summary

- add authenticated PatentsView Provider v2 manifest and canonical adapter
- preserve legacy `pro` edition policy and register PatentsView as explicit-only, never as the target patent default
- resolve and redact the required API key before eligibility, then lazy-create a fixed-host transport
- add bounded patent DTO mapping, cancellation/lifecycle/error tests, Delivery API coverage, and migration documentation
- extend the existing Provider v2 conformance CI gate

## Compatibility and rollback

- legacy registry/client remain the coexistence and rollback truth
- missing, blank, disabled, or basic-edition credentials remain unavailable without affecting required readiness
- no deployment, tag, Release, or publication behavior is changed

## Validation

- full pytest: `2704 passed, 3 skipped`
- post-review config/provider regression: `186 passed`
- `ruff check src tests scripts tools`
- `ruff format --check src tests scripts tools`
- architecture, generated docs, Markdown links, actionlint, legacy-term gate
- pro/basic CI profiles
- two final read-only reviews: proceed/pass
