### PR TITLE
ci: prove four RC2 server bundles

### DIFF
--- a/.github/actions/server-bundle-smoke/action.yml
+++ b/.github/actions/server-bundle-smoke/action.yml
@@ -1,0 +1,426 @@
+name: Souwen RC2 server bundle smoke
+description: Unpack and verify one final target-native PyInstaller server archive
+
+inputs:
+  archive:
+    description: Path to the final .tar.gz or .zip archive
+    required: true
+  platform:
+    description: linux-amd64, linux-arm64, macos-arm64, or windows-amd64
+    required: true
+  candidate-sha:
+    description: Exact 40-character source SHA embedded in the bundle
+    required: true
+  version:
+    description: Expected RC version
+    required: true
+  openapi-sha256:
+    description: Expected canonical target OpenAPI SHA-256
+    required: true
+  report-json:
+    description: Machine-readable smoke evidence output path
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Verify unpacked final archive on the target runner
+      shell: bash
+      env:
+        SOUWEN_SERVER_ARCHIVE: ${{ inputs.archive }}
+        SOUWEN_SERVER_PLATFORM: ${{ inputs.platform }}
+        SOUWEN_SERVER_CANDIDATE_SHA: ${{ inputs.candidate-sha }}
+        SOUWEN_SERVER_VERSION: ${{ inputs.version }}
+        SOUWEN_SERVER_OPENAPI_SHA256: ${{ inputs.openapi-sha256 }}
+        SOUWEN_SERVER_REPORT_JSON: ${{ inputs.report-json }}
+      run: |
+        python - <<'PY'
+        from __future__ import annotations
+
+        import contextlib
+        import hashlib
+        import json
+        import os
+        import platform as platform_info
+        import re
+        import shutil
+        import signal
+        import socket
+        import subprocess
+        import tarfile
+        import tempfile
+        import time
+        import urllib.error
+        import urllib.request
+        import zipfile
+        from pathlib import Path
+
+
+        archive = Path(os.environ['SOUWEN_SERVER_ARCHIVE']).resolve()
+        platform = os.environ['SOUWEN_SERVER_PLATFORM']
+        candidate_sha = os.environ['SOUWEN_SERVER_CANDIDATE_SHA']
+        expected_version = os.environ['SOUWEN_SERVER_VERSION']
+        expected_openapi_sha256 = os.environ['SOUWEN_SERVER_OPENAPI_SHA256']
+        report_path = Path(os.environ['SOUWEN_SERVER_REPORT_JSON'])
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        checks: list[dict[str, str]] = []
+        failure: Exception | None = None
+        server: subprocess.Popen[bytes] | None = None
+        api_port: int | None = None
+        worker_port: int | None = None
+        termination_forced = False
+        temp_root: Path | None = None
+
+        expected_archives = {
+            'linux-amd64': 'souwen-server-2.0.0rc2-linux-amd64.tar.gz',
+            'linux-arm64': 'souwen-server-2.0.0rc2-linux-arm64.tar.gz',
+            'macos-arm64': 'souwen-server-2.0.0rc2-macos-arm64.tar.gz',
+            'windows-amd64': 'souwen-server-2.0.0rc2-windows-amd64.zip',
+        }
+        user_fixture = 'rc2-server-bundle-user-fixture'
+
+        def record(name: str, status: str, detail: str) -> None:
+            checks.append({'name': name, 'status': status, 'detail': detail[:500]})
+
+        def sha256_file(path: Path) -> str:
+            digest = hashlib.sha256()
+            with path.open('rb') as source:
+                for chunk in iter(lambda: source.read(1024 * 1024), b''):
+                    digest.update(chunk)
+            return digest.hexdigest()
+
+        def safe_destination(root: Path, member_name: str) -> Path:
+            destination = (root / member_name).resolve()
+            if root.resolve() not in destination.parents and destination != root.resolve():
+                raise RuntimeError(f'unsafe archive member: {member_name!r}')
+            return destination
+
+        def extract_final_archive(root: Path) -> Path:
+            if archive.name.endswith('.tar.gz'):
+                with tarfile.open(archive, 'r:gz') as payload:
+                    for member in payload.getmembers():
+                        safe_destination(root, member.name)
+                        if member.issym() or member.islnk():
+                            raise RuntimeError(f'archive contains a link: {member.name!r}')
+                    payload.extractall(root, filter='data')
+            elif archive.name.endswith('.zip'):
+                with zipfile.ZipFile(archive) as payload:
+                    for member in payload.infolist():
+                        safe_destination(root, member.filename)
+                    payload.extractall(root)
+            else:
+                raise RuntimeError('unsupported server bundle archive format')
+            bundle_root = root / 'souwen-server'
+            if not bundle_root.is_dir():
+                raise RuntimeError('archive root directory must be exactly souwen-server/')
+            top_level = {path.name for path in root.iterdir()}
+            if top_level != {'souwen-server'}:
+                raise RuntimeError(f'archive has unexpected top-level entries: {sorted(top_level)}')
+            return bundle_root
+
+        def target_native_machine() -> str:
+            machine = platform_info.machine().strip().lower()
+            if os.name == 'nt':
+                observed = 'windows-amd64' if machine in {'amd64', 'x86_64'} else ''
+            elif platform_info.system() == 'Darwin':
+                observed = 'macos-arm64' if machine in {'arm64', 'aarch64'} else ''
+            elif platform_info.system() == 'Linux' and machine in {'amd64', 'x86_64'}:
+                observed = 'linux-amd64'
+            elif platform_info.system() == 'Linux' and machine in {'arm64', 'aarch64'}:
+                observed = 'linux-arm64'
+            else:
+                observed = ''
+            if observed != platform:
+                raise RuntimeError(
+                    f'target-native runner mismatch: expected={platform}, '
+                    f'os={platform_info.system()}, machine={machine}'
+                )
+            return machine
+
+        def free_port() -> int:
+            with socket.socket() as listener:
+                listener.bind(('127.0.0.1', 0))
+                return listener.getsockname()[1]
+
+        def request(
+            base_url: str,
+            path: str,
+            *,
+            expected: tuple[int, ...] = (200,),
+            headers: dict[str, str] | None = None,
+        ) -> tuple[int, bytes, dict[str, str]]:
+            req = urllib.request.Request(f'{base_url}{path}', headers=headers or {})
+            try:
+                with urllib.request.urlopen(req, timeout=10) as response:
+                    code = response.status
+                    body = response.read(2 * 1024 * 1024)
+                    response_headers = dict(response.headers.items())
+            except urllib.error.HTTPError as exc:
+                code = exc.code
+                body = exc.read(2 * 1024 * 1024)
+                response_headers = dict(exc.headers.items())
+            if code not in expected:
+                raise RuntimeError(f'{path} returned HTTP {code}; expected {list(expected)}')
+            return code, body, {name.lower(): value for name, value in response_headers.items()}
+
+        def wait_for_health(base_url: str) -> tuple[dict[str, object], dict[str, str]]:
+            deadline = time.monotonic() + 90
+            while time.monotonic() < deadline:
+                if server is not None and server.poll() is not None:
+                    raise RuntimeError(f'server bundle exited before health: {server.returncode}')
+                try:
+                    _, body, headers = request(base_url, '/health')
+                    return json.loads(body), headers
+                except (OSError, ValueError, RuntimeError):
+                    time.sleep(0.5)
+            raise RuntimeError('server bundle did not become healthy within 90 seconds')
+
+        def port_is_closed(port: int) -> bool:
+            try:
+                with socket.create_connection(('127.0.0.1', port), timeout=0.25):
+                    return False
+            except OSError:
+                return True
+
+        def stop_server() -> None:
+            global termination_forced
+            if server is None or server.poll() is not None:
+                return
+            if os.name == 'nt' and hasattr(signal, 'CTRL_BREAK_EVENT'):
+                server.send_signal(signal.CTRL_BREAK_EVENT)
+            else:
+                server.terminate()
+            try:
+                server.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                termination_forced = True
+                server.kill()
+                server.wait(timeout=10)
+
+        try:
+            if platform not in expected_archives:
+                raise RuntimeError(f'unsupported server bundle platform: {platform!r}')
+            if archive.name != expected_archives[platform]:
+                raise RuntimeError(
+                    f'archive name mismatch: expected={expected_archives[platform]!r}, '
+                    f'actual={archive.name!r}'
+                )
+            if expected_version != '2.0.0rc2':
+                raise RuntimeError(f'unsupported server bundle version: {expected_version!r}')
+            if re.fullmatch(r'[0-9a-f]{40}', candidate_sha) is None:
+                raise RuntimeError('candidate SHA must be exactly 40 lowercase hexadecimal characters')
+            if re.fullmatch(r'[0-9a-f]{64}', expected_openapi_sha256) is None:
+                raise RuntimeError('OpenAPI checksum must be exactly 64 lowercase hexadecimal characters')
+            if not archive.is_file() or archive.stat().st_size == 0:
+                raise RuntimeError(f'server bundle archive is missing or empty: {archive}')
+            archive_sha256 = sha256_file(archive)
+            record('archive/inventory', 'PASS', f'name={archive.name}, sha256={archive_sha256}')
+            machine = target_native_machine()
+            record('runner/target-native', 'PASS', f'platform={platform}, machine={machine}')
+
+            with contextlib.nullcontext(
+                tempfile.mkdtemp(prefix='souwen-server-bundle-smoke-')
+            ) as tempdir:
+                temp_root = Path(tempdir)
+                bundle_root = extract_final_archive(temp_root / 'unpacked')
+                executable = bundle_root / ('souwen-server.exe' if os.name == 'nt' else 'souwen-server')
+                if not executable.is_file():
+                    raise RuntimeError(f'server executable is missing: {executable.name}')
+                if os.name != 'nt' and not os.access(executable, os.X_OK):
+                    raise RuntimeError('server executable is not executable')
+                source_receipt = bundle_root / 'runtime.source.sha'
+                if source_receipt.read_text(encoding='utf-8').strip() != candidate_sha:
+                    raise RuntimeError('archive-level source provenance does not match candidate SHA')
+                record('archive/source-provenance', 'PASS', candidate_sha)
+                browser_root = bundle_root / 'ms-playwright'
+                browser_files = [path for path in browser_root.rglob('*') if path.is_file()]
+                if not browser_files:
+                    raise RuntimeError('final archive does not contain Playwright Chromium')
+                browser_executables = [
+                    path
+                    for path in browser_files
+                    if path.name.lower()
+                    in {'chrome', 'chrome.exe', 'chrome-headless-shell', 'chromium', 'headless_shell'}
+                ]
+                if not browser_executables:
+                    raise RuntimeError('final archive does not contain a Chromium executable')
+                record(
+                    'archive/playwright-chromium',
+                    'PASS',
+                    f'files={len(browser_files)}, executables={len(browser_executables)}',
+                )
+
+                runtime_env = os.environ.copy()
+                for name in (
+                    'SOUWEN_SOURCE_SHA',
+                    'SOUWEN_SOURCE_SHA_FILE',
+                    'SOUWEN_ADMIN_PASSWORD',
+                    'SOUWEN_USER_PASSWORD',
+                    'SOUWEN_BROWSER_WORKER_TOKEN',
+                ):
+                    runtime_env.pop(name, None)
+                runtime_env.update(
+                    {
+                        'HOME': str(temp_root / 'home'),
+                        'PYTHONIOENCODING': 'utf-8',
+                        'SOUWEN_PLUGIN_AUTOLOAD': '0',
+                        'SOUWEN_V2_ROLLOUT': 'target',
+                        'SOUWEN_ADMIN_OPEN': '0',
+                        'SOUWEN_EXPOSE_DOCS': '1',
+                        'SOUWEN_USER_PASSWORD': user_fixture,
+                    }
+                )
+                Path(runtime_env['HOME']).mkdir()
+
+                api_port = free_port()
+                worker_port = free_port()
+                while worker_port == api_port:
+                    worker_port = free_port()
+                runtime_env['HOST'] = '127.0.0.1'
+                runtime_env['PORT'] = str(api_port)
+                runtime_env['SOUWEN_BROWSER_WORKER_PORT'] = str(worker_port)
+                creationflags = (
+                    subprocess.CREATE_NEW_PROCESS_GROUP
+                    if os.name == 'nt' and hasattr(subprocess, 'CREATE_NEW_PROCESS_GROUP')
+                    else 0
+                )
+                server = subprocess.Popen(
+                    [str(executable)],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    env=runtime_env,
+                    creationflags=creationflags,
+                    start_new_session=os.name != 'nt',
+                )
+                base_url = f'http://127.0.0.1:{api_port}'
+                health, health_headers = wait_for_health(base_url)
+                if (
+                    health.get('version') != expected_version
+                    or health.get('source_sha') != candidate_sha
+                    or health.get('rollout_mode') != 'target'
+                ):
+                    raise RuntimeError(f'health provenance mismatch: {health}')
+                if health_headers.get('x-souwen-api-major') != '2':
+                    raise RuntimeError('health response omitted API major 2')
+                if health_headers.get('x-souwen-rollout-mode') != 'target':
+                    raise RuntimeError('health response omitted target rollout header')
+                record('server/health', 'PASS', 'version, source SHA, API major, target rollout')
+
+                _, readiness_body, _ = request(base_url, '/readiness')
+                readiness = json.loads(readiness_body)
+                if (
+                    readiness.get('ready') is not True
+                    or readiness.get('source_sha') != candidate_sha
+                    or readiness.get('worker_source_sha') != candidate_sha
+                    or readiness.get('rollout_mode') != 'target'
+                    or readiness.get('components', {}).get('browser_worker') != 'ready'
+                ):
+                    raise RuntimeError(f'target readiness/browser worker mismatch: {readiness}')
+                record('server/readiness-browser-worker', 'PASS', 'target runtime and worker ready')
+
+                api_headers = {
+                    'X-SouWen-API-Major': '2',
+                    'X-Request-ID': 'server-bundle-provider-catalog',
+                    'X-SouWen-Token': user_fixture,
+                }
+                _, providers_body, provider_headers = request(
+                    base_url, '/api/v1/providers', headers=api_headers
+                )
+                providers = json.loads(providers_body)
+                if providers.get('context', {}).get('request_id') != 'server-bundle-provider-catalog':
+                    raise RuntimeError(f'provider catalog context mismatch: {providers}')
+                if not isinstance(providers.get('items'), list) or not providers['items']:
+                    raise RuntimeError('canonical provider catalog is empty or malformed')
+                if provider_headers.get('x-souwen-api-major') != '2':
+                    raise RuntimeError('provider catalog omitted API major 2')
+                if provider_headers.get('x-souwen-rollout-mode') != 'target':
+                    raise RuntimeError('provider catalog omitted target rollout header')
+                record('server/canonical-provider-api', 'PASS', f'items={len(providers["items"])}')
+
+                _, mismatch_body, _ = request(
+                    base_url,
+                    '/api/v1/providers',
+                    expected=(409,),
+                    headers={
+                        'X-SouWen-API-Major': '1',
+                        'X-SouWen-Token': user_fixture,
+                    },
+                )
+                mismatch = json.loads(mismatch_body)
+                if mismatch.get('error', {}).get('code') != 'api_major_mismatch':
+                    raise RuntimeError(f'API-major mismatch did not fail closed: {mismatch}')
+                record('server/api-major-fail-closed', 'PASS', 'unsupported major returned 409')
+
+                request(base_url, '/api/v1/admin/ping', expected=(401,))
+                record('server/admin-fail-closed', 'PASS', 'unauthenticated admin returned 401')
+
+                _, openapi_body, _ = request(base_url, '/openapi.json')
+                openapi = json.loads(openapi_body)
+                if openapi.get('x-souwen-api-major') != 2:
+                    raise RuntimeError('target OpenAPI omitted API major 2')
+                if openapi.get('x-souwen-rollout-mode') != 'target':
+                    raise RuntimeError('target OpenAPI omitted rollout mode')
+                required_paths = {
+                    '/api/v1/search',
+                    '/api/v1/llm-search',
+                    '/api/v1/fetch',
+                    '/api/v1/providers',
+                }
+                if not required_paths.issubset(openapi.get('paths', {})):
+                    raise RuntimeError('target OpenAPI is missing canonical operations')
+                canonical_openapi = json.dumps(
+                    openapi, sort_keys=True, separators=(',', ':'), ensure_ascii=False
+                ).encode('utf-8')
+                actual_openapi_sha256 = hashlib.sha256(canonical_openapi).hexdigest()
+                if actual_openapi_sha256 != expected_openapi_sha256:
+                    raise RuntimeError(
+                        'OpenAPI checksum mismatch: '
+                        f'expected={expected_openapi_sha256}, actual={actual_openapi_sha256}'
+                    )
+                record('server/openapi-checksum', 'PASS', actual_openapi_sha256)
+
+                stop_server()
+                if termination_forced:
+                    raise RuntimeError('server bundle required a forced kill during termination')
+                deadline = time.monotonic() + 20
+                while time.monotonic() < deadline:
+                    if port_is_closed(api_port) and port_is_closed(worker_port):
+                        break
+                    time.sleep(0.25)
+                else:
+                    raise RuntimeError('server bundle left API or Browser Worker port open')
+                record(
+                    'server/clean-termination',
+                    'PASS',
+                    f'parent, API, and worker stopped; exit={server.returncode}',
+                )
+        except Exception as exc:
+            failure = exc
+            record('server-bundle-smoke', 'FAIL', f'{type(exc).__name__}: {exc}')
+        finally:
+            stop_server()
+            if temp_root is not None:
+                shutil.rmtree(temp_root, ignore_errors=True)
+            overall = 'FAIL' if failure else 'PASS'
+            payload = {
+                'schema_version': 1,
+                'script': 'github-composite/server-bundle-smoke',
+                'overall': overall,
+                'platform': platform,
+                'machine': platform_info.machine().strip().lower(),
+                'target_native': failure is None,
+                'version': expected_version,
+                'api_major': 2,
+                'candidate_sha': candidate_sha,
+                'archive': archive.name,
+                'archive_sha256': (
+                    sha256_file(archive) if archive.is_file() else None
+                ),
+                'openapi_sha256': expected_openapi_sha256,
+                'checks': checks,
+            }
+            report_path.write_text(json.dumps(payload, indent=2) + '\n', encoding='utf-8')
+
+        if failure is not None:
+            raise SystemExit(f'server bundle smoke failed: {failure}')
+        PY

--- a/.github/workflows/build-pyinstaller-server.yml
+++ b/.github/workflows/build-pyinstaller-server.yml
@@ -1,0 +1,497 @@
+# =============================================================================
+# RC2 target server bundle builder
+#
+# Builds exactly one native PyInstaller onedir archive per approved target. This
+# reusable workflow is an artifact producer only: it cannot tag, publish, or
+# deploy. workflow_dispatch exists solely for manual proof runs.
+# =============================================================================
+name: Build RC2 PyInstaller server bundles
+
+on:
+  workflow_call:
+    inputs:
+      candidate_sha:
+        description: 'Exact 40-character candidate commit SHA'
+        required: true
+        type: string
+    outputs:
+      bundle_artifact_pattern:
+        description: 'Artifact-name pattern containing the four native archives'
+        value: ${{ jobs.aggregate.outputs.bundle_artifact_pattern }}
+      smoke_artifact_pattern:
+        description: 'Artifact-name pattern containing target-native smoke JSON'
+        value: ${{ jobs.aggregate.outputs.smoke_artifact_pattern }}
+      inventory_artifact:
+        description: 'Artifact containing the bounded four-archive inventory JSON'
+        value: ${{ jobs.aggregate.outputs.inventory_artifact }}
+      binary_count:
+        description: 'Exact number of approved RC2 server bundles'
+        value: ${{ jobs.aggregate.outputs.binary_count }}
+  workflow_dispatch:
+    inputs:
+      candidate_sha:
+        description: 'Exact 40-character candidate commit SHA for a proof run'
+        required: true
+        type: string
+
+concurrency:
+  group: rc2-server-bundles-${{ inputs.candidate_sha }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  PYTHON_VERSION: '3.11'
+  RC_VERSION: '2.0.0rc2'
+  BUNDLE_ARTIFACT_PATTERN: souwen-server-bundle-*
+  SMOKE_ARTIFACT_PATTERN: souwen-server-smoke-*
+  INVENTORY_ARTIFACT: souwen-server-inventory-2.0.0rc2
+
+jobs:
+  validate:
+    name: Validate immutable server-bundle candidate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      candidate_sha: ${{ steps.candidate.outputs.candidate_sha }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.candidate_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate candidate and RC2 version
+        id: candidate
+        env:
+          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+        run: |
+          python3 -I - <<'PY'
+          import os
+          import re
+          import subprocess
+          import tomllib
+
+          candidate = os.environ['CANDIDATE_SHA']
+          if re.fullmatch(r'[0-9a-f]{40}', candidate) is None:
+              raise SystemExit('candidate_sha must be exactly 40 lowercase hexadecimal characters')
+          head = subprocess.check_output(['git', 'rev-parse', 'HEAD'], text=True).strip()
+          kind = subprocess.check_output(['git', 'cat-file', '-t', candidate], text=True).strip()
+          if head != candidate or kind != 'commit':
+              raise SystemExit(
+                  f'immutable checkout failed: head={head}, type={kind}, expected={candidate}'
+              )
+          with open('pyproject.toml', 'rb') as file:
+              version = tomllib.load(file)['project']['version']
+          if version != '2.0.0rc2':
+              raise SystemExit(f'server bundle requires version 2.0.0rc2, got {version!r}')
+          with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as output:
+              output.write(f'candidate_sha={candidate}\n')
+          PY
+
+  panel:
+    name: Build immutable Panel artifact
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate.outputs.candidate_sha }}
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: panel/package-lock.json
+
+      - name: Build and verify embedded Panel
+        working-directory: panel
+        run: |
+          npm ci
+          npm run build:local
+          npm run check:artifact
+
+      - name: Upload immutable Panel input
+        uses: actions/upload-artifact@v7
+        with:
+          name: rc2-server-panel-html
+          path: src/souwen/server/panel.html
+          if-no-files-found: error
+          retention-days: 1
+
+  build:
+    name: Server bundle (${{ matrix.arch }})
+    needs: [validate, panel]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            arch: linux-amd64
+            archive: souwen-server-2.0.0rc2-linux-amd64.tar.gz
+          - os: ubuntu-24.04-arm
+            arch: linux-arm64
+            archive: souwen-server-2.0.0rc2-linux-arm64.tar.gz
+          - os: macos-15
+            arch: macos-arm64
+            archive: souwen-server-2.0.0rc2-macos-arm64.tar.gz
+          - os: windows-2025
+            arch: windows-amd64
+            archive: souwen-server-2.0.0rc2-windows-amd64.zip
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.server-bundle-ms-playwright
+      SOUWEN_PLUGIN_AUTOLOAD: '0'
+      SOUWEN_V2_ROLLOUT: target
+      SOUWEN_ADMIN_OPEN: '0'
+      SOUWEN_EXPOSE_DOCS: '1'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate.outputs.candidate_sha }}
+          persist-credentials: false
+
+      - name: Checkout trusted server-bundle verifier
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .trusted-verifier
+          sparse-checkout: .github/actions/server-bundle-smoke
+          persist-credentials: false
+
+      - name: Download immutable Panel input
+        uses: actions/download-artifact@v8
+        with:
+          name: rc2-server-panel-html
+          path: src/souwen/server
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+
+      - name: Install target server build dependencies
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[edition-pro]"
+          pip install "playwright>=1.40" "setuptools<82" pyinstaller
+
+      - name: Install native Playwright Chromium into the bundle input
+        shell: bash
+        run: |
+          if [ "${{ runner.os }}" = Linux ]; then
+            python -m playwright install --with-deps chromium
+          else
+            python -m playwright install chromium
+          fi
+          python - <<'PY'
+          import os
+          from pathlib import Path
+
+          root = Path(os.environ['PLAYWRIGHT_BROWSERS_PATH'])
+          files = [path for path in root.rglob('*') if path.is_file()]
+          if not files:
+              raise SystemExit('Playwright Chromium installation produced no files')
+          print(f'Chromium bundle input: files={len(files)}')
+          PY
+
+      - name: Materialize immutable source provenance
+        shell: bash
+        env:
+          CANDIDATE_SHA: ${{ needs.validate.outputs.candidate_sha }}
+        run: |
+          printf '%s\n' "$CANDIDATE_SHA" > runtime.source.sha
+
+      - name: Compute target OpenAPI checksum
+        id: openapi
+        shell: bash
+        run: |
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+
+          from souwen.server.app import app
+
+          payload = json.dumps(
+              app.openapi(), sort_keys=True, separators=(',', ':'), ensure_ascii=False
+          ).encode('utf-8')
+          digest = hashlib.sha256(payload).hexdigest()
+          with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as output:
+              output.write(f'sha256={digest}\n')
+          print(f'target OpenAPI sha256={digest}')
+          PY
+
+      - name: Build target server with PyInstaller onedir
+        shell: bash
+        run: |
+          if [ "${{ runner.os }}" = Windows ]; then DATA_SEP=';'; else DATA_SEP=':'; fi
+          PYTHON_OPTIONS=()
+          if [ "${{ runner.os }}" = Windows ]; then
+            PYTHON_OPTIONS+=(--python-option "X utf8=1")
+          fi
+          pyinstaller --onedir --clean --noconfirm --name souwen-server \
+            "${PYTHON_OPTIONS[@]}" \
+            --paths src --paths deploy/process \
+            --add-data "runtime.source.sha${DATA_SEP}." \
+            --add-data "src/souwen/server/panel.html${DATA_SEP}souwen/server" \
+            --hidden-import=supervisor \
+            --hidden-import=souwen.server.app \
+            --hidden-import=souwen.worker.browser_fetch.runtime \
+            --collect-submodules=souwen.server \
+            --collect-submodules=souwen.delivery \
+            --collect-submodules=souwen.providers \
+            --collect-submodules=souwen.registry.sources \
+            --collect-submodules=souwen.worker.browser_fetch \
+            --collect-submodules=rich._unicode_data \
+            --collect-all=playwright \
+            deploy/process/server_main.py
+
+      - name: Stage Chromium and create the final archive
+        id: archive
+        shell: bash
+        env:
+          ARCHIVE_NAME: ${{ matrix.archive }}
+          ARCH: ${{ matrix.arch }}
+        run: |
+          python - <<'PY'
+          import os
+          import shutil
+          import tarfile
+          from pathlib import Path
+
+          archive_name = os.environ['ARCHIVE_NAME']
+          bundle_name = 'souwen-server'
+          source = Path('dist/souwen-server')
+          stage = Path('server-bundle-stage') / bundle_name
+          shutil.copytree(source, stage)
+          shutil.copy2('runtime.source.sha', stage / 'runtime.source.sha')
+          shutil.copytree(
+              Path(os.environ['PLAYWRIGHT_BROWSERS_PATH']),
+              stage / 'ms-playwright',
+          )
+          output = Path('server-bundle-output') / archive_name
+          output.parent.mkdir(parents=True, exist_ok=True)
+          if archive_name.endswith('.zip'):
+              produced = shutil.make_archive(
+                  str(output.with_suffix('')), 'zip', root_dir=stage.parent, base_dir=bundle_name
+              )
+              if Path(produced) != output:
+                  raise SystemExit(f'unexpected zip output: {produced}')
+          else:
+              with tarfile.open(output, 'w:gz') as archive:
+                  archive.add(stage, arcname=bundle_name)
+          if not output.is_file() or output.stat().st_size == 0:
+              raise SystemExit(f'archive was not created: {output}')
+          with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as workflow_output:
+              workflow_output.write(f'path={output.as_posix()}\n')
+          PY
+
+      - name: Unpack final archive and run target-native server smoke
+        uses: ./.trusted-verifier/.github/actions/server-bundle-smoke
+        with:
+          archive: ${{ steps.archive.outputs.path }}
+          platform: ${{ matrix.arch }}
+          candidate-sha: ${{ needs.validate.outputs.candidate_sha }}
+          version: ${{ env.RC_VERSION }}
+          openapi-sha256: ${{ steps.openapi.outputs.sha256 }}
+          report-json: server-bundle-evidence/server-bundle-smoke-${{ matrix.arch }}.json
+
+      - name: Upload target-native smoke evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: souwen-server-smoke-${{ matrix.arch }}
+          path: server-bundle-evidence/server-bundle-smoke-${{ matrix.arch }}.json
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload immutable server bundle
+        uses: actions/upload-artifact@v7
+        with:
+          name: souwen-server-bundle-${{ matrix.arch }}
+          path: ${{ steps.archive.outputs.path }}
+          if-no-files-found: error
+          retention-days: 30
+
+  aggregate:
+    name: Verify four-bundle inventory
+    needs: [validate, build]
+    if: ${{ always() && needs.validate.result == 'success' && needs.build.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      bundle_artifact_pattern: ${{ steps.contract.outputs.bundle_artifact_pattern }}
+      smoke_artifact_pattern: ${{ steps.contract.outputs.smoke_artifact_pattern }}
+      inventory_artifact: ${{ steps.contract.outputs.inventory_artifact }}
+      binary_count: ${{ steps.contract.outputs.binary_count }}
+    steps:
+      - name: Download four native bundle artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: souwen-server-bundle-*
+          path: aggregate/bundles
+          merge-multiple: true
+
+      - name: Download four target-native smoke artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: souwen-server-smoke-*
+          path: aggregate/smoke
+          merge-multiple: true
+
+      - name: Verify exact inventory and emit reusable outputs
+        id: contract
+        env:
+          CANDIDATE_SHA: ${{ needs.validate.outputs.candidate_sha }}
+          VERIFIER_SHA: ${{ github.workflow_sha }}
+        run: |
+          python3 - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          def sha256_file(path: Path) -> str:
+              digest = hashlib.sha256()
+              with path.open('rb') as source:
+                  for chunk in iter(lambda: source.read(1024 * 1024), b''):
+                      digest.update(chunk)
+              return digest.hexdigest()
+
+          expected = {
+              'linux-amd64': 'souwen-server-2.0.0rc2-linux-amd64.tar.gz',
+              'linux-arm64': 'souwen-server-2.0.0rc2-linux-arm64.tar.gz',
+              'macos-arm64': 'souwen-server-2.0.0rc2-macos-arm64.tar.gz',
+              'windows-amd64': 'souwen-server-2.0.0rc2-windows-amd64.zip',
+          }
+          bundle_root = Path('aggregate/bundles')
+          actual = {path.name for path in bundle_root.iterdir() if path.is_file()}
+          expected_names = set(expected.values())
+          if actual != expected_names:
+              raise SystemExit(
+                  'server bundle inventory mismatch: '
+                  f'missing={sorted(expected_names - actual)}, '
+                  f'unexpected={sorted(actual - expected_names)}'
+              )
+          smoke_root = Path('aggregate/smoke')
+          reports = sorted(smoke_root.glob('server-bundle-smoke-*.json'))
+          if len(reports) != 4:
+              raise SystemExit(f'expected exactly four smoke reports, got {len(reports)}')
+          candidate = os.environ['CANDIDATE_SHA']
+          verifier = os.environ['VERIFIER_SHA']
+          if len(verifier) != 40 or any(char not in '0123456789abcdef' for char in verifier):
+              raise SystemExit('verifier SHA must be exactly 40 lowercase hexadecimal characters')
+          bundle_digests = {
+              path.name: sha256_file(path)
+              for path in bundle_root.iterdir()
+              if path.is_file()
+          }
+          reports_by_platform = {}
+          required_checks = {
+              'archive/inventory',
+              'archive/playwright-chromium',
+              'archive/source-provenance',
+              'runner/target-native',
+              'server/health',
+              'server/readiness-browser-worker',
+              'server/canonical-provider-api',
+              'server/api-major-fail-closed',
+              'server/admin-fail-closed',
+              'server/openapi-checksum',
+              'server/clean-termination',
+          }
+          for report in reports:
+              payload = json.loads(report.read_text(encoding='utf-8'))
+              platform = payload.get('platform')
+              if platform not in expected or platform in reports_by_platform:
+                  raise SystemExit(f'duplicate or unexpected smoke platform: {report}')
+              checks = payload.get('checks')
+              if not isinstance(checks, list):
+                  raise SystemExit(f'smoke report has no checks list: {report}')
+              checks_by_name = {}
+              for check in checks:
+                  if not isinstance(check, dict):
+                      raise SystemExit(f'smoke report contains a malformed check: {report}')
+                  name = check.get('name')
+                  if not isinstance(name, str) or name in checks_by_name:
+                      raise SystemExit(f'smoke report contains a duplicate check: {report}')
+                  checks_by_name[name] = check.get('status')
+              if set(checks_by_name) != required_checks or any(
+                  status != 'PASS' for status in checks_by_name.values()
+              ):
+                  raise SystemExit(f'smoke report check inventory is not exact PASS: {report}')
+              if (
+                  payload.get('overall') != 'PASS'
+                  or payload.get('target_native') is not True
+                  or payload.get('candidate_sha') != candidate
+                  or payload.get('version') != '2.0.0rc2'
+                  or payload.get('api_major') != 2
+                  or payload.get('archive') != expected[platform]
+                  or payload.get('archive_sha256') != bundle_digests[expected[platform]]
+                  or not isinstance(payload.get('machine'), str)
+                  or not payload['machine']
+                  or not isinstance(payload.get('openapi_sha256'), str)
+                  or len(payload['openapi_sha256']) != 64
+              ):
+                  raise SystemExit(f'invalid target-native smoke report: {report}')
+              reports_by_platform[platform] = (report.name, payload)
+          if set(reports_by_platform) != set(expected):
+              raise SystemExit(
+                  f'smoke platform inventory mismatch: {sorted(reports_by_platform)}'
+              )
+          openapi_checksums = {
+              payload['openapi_sha256'] for _report, payload in reports_by_platform.values()
+          }
+          if len(openapi_checksums) != 1:
+              raise SystemExit(
+                  f'OpenAPI checksum differs across native bundles: {sorted(openapi_checksums)}'
+              )
+          inventory = {
+              'schema_version': 1,
+              'version': '2.0.0rc2',
+              'candidate_sha': candidate,
+              'verifier_sha': verifier,
+              'workflow_identity': '.github/workflows/build-pyinstaller-server.yml',
+              'api_major': 2,
+              'openapi_sha256': next(iter(openapi_checksums)),
+              'binary_count': 4,
+              'bundles': [
+                  {
+                      'name': archive_name,
+                      'platform': platform,
+                      'size': path.stat().st_size,
+                      'sha256': bundle_digests[archive_name],
+                      'candidate_sha': candidate,
+                      'api_major': 2,
+                      'openapi_sha256': reports_by_platform[platform][1]['openapi_sha256'],
+                      'target_native': True,
+                      'smoke_overall': 'PASS',
+                      'smoke_report': reports_by_platform[platform][0],
+                  }
+                  for platform, archive_name in sorted(expected.items())
+                  for path in (bundle_root / archive_name,)
+              ],
+              'smoke_reports': [report.name for report in reports],
+          }
+          output_path = Path('aggregate/server-bundle-inventory.json')
+          output_path.write_text(json.dumps(inventory, indent=2) + '\n', encoding='utf-8')
+          with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as output:
+              output.write('bundle_artifact_pattern=souwen-server-bundle-*\n')
+              output.write('smoke_artifact_pattern=souwen-server-smoke-*\n')
+              output.write('inventory_artifact=souwen-server-inventory-2.0.0rc2\n')
+              output.write('binary_count=4\n')
+          PY
+
+      - name: Upload bounded inventory
+        uses: actions/upload-artifact@v7
+        with:
+          name: souwen-server-inventory-2.0.0rc2
+          path: aggregate/server-bundle-inventory.json
+          if-no-files-found: error
+          retention-days: 30

--- a/deploy/process/server_main.py
+++ b/deploy/process/server_main.py
@@ -1,0 +1,105 @@
+"""Frozen-aware entry point for the target SouWen server bundle."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+if __package__:
+    from .supervisor import INTERNAL_ROLE_ENV, DeploymentSettings, main as supervisor_main
+else:
+    from supervisor import INTERNAL_ROLE_ENV, DeploymentSettings, main as supervisor_main
+
+
+logger = logging.getLogger("souwen.deployment.server_main")
+_ROLLOUT_ENV = "SOUWEN_V2_ROLLOUT"
+_BROWSER_DIRNAME = "ms-playwright"
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="souwen-server",
+        description="Start the target SouWen API runtime and its internal Browser Worker.",
+    )
+    parser.add_argument("--host", choices=("0.0.0.0", "127.0.0.1"))
+    parser.add_argument("--port", type=int)
+    parser.add_argument(
+        "--internal-role",
+        choices=("worker", "api"),
+        help=argparse.SUPPRESS,
+    )
+    return parser
+
+
+def _force_target_rollout() -> None:
+    configured = os.environ.get(_ROLLOUT_ENV, "").strip().lower()
+    if configured and configured != "target":
+        raise ValueError("souwen-server only supports SOUWEN_V2_ROLLOUT=target")
+    os.environ[_ROLLOUT_ENV] = "target"
+
+
+def _configure_frozen_browser_runtime() -> None:
+    if not getattr(sys, "frozen", False):
+        return
+    browser_root = Path(sys.executable).resolve().parent / _BROWSER_DIRNAME
+    if not browser_root.is_dir():
+        raise RuntimeError("souwen-server bundle is missing its Playwright Chromium runtime")
+    os.environ["PLAYWRIGHT_BROWSERS_PATH"] = str(browser_root)
+
+
+def _run_worker() -> None:
+    from souwen.worker.browser_fetch.runtime import run
+
+    run()
+
+
+def _run_api() -> None:
+    import uvicorn
+
+    settings = DeploymentSettings.from_env()
+    uvicorn.run(
+        "souwen.server.app:app",
+        host=settings.api_host,
+        port=settings.api_port,
+        workers=1,
+        log_level="info",
+        access_log=True,
+        timeout_keep_alive=120,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _parser()
+    args = parser.parse_args(argv)
+    if args.internal_role is not None and os.environ.get(INTERNAL_ROLE_ENV) != "1":
+        parser.error("internal server roles are reserved for the SouWen supervisor")
+
+    try:
+        _force_target_rollout()
+        _configure_frozen_browser_runtime()
+        if args.host is not None:
+            os.environ["HOST"] = args.host
+        if args.port is not None:
+            os.environ["PORT"] = str(args.port)
+
+        if args.internal_role == "worker":
+            _run_worker()
+            return 0
+        if args.internal_role == "api":
+            _run_api()
+            return 0
+        return supervisor_main()
+    except (RuntimeError, ValueError) as exc:
+        logger.error("server bundle entry point failed: %s", exc)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = ["main"]

--- a/deploy/process/supervisor.py
+++ b/deploy/process/supervisor.py
@@ -29,6 +29,7 @@ from souwen.worker.browser_fetch.protocol import (
 
 logger = logging.getLogger("souwen.deployment.supervisor")
 _FULL_SHA_LENGTH = 40
+INTERNAL_ROLE_ENV = "SOUWEN_SERVER_INTERNAL_ROLE"
 
 
 class ChildProcess(Protocol):
@@ -236,9 +237,12 @@ class DeploymentSupervisor:
     def _child_env(self) -> dict[str, str]:
         env = dict(os.environ)
         env["SOUWEN_V2_ROLLOUT"] = self.settings.rollout_mode.value
+        env["HOST"] = self.settings.api_host
+        env["PORT"] = str(self.settings.api_port)
         env["SOUWEN_BROWSER_WORKER_HOST"] = self.settings.worker_host
         env["SOUWEN_BROWSER_WORKER_PORT"] = str(self.settings.worker_port)
         env["SOUWEN_BROWSER_WORKER_TOKEN"] = self._token
+        env[INTERNAL_ROLE_ENV] = "1"
         if self.settings.source_sha is not None:
             env["SOUWEN_SOURCE_SHA"] = self.settings.source_sha
         if self.settings.wrapper_sha is not None:
@@ -248,9 +252,13 @@ class DeploymentSupervisor:
         return env
 
     def _worker_command(self) -> tuple[str, ...]:
+        if getattr(sys, "frozen", False):
+            return (sys.executable, "--internal-role", "worker")
         return (sys.executable, "-m", "souwen.worker.browser_fetch.runtime")
 
     def _api_command(self) -> tuple[str, ...]:
+        if getattr(sys, "frozen", False):
+            return (sys.executable, "--internal-role", "api")
         return (
             sys.executable,
             "-m",
@@ -296,12 +304,14 @@ class DeploymentSupervisor:
             if process is not None and process.poll() is None:
                 try:
                     self._send_signal(process, signum)
-                except OSError:
+                except (OSError, ValueError):
                     pass
 
     def _install_signal_handlers(self) -> None:
         signal.signal(signal.SIGTERM, self._handle_signal)
         signal.signal(signal.SIGINT, self._handle_signal)
+        if hasattr(signal, "SIGBREAK"):
+            signal.signal(signal.SIGBREAK, self._handle_signal)
         if hasattr(signal, "SIGHUP"):
             signal.signal(signal.SIGHUP, signal.SIG_IGN)
 
@@ -330,6 +340,13 @@ class DeploymentSupervisor:
         if self._use_process_groups and os.name == "posix":
             os.killpg(process.pid, signum)
         else:
+            if (
+                os.name == "nt"
+                and hasattr(signal, "SIGBREAK")
+                and hasattr(signal, "CTRL_BREAK_EVENT")
+                and signum == signal.SIGBREAK
+            ):
+                signum = signal.CTRL_BREAK_EVENT
             process.send_signal(signum)
 
     def _kill_remaining_group(self, process: ChildProcess) -> None:
@@ -406,4 +423,4 @@ if __name__ == "__main__":
     raise SystemExit(main())
 
 
-__all__ = ["DeploymentSettings", "DeploymentSupervisor", "main"]
+__all__ = ["DeploymentSettings", "DeploymentSupervisor", "INTERNAL_ROLE_ENV", "main"]

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -58,6 +58,47 @@ artifacts，不创建 Release；tag 与 prerelease 只能由 central workflow �
 当前 central workflow 还会拒绝 `publish=true`；Phase 8 完成四 server bundle、manifest 和
 target-native smoke 契约后才能解除该保护。
 
+## RC2 PyInstaller Server bundle
+
+`.github/workflows/build-pyinstaller-server.yml` 是 RC2 四平台 Server bundle builder。它既可由
+`workflow_dispatch` 对一个 40 位 immutable candidate做独立 proof，也可由 central release
+workflow 通过 `workflow_call` 调用。Builder 不创建 tag、Release或HFS deployment。
+Candidate checkout只提供待构建源码；target-native smoke action另从 `github.workflow_sha`
+checkout trusted verifier，aggregate要求精确required-check集合全部 `PASS`，不能信任candidate
+自行生成的summary字段。
+
+正式 archive 名称固定为：
+
+```text
+souwen-server-2.0.0rc2-linux-amd64.tar.gz
+souwen-server-2.0.0rc2-linux-arm64.tar.gz
+souwen-server-2.0.0rc2-macos-arm64.tar.gz
+souwen-server-2.0.0rc2-windows-amd64.zip
+```
+
+Archive 内部统一使用 `souwen-server/` 目录；Windows executable 为
+`souwen-server.exe`，其余平台为 `souwen-server`。同目录包含 `ms-playwright/` 和
+`runtime.source.sha`。这是 Browser Worker运行所需的 deployment unit，不是一个仅改名的旧 CLI
+binary。
+
+默认入口：
+
+```bash
+./souwen-server/souwen-server --host 127.0.0.1 --port 49265
+```
+
+默认入口只接受 target rollout；环境显式指定 `SOUWEN_V2_ROLLOUT=legacy` 时 fail closed。
+Supervisor 在 frozen runtime中用同一个 executable 的隐藏 `--internal-role worker|api` 派生两个
+子进程，并通过仅由 Supervisor设置的内部环境标记限制直接调用。源码/container路径继续使用
+现有 Python module child commands，避免改变 HFS runtime合同。
+Windows bundle同时启用 PyInstaller embedded Python UTF-8 mode；Windows Supervisor把收到的
+`SIGBREAK` 映射为 child process group可接受的 `CTRL_BREAK_EVENT`，再执行有界shutdown。
+
+每个平台必须安装并打包 Playwright Chromium，设置 bundle-local
+`PLAYWRIGHT_BROWSERS_PATH`，解压最终 archive 后运行 target-native smoke。Linux bundle的支持
+基线是构建它的 GitHub-hosted Ubuntu runner ABI；目标主机仍需具备 Chromium运行所需的系统
+libraries。RC2 不把一个不含 browser runtime的裸 executable描述为 self-contained bundle。
+
 ## Docker
 
 ```bash

--- a/docs/internal/rc-readiness-gates.md
+++ b/docs/internal/rc-readiness-gates.md
@@ -171,6 +171,14 @@ RC-ready run 可以验证从 current main 派生的 candidate；任何 secret-be
   macOS arm64、Windows amd64；artifact 前缀为 `souwen-server-2.0.0rc2-*`。
 - 四个 bundle 必须在目标平台执行 server、health/readiness、API-major 与 target-native smoke；
   不得用 cross-build 成功、旧 CLI help/version 或 Nuitka 结果替代。
+- 精确 archive合同为 Linux amd64/arm64与macOS arm64的 `.tar.gz`，以及Windows amd64的
+  `.zip`；四个名称必须分别为
+  `souwen-server-2.0.0rc2-{linux-amd64,linux-arm64,macos-arm64,windows-amd64}` 加对应后缀。
+- Bundle必须是 PyInstaller `onedir` archive并携带 bundle-local Playwright Chromium；一个裸
+  executable、缺 browser runtime的archive或仅对 `dist/` 临时目录做smoke均为 FAIL。
+- Target-native smoke必须从最终archive解包后启动默认Server入口，证明
+  `version=2.0.0rc2`、candidate source SHA、API major 2、`rollout_mode=target`、Browser Worker
+  ready、Admin未认证401、canonical Provider API与OpenAPI checksum，并在终止后无残留 child。
 
 **Evidence**：四项 target-native matrix report、目标 runner、bundle checksum、每项 server smoke 输出。
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -163,8 +163,23 @@ PR required 只覆盖关键最小 smoke。高波动外部源不应默认阻断�
 
 ## 二进制构建 Profile
 
-`Build with PyInstaller` 和 `Build with Nuitka` 发布工作流按 CLI edition 构建
-三档二进制产物：
+RC2 目标发布面由 `Build PyInstaller Server bundles` 构建，固定使用四个平台的
+target-native runner：
+
+| Platform | Runner architecture | Release archive |
+|---|---|---|
+| Linux amd64 | `x86_64` | `souwen-server-2.0.0rc2-linux-amd64.tar.gz` |
+| Linux arm64 | `aarch64` / `arm64` | `souwen-server-2.0.0rc2-linux-arm64.tar.gz` |
+| macOS arm64 | `arm64` | `souwen-server-2.0.0rc2-macos-arm64.tar.gz` |
+| Windows amd64 | `AMD64` / `x86_64` | `souwen-server-2.0.0rc2-windows-amd64.zip` |
+
+每个 archive 是 PyInstaller `onedir` Server bundle，包含 `souwen-server` executable、
+`runtime.source.sha`、Playwright Chromium runtime 和构建后的 Panel artifact。Runner 必须先
+生成最终 archive，再解压到新目录执行 `.github/actions/server-bundle-smoke`；直接运行 `dist/`
+目录不构成发布证据。Smoke 必须覆盖 health/readiness、version/source/API-major、target rollout、
+Browser Worker、Admin fail-closed、Provider API、OpenAPI checksum 和 Supervisor 干净退出。
+
+`Build with PyInstaller` 和 `Build with Nuitka` 是旧 CLI edition rollback baseline，按三档构建：
 
 | Profile | 安装面 | 产物后缀 |
 |---|---|---|
@@ -180,6 +195,9 @@ PR required 只覆盖关键最小 smoke。高波动外部源不应默认阻断�
 抓取模块。`full-cli` 使用
 `edition-full` 核心运行时，`crawl4ai` / `scrapling` 的互斥浏览器栈继续由
 专项 functional gate 验证。
+
+旧 workflow 在新的四 bundle proof 进入 `main` 且 central release 完成切换前保留，不能作为
+RC2 publish evidence；不能把旧 `pro-cli` binary重命名为 Server bundle。
 
 ## V2 / main 发布前 Gate
 

--- a/tests/test_binary_build_workflows.py
+++ b/tests/test_binary_build_workflows.py
@@ -175,3 +175,132 @@ def test_binary_smoke_covers_tier_aware_target_runner_contracts() -> None:
     assert "deadline = time.monotonic() + 60" in text
     assert 'f"serve exit={returncode}, port closed"' in text
     assert '"49651"' not in text
+
+
+def test_rc2_server_bundle_workflow_is_a_read_only_reusable_proof_builder() -> None:
+    text = _workflow_text(".github/workflows/build-pyinstaller-server.yml")
+    trigger = text.split("\non:\n", maxsplit=1)[1].split("\nconcurrency:", maxsplit=1)[0]
+
+    assert "workflow_call:" in trigger
+    assert "workflow_dispatch:" in trigger
+    assert "push:" not in trigger
+    assert "candidate_sha:" in trigger
+    for output in (
+        "bundle_artifact_pattern:",
+        "smoke_artifact_pattern:",
+        "inventory_artifact:",
+        "binary_count:",
+    ):
+        assert output in trigger
+    assert "permissions:\n  contents: read" in text
+    assert "persist-credentials: false" in text
+    assert "contents: write" not in text
+    assert "gh release" not in text
+    assert "git tag" not in text
+    assert "deploy-hf-space" not in text
+    assert "release-candidate.yml" not in text
+
+
+def test_rc2_server_bundle_workflow_has_exact_native_four_archive_matrix() -> None:
+    text = _workflow_text(".github/workflows/build-pyinstaller-server.yml")
+    expected = {
+        "ubuntu-24.04": "souwen-server-2.0.0rc2-linux-amd64.tar.gz",
+        "ubuntu-24.04-arm": "souwen-server-2.0.0rc2-linux-arm64.tar.gz",
+        "macos-15": "souwen-server-2.0.0rc2-macos-arm64.tar.gz",
+        "windows-2025": "souwen-server-2.0.0rc2-windows-amd64.zip",
+    }
+
+    assert text.count("archive: souwen-server-2.0.0rc2-") == 4
+    for runner, archive in expected.items():
+        assert f"os: {runner}" in text
+        assert f"archive: {archive}" in text
+        assert f"'{archive}'" in text
+    assert "if actual != expected_names:" in text
+    assert "'binary_count': 4" in text
+    assert "output.write('binary_count=4\\n')" in text
+    assert "bundle_digests[expected[platform]]" in text
+    assert "payload.get('target_native') is not True" in text
+    assert "payload.get('api_major') != 2" in text
+    assert "payload.get('archive') != expected[platform]" in text
+    assert "len(openapi_checksums) != 1" in text
+    assert "set(checks_by_name) != required_checks" in text
+    assert "status != 'PASS' for status in checks_by_name.values()" in text
+    assert "VERIFIER_SHA: ${{ github.workflow_sha }}" in text
+    assert "'verifier_sha': verifier" in text
+    assert "'workflow_identity': '.github/workflows/build-pyinstaller-server.yml'" in text
+
+
+def test_rc2_server_bundle_builds_tracked_target_onedir_with_bundled_chromium() -> None:
+    text = _workflow_text(".github/workflows/build-pyinstaller-server.yml")
+
+    assert 'pip install -e ".[edition-pro]"' in text
+    assert 'pip install "playwright>=1.40" "setuptools<82" pyinstaller' in text
+    assert "python -m playwright install --with-deps chromium" in text
+    assert "python -m playwright install chromium" in text
+    assert "pyinstaller --onedir" in text
+    assert "deploy/process/server_main.py" in text
+    assert "--paths src --paths deploy/process" in text
+    assert "--hidden-import=supervisor" in text
+    assert "--collect-all=playwright" in text
+    assert "bundle_name = 'souwen-server'" in text
+    assert "shutil.copy2('runtime.source.sha', stage / 'runtime.source.sha')" in text
+    assert "stage / 'ms-playwright'" in text
+    assert "ref: ${{ github.workflow_sha }}" in text
+    assert "path: .trusted-verifier" in text
+    assert "uses: ./.trusted-verifier/.github/actions/server-bundle-smoke" in text
+    assert 'PYTHON_OPTIONS+=(--python-option "X utf8=1")' in text
+    assert text.index("Stage Chromium and create the final archive") < text.index(
+        "Unpack final archive and run target-native server smoke"
+    )
+    for retired_surface in (
+        ".[edition-full]",
+        "crawl4ai",
+        "scrapling",
+        "superweb2pdf",
+        "server_bundle_entry.py",
+        '"--worker"',
+        '"--api"',
+    ):
+        assert retired_surface not in text
+
+
+def test_server_bundle_smoke_covers_target_release_contract() -> None:
+    text = (REPO_ROOT / ".github/actions/server-bundle-smoke/action.yml").read_text(
+        encoding="utf-8"
+    )
+
+    for check in (
+        "archive/inventory",
+        "archive/playwright-chromium",
+        "archive/source-provenance",
+        "runner/target-native",
+        "server/health",
+        "server/readiness-browser-worker",
+        "server/canonical-provider-api",
+        "server/api-major-fail-closed",
+        "server/admin-fail-closed",
+        "server/openapi-checksum",
+        "server/clean-termination",
+    ):
+        assert check in text
+    assert "bundle_root = root / 'souwen-server'" in text
+    assert "top_level != {'souwen-server'}" in text
+    assert "bundle_root / 'ms-playwright'" in text
+    assert "target_native_machine()" in text
+    assert "platform_info.machine().strip().lower()" in text
+    assert "payload.extractall(root, filter='data')" in text
+    assert "archive contains a link" in text
+    assert "SOUWEN_SOURCE_SHA_FILE" in text
+    assert "health.get('source_sha') != candidate_sha" in text
+    assert "readiness.get('worker_source_sha') != candidate_sha" in text
+    assert "readiness.get('components', {}).get('browser_worker') != 'ready'" in text
+    assert "'/api/v1/providers'" in text
+    assert "'SOUWEN_USER_PASSWORD': user_fixture" in text
+    assert "'X-SouWen-Token': user_fixture" in text
+    assert "mismatch.get('error', {}).get('code') != 'api_major_mismatch'" in text
+    assert "'/api/v1/admin/ping', expected=(401,)" in text
+    assert "actual_openapi_sha256 != expected_openapi_sha256" in text
+    assert "server bundle required a forced kill during termination" in text
+    assert "server bundle left API or Browser Worker port open" in text
+    assert "'target_native': failure is None" in text
+    assert "'api_major': 2" in text

--- a/tests/test_process_supervisor.py
+++ b/tests/test_process_supervisor.py
@@ -7,7 +7,8 @@ from collections import deque
 
 import pytest
 
-from deploy.process.supervisor import DeploymentSettings, DeploymentSupervisor
+from deploy.process import supervisor as supervisor_module
+from deploy.process.supervisor import INTERNAL_ROLE_ENV, DeploymentSettings, DeploymentSupervisor
 from souwen.delivery.api import RolloutMode
 
 
@@ -92,10 +93,13 @@ def test_worker_is_ready_before_api_and_children_share_private_runtime_env(monke
     for command, env in spawned:
         assert "t" * 48 not in command
         assert env["SOUWEN_BROWSER_WORKER_TOKEN"] == "t" * 48
+        assert env["HOST"] == "0.0.0.0"
+        assert env["PORT"] == "49265"
         assert env["SOUWEN_SOURCE_SHA"] == "a" * 40
         assert env["SOUWEN_WRAPPER_SHA"] == "b" * 40
         assert env["SOUWEN_CONFIG_REVISION"] == "source-" + "a" * 40
         assert env["SOUWEN_V2_ROLLOUT"] == "target"
+        assert env[INTERNAL_ROLE_ENV] == "1"
     assert worker.signals == [signal.SIGTERM]
 
 
@@ -177,6 +181,38 @@ def test_signal_is_forwarded_to_both_children_without_exposing_token() -> None:
     assert supervisor._api.signals == [signal.SIGTERM]
 
 
+def test_windows_break_signal_is_installed_when_available(monkeypatch) -> None:
+    installed: dict[int, object] = {}
+    sigbreak = getattr(signal, "SIGBREAK", 21)
+    monkeypatch.setattr(signal, "SIGBREAK", sigbreak, raising=False)
+    monkeypatch.setattr(signal, "signal", installed.__setitem__)
+
+    supervisor = DeploymentSupervisor(
+        _settings(), process_factory=lambda *_args: _Process(), token="t" * 48
+    )
+    supervisor._install_signal_handlers()
+
+    assert installed[sigbreak] == supervisor._handle_signal
+
+
+def test_windows_break_handler_maps_to_child_control_event(monkeypatch) -> None:
+    sigbreak = getattr(signal, "SIGBREAK", 21)
+    ctrl_break = getattr(signal, "CTRL_BREAK_EVENT", 1)
+    monkeypatch.setattr(supervisor_module.os, "name", "nt")
+    monkeypatch.setattr(signal, "SIGBREAK", sigbreak, raising=False)
+    monkeypatch.setattr(signal, "CTRL_BREAK_EVENT", ctrl_break, raising=False)
+    supervisor = DeploymentSupervisor(
+        _settings(), process_factory=lambda *_args: _Process(), token="t" * 48
+    )
+    supervisor._worker = _Process()
+    supervisor._api = _Process()
+
+    supervisor._handle_signal(sigbreak, None)
+
+    assert supervisor._worker.signals == [ctrl_break]
+    assert supervisor._api.signals == [ctrl_break]
+
+
 def test_target_settings_resolve_source_and_config_revision_from_deployment(monkeypatch) -> None:
     monkeypatch.setenv("SOUWEN_V2_ROLLOUT", "target")
     monkeypatch.setenv("SOUWEN_SOURCE_SHA", "A" * 40)
@@ -207,3 +243,47 @@ def test_supervisor_ignores_ambient_static_worker_token(monkeypatch) -> None:
     supervisor = DeploymentSupervisor(_settings(), process_factory=lambda *_args: _Process())
 
     assert supervisor._child_env()["SOUWEN_BROWSER_WORKER_TOKEN"] == "g" * 48
+
+
+def test_frozen_supervisor_reenters_same_executable_for_internal_roles(monkeypatch) -> None:
+    monkeypatch.setattr(supervisor_module.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(supervisor_module.sys, "executable", "/bundle/souwen-server")
+    supervisor = DeploymentSupervisor(
+        _settings(api_host="127.0.0.1", api_port=49300),
+        process_factory=lambda *_args: _Process(),
+        token="t" * 48,
+    )
+
+    assert supervisor._worker_command() == (
+        "/bundle/souwen-server",
+        "--internal-role",
+        "worker",
+    )
+    assert supervisor._api_command() == (
+        "/bundle/souwen-server",
+        "--internal-role",
+        "api",
+    )
+    child_env = supervisor._child_env()
+    assert child_env["HOST"] == "127.0.0.1"
+    assert child_env["PORT"] == "49300"
+    assert child_env[INTERNAL_ROLE_ENV] == "1"
+
+
+def test_source_supervisor_keeps_python_module_child_commands(monkeypatch) -> None:
+    monkeypatch.delattr(supervisor_module.sys, "frozen", raising=False)
+    supervisor = DeploymentSupervisor(
+        _settings(), process_factory=lambda *_args: _Process(), token="t" * 48
+    )
+
+    assert supervisor._worker_command() == (
+        supervisor_module.sys.executable,
+        "-m",
+        "souwen.worker.browser_fetch.runtime",
+    )
+    assert supervisor._api_command()[:4] == (
+        supervisor_module.sys.executable,
+        "-m",
+        "uvicorn",
+        "souwen.server.app:app",
+    )

--- a/tests/test_server_bundle_entrypoint.py
+++ b/tests/test_server_bundle_entrypoint.py
@@ -1,0 +1,85 @@
+"""Deterministic tests for the frozen SouWen server multi-call entry point."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from deploy.process import server_main
+from deploy.process.supervisor import INTERNAL_ROLE_ENV
+
+
+def test_product_entry_forces_target_and_applies_bounded_listener_overrides(monkeypatch) -> None:
+    observed: dict[str, str] = {}
+
+    def run_supervisor() -> int:
+        observed["rollout"] = server_main.os.environ["SOUWEN_V2_ROLLOUT"]
+        observed["host"] = server_main.os.environ["HOST"]
+        observed["port"] = server_main.os.environ["PORT"]
+        return 0
+
+    monkeypatch.delenv("SOUWEN_V2_ROLLOUT", raising=False)
+    monkeypatch.setattr(server_main, "supervisor_main", run_supervisor)
+
+    assert server_main.main(["--host", "127.0.0.1", "--port", "49300"]) == 0
+    assert observed == {"rollout": "target", "host": "127.0.0.1", "port": "49300"}
+
+
+def test_product_entry_rejects_legacy_rollout_without_starting_supervisor(monkeypatch) -> None:
+    started = False
+
+    def run_supervisor() -> int:
+        nonlocal started
+        started = True
+        return 0
+
+    monkeypatch.setenv("SOUWEN_V2_ROLLOUT", "legacy")
+    monkeypatch.setattr(server_main, "supervisor_main", run_supervisor)
+
+    assert server_main.main([]) == 1
+    assert started is False
+
+
+def test_frozen_entry_uses_only_bundle_local_playwright_runtime(monkeypatch, tmp_path) -> None:
+    executable = tmp_path / "souwen-server"
+    browser_root = tmp_path / "ms-playwright"
+    browser_root.mkdir()
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "executable", str(executable))
+    monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", "/untrusted/external-browser")
+    monkeypatch.delenv("SOUWEN_V2_ROLLOUT", raising=False)
+    monkeypatch.setattr(server_main, "supervisor_main", lambda: 0)
+
+    assert server_main.main([]) == 0
+    assert server_main.os.environ["PLAYWRIGHT_BROWSERS_PATH"] == str(browser_root)
+
+
+def test_frozen_entry_fails_closed_without_bundled_playwright(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "executable", str(tmp_path / "souwen-server"))
+    monkeypatch.delenv("SOUWEN_V2_ROLLOUT", raising=False)
+    monkeypatch.setattr(server_main, "supervisor_main", lambda: pytest.fail("must not start"))
+
+    assert server_main.main([]) == 1
+
+
+def test_internal_roles_are_hidden_and_rejected_outside_supervisor(monkeypatch) -> None:
+    monkeypatch.delenv(INTERNAL_ROLE_ENV, raising=False)
+    assert "--internal-role" not in server_main._parser().format_help()
+
+    with pytest.raises(SystemExit) as exc_info:
+        server_main.main(["--internal-role", "worker"])
+    assert exc_info.value.code == 2
+
+
+@pytest.mark.parametrize("role, runner", [("worker", "_run_worker"), ("api", "_run_api")])
+def test_internal_role_dispatch_requires_supervisor_marker(monkeypatch, role, runner) -> None:
+    calls: list[str] = []
+    monkeypatch.setenv(INTERNAL_ROLE_ENV, "1")
+    monkeypatch.delenv("SOUWEN_V2_ROLLOUT", raising=False)
+    monkeypatch.setattr(server_main, runner, lambda: calls.append(role))
+
+    assert server_main.main(["--internal-role", role]) == 0
+    assert calls == [role]
+    assert server_main.os.environ["SOUWEN_V2_ROLLOUT"] == "target"


### PR DESCRIPTION
## Summary

- add the frozen-aware `souwen-server` multi-call entry point and preserve the source/HFS supervisor path
- build exactly four PyInstaller onedir Server archives with bundle-local Playwright Chromium
- run trusted, target-native archive smoke for provenance, API major, target rollout, Browser Worker, auth, OpenAPI and clean shutdown
- aggregate an exact four-bundle inventory without publishing, tagging or deploying

## Release boundary

This PR is the standalone four-bundle proof only. It does not modify the central release orchestrator, remove the legacy 24-binary rollback baseline, create `v2.0.0rc2`, publish a GitHub Release, or deploy HFS.

## Local verification

- `2719 passed, 3 skipped` full pytest
- architecture dependency checker passed
- Ruff check/format passed
- generated docs check passed
- Markdown links passed
- `actionlint` passed
- focused workflow/supervisor/entrypoint tests: `32 passed`
