### PR TITLE
fix: normalize Windows server archive path

### DIFF
--- a/.github/workflows/build-pyinstaller-server.yml
+++ b/.github/workflows/build-pyinstaller-server.yml
@@ -281,7 +281,7 @@ jobs:
               produced = shutil.make_archive(
                   str(output.with_suffix('')), 'zip', root_dir=stage.parent, base_dir=bundle_name
               )
-              if Path(produced) != output:
+              if Path(produced).resolve() != output.resolve():
                   raise SystemExit(f'unexpected zip output: {produced}')
           else:
               with tarfile.open(output, 'w:gz') as archive:
@@ -308,7 +308,7 @@ jobs:
         with:
           name: souwen-server-smoke-${{ matrix.arch }}
           path: server-bundle-evidence/server-bundle-smoke-${{ matrix.arch }}.json
-          if-no-files-found: error
+          if-no-files-found: warn
           retention-days: 30
 
       - name: Upload immutable server bundle

--- a/tests/test_binary_build_workflows.py
+++ b/tests/test_binary_build_workflows.py
@@ -243,6 +243,7 @@ def test_rc2_server_bundle_builds_tracked_target_onedir_with_bundled_chromium() 
     assert "--hidden-import=supervisor" in text
     assert "--collect-all=playwright" in text
     assert "bundle_name = 'souwen-server'" in text
+    assert "Path(produced).resolve() != output.resolve()" in text
     assert "shutil.copy2('runtime.source.sha', stage / 'runtime.source.sha')" in text
     assert "stage / 'ms-playwright'" in text
     assert "ref: ${{ github.workflow_sha }}" in text


### PR DESCRIPTION
## Summary

- compare the Windows `shutil.make_archive` absolute return path against the resolved expected archive path
- keep the original archive-stage failure as the job failure without adding a second missing-smoke artifact error
- add the deterministic workflow contract assertion

## Evidence

Four-bundle proof run #30163058343 passed build and target-native smoke on Linux amd64, Linux arm64 and macOS arm64. Windows completed PyInstaller successfully and failed only because the absolute produced zip path was compared with a relative `Path`.

This PR does not publish, tag, deploy HFS or modify the central release workflow.
