### PR TITLE
ci(release): enforce RC2 four-server-bundle contract

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -114,8 +114,8 @@ jobs:
               raise SystemExit('publish=true requires deploy_hfs=true and a successful live promotion')
           if publish == 'true':
               raise SystemExit(
-                  'RC2 publication remains disabled until Phase 8 replaces the legacy '
-                  '24-binary matrix with exactly four PyInstaller server bundles'
+                  'RC2 publication remains disabled until Phase 8 removes legacy release '
+                  'residue and verifies the exact four-server-bundle release contract'
               )
 
           head = subprocess.check_output(['git', 'rev-parse', 'HEAD'], text=True).strip()
@@ -253,25 +253,13 @@ jobs:
       candidate_sha: ${{ needs.validate.outputs.candidate_sha }}
       suite: release
 
-  pyinstaller:
-    name: PyInstaller 12-binary matrix
+  server-bundles:
+    name: PyInstaller four-server-bundle matrix
     needs: validate
     if: ${{ inputs.evidence_profile == 'release' }}
-    uses: ./.github/workflows/build-pyinstaller.yml
+    uses: ./.github/workflows/build-pyinstaller-server.yml
     with:
       candidate_sha: ${{ needs.validate.outputs.candidate_sha }}
-      build_tier: all
-      platforms: all
-
-  nuitka:
-    name: Nuitka 12-binary matrix
-    needs: validate
-    if: ${{ inputs.evidence_profile == 'release' }}
-    uses: ./.github/workflows/build-nuitka.yml
-    with:
-      candidate_sha: ${{ needs.validate.outputs.candidate_sha }}
-      build_tier: all
-      platforms: all
 
   package:
     name: Python distributions and SBOMs
@@ -311,6 +299,37 @@ jobs:
           python -m build
           test "$(find dist -maxdepth 1 -name 'souwen-*.whl' | wc -l)" -eq 1
           test "$(find dist -maxdepth 1 -name 'souwen-*.tar.gz' | wc -l)" -eq 1
+
+      - name: Materialize immutable target OpenAPI artifact
+        env:
+          SOUWEN_V2_ROLLOUT: target
+          SOUWEN_SOURCE_SHA: ${{ needs.validate.outputs.candidate_sha }}
+          SOUWEN_CONFIG_REVISION: source-${{ needs.validate.outputs.candidate_sha }}
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          from souwen.server.app import app
+
+          document = app.openapi()
+          if document.get('info', {}).get('version') != '2.0.0rc2':
+              raise SystemExit('target OpenAPI version mismatch')
+          if document.get('x-souwen-api-major') != 2:
+              raise SystemExit('target OpenAPI API major mismatch')
+          if document.get('x-souwen-rollout-mode') != 'target':
+              raise SystemExit('target OpenAPI rollout mode mismatch')
+          output = Path('dist/souwen-openapi-2.0.0rc2.json')
+          output.write_text(
+              json.dumps(
+                  document,
+                  sort_keys=True,
+                  separators=(',', ':'),
+                  ensure_ascii=False,
+              ),
+              encoding='utf-8',
+          )
+          PY
 
       - name: Generate Python environment CycloneDX SBOM
         run: |
@@ -520,7 +539,7 @@ jobs:
 
   promotion-gate:
     name: Validate profile-specific HFS prerequisites
-    needs: [validate, ci, source, external, pyinstaller, nuitka, package, clean-install, container]
+    needs: [validate, ci, source, external, server-bundles, package, clean-install, container]
     if: ${{ always() && inputs.deploy_hfs }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -546,16 +565,16 @@ jobs:
 
           if [ "$PROFILE" = deployment ]; then
             jq -e '
-              .pyinstaller.result == "skipped" and .nuitka.result == "skipped"
+              .["server-bundles"].result == "skipped"
             ' <<<"$NEEDS_JSON" >/dev/null || {
-              echo "::error::deployment requires skipped binary release matrices"
+              echo "::error::deployment requires the server-bundle release matrix to be skipped"
               exit 1
             }
           elif [ "$PROFILE" = release ]; then
             jq -e '
-              .pyinstaller.result == "success" and .nuitka.result == "success"
+              .["server-bundles"].result == "success"
             ' <<<"$NEEDS_JSON" >/dev/null || {
-              echo "::error::release requires successful binary release matrices"
+              echo "::error::release requires the four-server-bundle matrix to succeed"
               exit 1
             }
           else
@@ -581,7 +600,7 @@ jobs:
 
   assemble-deployment:
     name: Verify and attest deployment evidence
-    needs: [validate, ci, source, external, pyinstaller, nuitka, package, clean-install, container, hfs]
+    needs: [validate, ci, source, external, server-bundles, package, clean-install, container, hfs]
     if: ${{ always() && inputs.evidence_profile == 'deployment' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -599,7 +618,7 @@ jobs:
           jq -e '
             all(
               to_entries[];
-              if .key == "pyinstaller" or .key == "nuitka"
+              if .key == "server-bundles"
               then .value.result == "skipped"
               else .value.result == "success"
               end
@@ -735,7 +754,7 @@ jobs:
           }
           if failed_jobs:
               raise SystemExit(f'deployment evidence has failed gates: {failed_jobs}')
-          binary_jobs = ('pyinstaller', 'nuitka')
+          binary_jobs = ('server-bundles',)
           unexpected_binary_jobs = {
               job_id: needs[job_id]['result']
               for job_id in binary_jobs
@@ -806,6 +825,7 @@ jobs:
 
           evidence_files = []
           binary_prefixes = (
+              'souwen-server-',
               'souwen-linux-',
               'souwen-macos-',
               'souwen-windows-',
@@ -922,7 +942,7 @@ jobs:
                       'status': 'NOT_RUN',
                       'required': False,
                       'run_urls': [run_url],
-                      'notes': ['evidence_profile=deployment; release binary matrix skipped'],
+                      'notes': ['evidence_profile=deployment; server-bundle release matrix skipped'],
                   }
                   for job_id in binary_jobs
               ],
@@ -1012,7 +1032,7 @@ jobs:
 
   assemble:
     name: Verify and attest release bundle
-    needs: [validate, ci, source, external, pyinstaller, nuitka, package, clean-install, container, hfs]
+    needs: [validate, ci, source, external, server-bundles, package, clean-install, container, hfs]
     if: ${{ always() && inputs.evidence_profile == 'release' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -1037,33 +1057,25 @@ jobs:
             )
           ' <<<"$NEEDS_JSON" >/dev/null
 
-      - name: Download PyInstaller Linux binaries
+      - name: Download four PyInstaller Server bundles
         uses: actions/download-artifact@v8
         with:
-          pattern: souwen-linux-*
+          pattern: souwen-server-bundle-*
           path: release-assets
           merge-multiple: true
 
-      - name: Download PyInstaller macOS binaries
+      - name: Download target-native Server bundle smoke evidence
         uses: actions/download-artifact@v8
         with:
-          pattern: souwen-macos-*
-          path: release-assets
+          pattern: souwen-server-smoke-*
+          path: release-evidence/server-bundles
           merge-multiple: true
 
-      - name: Download PyInstaller Windows binaries
+      - name: Download exact Server bundle inventory
         uses: actions/download-artifact@v8
         with:
-          pattern: souwen-windows-*
-          path: release-assets
-          merge-multiple: true
-
-      - name: Download Nuitka binaries
-        uses: actions/download-artifact@v8
-        with:
-          pattern: souwen-nuitka-*
-          path: release-assets
-          merge-multiple: true
+          name: souwen-server-inventory-2.0.0rc2
+          path: release-evidence/server-bundles
 
       - name: Download Python distributions
         uses: actions/download-artifact@v8
@@ -1076,13 +1088,6 @@ jobs:
         with:
           name: release-sboms
           path: release-assets
-
-      - name: Download binary smoke evidence
-        uses: actions/download-artifact@v8
-        with:
-          pattern: binary-smoke-*
-          path: release-evidence
-          merge-multiple: true
 
       - name: Download container smoke evidence
         uses: actions/download-artifact@v8
@@ -1139,7 +1144,7 @@ jobs:
           path: release-evidence
           merge-multiple: true
 
-      - name: Verify 24 binaries and write release manifest
+      - name: Verify four Server bundles and write release manifest
         env:
           CANDIDATE_SHA: ${{ needs.validate.outputs.candidate_sha }}
           VERSION: ${{ needs.validate.outputs.version }}
@@ -1169,33 +1174,108 @@ jobs:
 
           root = Path('release-assets')
           evidence_root = Path('release-evidence')
-          profiles = ('basic-cli', 'pro-cli', 'full-cli')
-          platforms = (
-              ('linux-amd64', ''),
-              ('linux-arm64', ''),
-              ('macos-arm64', ''),
-              ('windows-amd64', '.exe'),
-          )
           expected = {
-              f'{prefix}{platform}-{profile}{suffix}'
-              for prefix in ('souwen-', 'souwen-nuitka-')
-              for platform, suffix in platforms
-              for profile in profiles
+              'souwen-server-2.0.0rc2-linux-amd64.tar.gz',
+              'souwen-server-2.0.0rc2-linux-arm64.tar.gz',
+              'souwen-server-2.0.0rc2-macos-arm64.tar.gz',
+              'souwen-server-2.0.0rc2-windows-amd64.zip',
           }
           actual = {
               path.name
               for path in root.iterdir()
               if path.is_file()
-              and (path.name.startswith('souwen-nuitka-') or path.name.startswith('souwen-'))
-              and not path.name.endswith(('.whl', '.tar.gz'))
+              and path.name.startswith('souwen-server-')
           }
           if actual != expected:
               raise SystemExit(
-                  'binary inventory mismatch: '
+                  'server bundle inventory mismatch: '
                   f'missing={sorted(expected - actual)}, unexpected={sorted(actual - expected)}'
               )
-          if len(actual) != 24:
-              raise SystemExit(f'expected exactly 24 binaries, got {len(actual)}')
+          if len(actual) != 4:
+              raise SystemExit(f'expected exactly four Server bundles, got {len(actual)}')
+
+          legacy_prefixes = ('souwen-linux-', 'souwen-macos-', 'souwen-windows-', 'souwen-nuitka-')
+          legacy_assets = sorted(
+              path.name
+              for path in root.iterdir()
+              if path.is_file() and path.name.startswith(legacy_prefixes)
+          )
+          if legacy_assets:
+              raise SystemExit(f'release assets contain retired binary artifacts: {legacy_assets}')
+
+          inventory_path = evidence_root / 'server-bundles' / 'server-bundle-inventory.json'
+          inventory = json.loads(inventory_path.read_text(encoding='utf-8'))
+          if (
+              inventory.get('candidate_sha') != os.environ['CANDIDATE_SHA']
+              or inventory.get('verifier_sha') != os.environ['VERIFIER_SHA']
+              or inventory.get('version') != os.environ['VERSION']
+              or inventory.get('api_major') != int(os.environ['API_MAJOR'])
+              or inventory.get('binary_count') != 4
+              or inventory.get('workflow_identity')
+              != '.github/workflows/build-pyinstaller-server.yml'
+          ):
+              raise SystemExit(f'Server bundle inventory provenance mismatch: {inventory}')
+          bundle_items = inventory.get('bundles', [])
+          if (
+              not isinstance(bundle_items, list)
+              or len(bundle_items) != len(expected)
+              or any(not isinstance(item, dict) for item in bundle_items)
+          ):
+              raise SystemExit('Server bundle inventory must contain exactly four objects')
+          bundle_metadata = {item.get('name'): item for item in bundle_items}
+          if len(bundle_metadata) != len(bundle_items) or set(bundle_metadata) != expected:
+              raise SystemExit('Server bundle inventory metadata does not match exact assets')
+          required_smoke_checks = {
+              'archive/inventory',
+              'archive/playwright-chromium',
+              'archive/source-provenance',
+              'runner/target-native',
+              'server/health',
+              'server/readiness-browser-worker',
+              'server/canonical-provider-api',
+              'server/api-major-fail-closed',
+              'server/admin-fail-closed',
+              'server/openapi-checksum',
+              'server/clean-termination',
+          }
+          for name, metadata in bundle_metadata.items():
+              path = root / name
+              digest = hashlib.sha256(path.read_bytes()).hexdigest()
+              if (
+                  metadata.get('sha256') != digest
+                  or metadata.get('candidate_sha') != os.environ['CANDIDATE_SHA']
+                  or metadata.get('api_major') != int(os.environ['API_MAJOR'])
+                  or metadata.get('openapi_sha256') != inventory.get('openapi_sha256')
+                  or metadata.get('target_native') is not True
+                  or metadata.get('smoke_overall') != 'PASS'
+              ):
+                  raise SystemExit(f'Server bundle metadata mismatch: {name}')
+              report_path = evidence_root / 'server-bundles' / str(metadata.get('smoke_report'))
+              report = json.loads(report_path.read_text(encoding='utf-8'))
+              check_items = report.get('checks', [])
+              if (
+                  not isinstance(check_items, list)
+                  or len(check_items) != len(required_smoke_checks)
+                  or any(not isinstance(item, dict) for item in check_items)
+              ):
+                  raise SystemExit(f'Server bundle smoke evidence mismatch: {report_path}')
+              checks = {item.get('name'): item.get('status') for item in check_items}
+              if (
+                  report.get('overall') != 'PASS'
+                  or report.get('target_native') is not True
+                  or report.get('archive') != name
+                  or report.get('archive_sha256') != digest
+                  or report.get('candidate_sha') != os.environ['CANDIDATE_SHA']
+                  or len(checks) != len(check_items)
+                  or set(checks) != required_smoke_checks
+                  or any(status != 'PASS' for status in checks.values())
+              ):
+                  raise SystemExit(f'Server bundle smoke evidence mismatch: {report_path}')
+
+          openapi_path = root / 'souwen-openapi-2.0.0rc2.json'
+          openapi_sha256 = hashlib.sha256(openapi_path.read_bytes()).hexdigest()
+          if openapi_sha256 != inventory.get('openapi_sha256'):
+              raise SystemExit('immutable OpenAPI checksum differs from Server bundle smoke')
 
           run_url = os.environ['RUN_URL']
           needs = json.loads(os.environ['NEEDS_JSON'])
@@ -1215,16 +1295,16 @@ jobs:
               ('panel', ('source',), ['release-evidence.tar.gz']),
               ('docs', ('source',), ['release-evidence.tar.gz']),
               ('clean_install', ('clean-install',), ['release-evidence.tar.gz']),
-              ('mcp_edition', ('clean-install', 'pyinstaller', 'nuitka'), ['release-evidence.tar.gz']),
+              ('mcp_edition', ('clean-install', 'source'), ['release-evidence.tar.gz']),
               ('package_contract', ('package',), ['wheel', 'sdist', 'SBOMs']),
               ('functional_fixtures', ('external',), ['release-evidence.tar.gz']),
               ('live_zero_key', ('external',), ['release-evidence.tar.gz']),
               ('containers', ('container', 'ci'), ['release-evidence.tar.gz']),
-              ('binary_matrix', ('pyinstaller', 'nuitka'), ['release-evidence.tar.gz']),
+              ('binary_matrix', ('server-bundles',), ['release-evidence.tar.gz']),
               ('security', ('ci',), ['pip-audit', 'npm audit', 'security tests']),
-              ('remote_ci', ('ci', 'source', 'external', 'pyinstaller', 'nuitka'), ['reusable workflow jobs']),
+              ('remote_ci', ('ci', 'source', 'external', 'server-bundles'), ['reusable workflow jobs']),
               ('hfs_promotion', ('hfs',), ['HF Space live evidence']),
-              ('rc_assets', ('package', 'pyinstaller', 'nuitka'), ['release bundle inventory']),
+              ('rc_assets', ('package', 'server-bundles'), ['release bundle inventory']),
           ]
           gates = []
           for gate_id, job_ids, evidence in gate_specs:
@@ -1245,15 +1325,18 @@ jobs:
               digest = hashlib.sha256(path.read_bytes()).hexdigest()
               if path.name.endswith('.whl'):
                   kind = 'wheel'
+              elif path.name in actual:
+                  kind = 'server_bundle'
               elif path.name.startswith('souwen-') and path.name.endswith('.tar.gz'):
                   kind = 'sdist'
+              elif path.name == 'souwen-openapi-2.0.0rc2.json':
+                  kind = 'openapi'
               elif path.name.endswith('.cdx.json'):
                   kind = 'sbom'
-              elif path.name in actual:
-                  kind = 'binary'
               else:
                   kind = 'report'
-              python_subject = kind in {'wheel', 'sdist', 'binary'}
+              python_subject = kind in {'wheel', 'sdist', 'server_bundle'}
+              bundle = bundle_metadata.get(path.name)
               artifacts.append(
                   {
                       'name': path.name,
@@ -1264,7 +1347,15 @@ jobs:
                       'sbom': 'python-sbom.cdx.json' if python_subject else None,
                       'provenance': f'{run_url}#attestations',
                       'source_sha': os.environ['CANDIDATE_SHA'],
-                      'embedded_provenance': kind == 'binary',
+                      'embedded_provenance': kind == 'server_bundle',
+                      'platform': bundle.get('platform') if bundle else None,
+                      'api_major': bundle.get('api_major') if bundle else None,
+                      'openapi_sha256': (
+                          bundle.get('openapi_sha256')
+                          if bundle
+                          else openapi_sha256 if kind == 'openapi' else None
+                      ),
+                      'target_native_smoke': bundle.get('smoke_report') if bundle else None,
                   }
               )
 
@@ -1291,8 +1382,7 @@ jobs:
               'ci': 'CI',
               'source': 'V2 CI',
               'external': 'External Smoke Gate',
-              'pyinstaller': 'Build with PyInstaller',
-              'nuitka': 'Build with Nuitka',
+              'server-bundles': 'Build RC2 PyInstaller server bundles',
           }
           if os.environ['DEPLOY_HFS'] == 'true':
               remote_workflows['hfs'] = 'HF Space CD'
@@ -1345,6 +1435,8 @@ jobs:
                   raise SystemExit('HFS promotion evidence is missing promotion_changed')
           manifest = {
               'schema_version': 1,
+              'evidence_profile': 'release',
+              'publishable': os.environ['PUBLISH'] == 'true',
               'product_name': os.environ['PRODUCT_NAME'],
               'version': os.environ['VERSION'],
               'api_major': int(os.environ['API_MAJOR']),
@@ -1526,8 +1618,9 @@ jobs:
 
           Release candidate built from immutable source SHA \`$CANDIDATE_SHA\`.
 
-          The attached bundle contains the wheel, sdist, 24 target-native binaries,
-          checksums, Python and Panel SBOMs, and the release evidence manifest.
+          The attached bundle contains the wheel, sdist, immutable OpenAPI artifact,
+          exactly four target-native PyInstaller Server bundles, checksums, Python and
+          Panel SBOMs, and the release evidence manifest.
           Release assets are covered by native GitHub build attestations. Browser-backed providers remain governed by
           the attached External Smoke Gate reports. SuperWeb2PDF is installed from
           the fixed commit and SHA-256-pinned direct reference recorded in package metadata.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -27,11 +27,13 @@ gh workflow run release-candidate.yml \
 
 `evidence_profile` 必须显式选择，默认哨兵值 `select` 会 fail closed：
 
-- `release` 在 Phase 8 前保留 source、clean install、Panel、container、external smoke 与历史
-  PyInstaller/Nuitka 24-binary regression，只能使用 `publish=false` 生成过渡 evidence。
-  它不是 RC2 publish-ready 证明；最终必须由精确四个 PyInstaller server bundle gate 替换。
-- `deployment` 必须同时使用 `deploy_hfs=true, publish=false`。它跳过外层 PyInstaller/Nuitka
-  release matrix，但保留全部非 binary gate、HFS reusable workflow 内的单次 Linux
+- `release` 运行 source、clean install、Panel、container、external smoke，以及精确四个平台的
+  PyInstaller Server bundle gate；package job 同时生成 immutable
+  `souwen-openapi-2.0.0rc2.json`。Assembler 只接受四个固定名称的 archive、对应的四份
+  target-native smoke、同 candidate inventory 和一致的 OpenAPI checksum。Phase 8 residue audit
+  完成前仍只能使用 `publish=false` 生成 RC evidence。
+- `deployment` 必须同时使用 `deploy_hfs=true, publish=false`。它跳过外层 `server-bundles`
+  release job，但保留全部非 binary gate、HFS reusable workflow 内的单次 Linux
   `basic-cli` PyInstaller smoke、live promotion、rollback 和 readback，产出不可发布的
   `deployment-evidence-*` artifact。M1 起，assembler 还会解析 surface/capability JSON，要求
   target rollout、Browser Worker readiness、OpenAlex Search、builtin Fetch 与 Browser Fetch
@@ -53,10 +55,11 @@ gh workflow run release-candidate.yml \
 `hf` / `release` environment；`publish=true` 还强制 `evidence_profile=release`、
 `deploy_hfs=true` 且 live promotion 已通过。
 
-PyInstaller 与 Nuitka workflow 只是 builder。手动运行或 `v*` tag 触发时只上传 workflow
-artifacts，不创建 Release；tag 与 prerelease 只能由 central workflow 的 publish job 创建。
-当前 central workflow 还会拒绝 `publish=true`；Phase 8 完成四 server bundle、manifest 和
-target-native smoke 契约后才能解除该保护。
+`build-pyinstaller-server.yml` 是 central release 的唯一 active binary builder；它只上传
+workflow artifacts，不创建 Release。旧 `build-pyinstaller.yml` 与 `build-nuitka.yml` 暂时仅作为
+rollback residue 保留，不被 RC2 central release 调用，也不得出现在 RC2 manifest 或 Release
+assets。Tag 与 prerelease 只能由 central workflow 的 publish job 创建。当前 central workflow
+仍会拒绝 `publish=true`；Phase 8 完成旧 CLI/Nuitka/compatibility residue audit 后才能解除该保护。
 
 ## RC2 PyInstaller Server bundle
 

--- a/docs/internal/development-branching.md
+++ b/docs/internal/development-branching.md
@@ -95,15 +95,15 @@ dedicated v2 public-surface gate and runs on `main`.
 - panel build: TypeScript check, Vitest, single-file panel build, and
   `src/souwen/server/panel.html` artifact validation.
 
-External smoke, HF Space local preflight, PyInstaller/Nuitka builders, and
+External smoke, HF Space local preflight, the RC2 Server bundle builder, and
 secret-backed checks keep their dedicated reusable/manual/schedule entrypoints.
 They should not be folded into every ordinary PR. Remote HFS promotion and
 GitHub publication are coordinated only by `release-candidate.yml`.
 
-PyInstaller and Nuitka release artifacts use the three CLI edition profiles:
-`basic-cli`, `pro-cli`, and `full-cli`. The manual workflow inputs keep legacy
-aliases for transition only: `cli` maps to `basic-cli`, `server` maps to
-`pro-cli`, and `full` maps to `full-cli`.
+`build-pyinstaller-server.yml` builds the RC2 release inventory: exactly four
+target-native PyInstaller Server bundles. The old three-edition PyInstaller and
+Nuitka workflows remain temporary rollback residue until the Phase 8 audit;
+the central release does not call them or include their artifacts.
 
 ## Central release-candidate flow
 
@@ -116,15 +116,16 @@ it from the current `main` workflow revision with an exact 40-character
 2. After the central workflow exists on trusted `main`, run it with
    `evidence_profile=release`, `publish=false`, and `deploy_hfs=false`. The
    candidate may be a descendant of current `origin/main`; this run has no
-   external release/deploy write.
+   external release/deploy write. It generates the immutable OpenAPI artifact,
+   exactly four Server bundles and their target-native smoke evidence.
 3. Accept **RC-ready** only when all 15 always-required gates pass on the exact
    candidate and the evidence bundle inventory/checksums agree.
 4. Merge the approved candidate. Before any HFS write, require
    `candidate_sha == origin/main`, protected `hf`/`release` environments, private
    Space dual-layer auth, and an immutable rollback point.
 5. For a lightweight runtime-only acceptance, use `evidence_profile=deployment`,
-   `deploy_hfs=true`, and `publish=false`. This skips the two full release binary
-   matrices but retains non-binary gates, the single HFS-local PyInstaller smoke,
+   `deploy_hfs=true`, and `publish=false`. This skips the `server-bundles` release
+   job but retains non-binary gates, the single HFS-local PyInstaller smoke,
    promotion, rollback and live readback. Its `deployment-evidence-*` artifact is
    not RC-ready or publish-ready evidence.
 6. An approved `evidence_profile=release`, `deploy_hfs=true`, `publish=false` run
@@ -132,11 +133,11 @@ it from the current `main` workflow revision with an exact 40-character
    the annotated tag and prerelease only after every gate, HFS promotion, bundle
    and attestation pass.
 
-The PyInstaller and Nuitka workflows always remain builders: each produces
-3 editions × 4 targets and uploads artifacts, but neither creates a Release.
-They run from the central workflow only for `evidence_profile=release`.
-Direct `HF Space CD` dispatch also remains local-only; merge/push to `main` does
-not automatically deploy.
+The active `build-pyinstaller-server.yml` workflow only builds and uploads the
+four Server bundles; it never creates a Release. The old CLI PyInstaller/Nuitka
+workflows are not part of the RC2 central release contract. Direct `HF Space CD`
+dispatch also remains local-only; merge/push to `main` does not automatically
+deploy.
 
 If `origin/main` advances beyond an unmerged candidate, the candidate must absorb
 that change and all affected gates must rerun. If a publish attempt pushes the

--- a/docs/internal/rc-readiness-gates.md
+++ b/docs/internal/rc-readiness-gates.md
@@ -5,10 +5,10 @@ candidate SHA、run URL、checksum、测试计数和部署回读等运行结果�
 而应由发布流水线写入候选专属的 `release-manifest.json` 或
 `deployment-manifest.json` artifact。
 
-> **Phase 8 前的执行边界**：RC2 的 `deployment` profile 可用于 P4-07/M1 HFS 验收；
-> 当前 `release` profile 仍保留历史 24-binary CLI/Nuitka matrix，只能生成过渡 evidence，
-> 不能满足 RC2 发布定义。`release-candidate.yml` 在四个 PyInstaller server bundle 契约落地前
-> 必须拒绝 `publish=true`。最终 RC2 Release 以 ADR 0005 的精确四 bundle inventory 为准。
+> **Phase 8 完成前的执行边界**：RC2 的 `deployment` profile 可用于 P4-07/M1 HFS 验收；
+> `release` profile 已切换为 ADR 0005 的精确四个 PyInstaller Server bundle 与 immutable OpenAPI
+> 契约。旧 24-binary CLI/Nuitka workflow 不参与 central release。旧发布面与 compatibility residue
+> audit 完成前，`release-candidate.yml` 仍必须拒绝 `publish=true`。
 
 ## 判定原则
 
@@ -28,8 +28,8 @@ candidate SHA、run URL、checksum、测试计数和部署回读等运行结果�
 本文件定义 16 个 gate，其中 15 个是 **always-required**，`HFS promotion` 是 conditional：
 
 - **Deployment-validated**：显式使用 `evidence_profile=deployment`、`publish=false`、
-  `deploy_hfs=true`。除两个外层 release binary matrix 外的 common gates 与 HFS promotion
-  全部 `PASS`；PyInstaller/Nuitka release matrix 为预期 `skipped`。该状态只证明候选的 HFS
+  `deploy_hfs=true`。除外层 `server-bundles` release job 外的 common gates 与 HFS promotion
+  全部 `PASS`；`server-bundles` 为预期 `skipped`。该状态只证明候选的 HFS
   runtime，不是 RC-ready 或 publish-ready，产物必须命名为 `deployment-evidence-*` 且标记
   `publishable=false, binary_count=0`。
 - **RC-ready**：除 HFS promotion 外的 15 个 gate 全部 `PASS`；HFS 为
@@ -37,7 +37,7 @@ candidate SHA、run URL、checksum、测试计数和部署回读等运行结果�
   `publish=false, deploy_hfs=false`，只生成 evidence bundle，不创建 tag/Release、不写 Space。
 - **Publish-ready target**：RC-ready 加上 HFS promotion `PASS`；private edge、SouWen admin、
   wrapper/runtime/source provenance 和 rollback point 均有证据。只有该状态才允许
-  `evidence_profile=release, publish=true`；Phase 8 四 bundle gate 落地前该状态不可达。
+  `evidence_profile=release, publish=true`；Phase 8 residue audit 完成前该状态不可达。
 
 `release-candidate.yml` 必须从当前 `origin/main` 的 control-plane workflow 运行；任何
 candidate code 执行前先做 immutable SHA、lineage 与 version static check。无 deploy/publish 的
@@ -163,10 +163,12 @@ RC-ready run 可以验证从 current main 派生的 candidate；任何 secret-be
 
 **Evidence**：3 个 image digest、build log、source SHA、endpoint smoke JSON、admin-lock assertion。
 
-### 12. Binary matrix transition
+### 12. Server bundle matrix
 
-- Phase 8 前，PyInstaller/Nuitka 的 24-binary CLI matrix 仅是历史 workflow regression，
-  不能作为 RC2 publish evidence，且不得解除 `publish=true` fail-closed guard。
+- Central release 的 active binary path 只允许 `build-pyinstaller-server.yml`。旧
+  PyInstaller/Nuitka 24-binary CLI workflow 在 Phase 8 清理完成前仅是暂存 rollback residue，
+  不参与 RC2 release job、manifest、checksum、attestation 或 Release assets，也不得解除
+  `publish=true` fail-closed guard。
 - RC2 最终 inventory 必须精确为四个 PyInstaller server bundle：Linux amd64、Linux arm64、
   macOS arm64、Windows amd64；artifact 前缀为 `souwen-server-2.0.0rc2-*`。
 - 四个 bundle 必须在目标平台执行 server、health/readiness、API-major 与 target-native smoke；
@@ -194,7 +196,8 @@ RC-ready run 可以验证从 current main 派生的 candidate；任何 secret-be
 
 ### 14. Remote CI
 
-- `CI`、`V2 CI`、`External Smoke Gate`、两个 binary workflow 和 container/deploy local gate
+- `CI`、`V2 CI`、`External Smoke Gate`、`Build PyInstaller Server bundles` 和
+  container/deploy local gate
   在 `candidate_sha` 上全部 green。
 - 每个 run 必须回读 head SHA、conclusion、required jobs 和 artifact inventory；分支名相同、
   rerun 成功或 merge 后别的 SHA green 都不能替代候选证据。
@@ -282,8 +285,8 @@ Deployment manifest 只索引轻量 HFS 验收证据，不得被 GitHub Release 
 
 最终 `deployment-evidence-*` artifact 只能包含 `deployment-manifest.json`、
 `deployment-evidence.tar.gz` 与 `SHA256SUMS`；archive 可封装 common gate、package/SBOM、
-container 与 HFS reports，但不得包含外层 PyInstaller/Nuitka release binary 或 binary-smoke
-artifact。三个 envelope 文件必须由 native build provenance attestation 覆盖。
+container 与 HFS reports，但不得包含外层 Server bundle、旧 PyInstaller/Nuitka release binary
+或 binary-smoke artifact。三个 envelope 文件必须由 native build provenance attestation 覆盖。
 
 ## `release-manifest.json` 最小字段
 
@@ -375,7 +378,7 @@ reviewer；无法从 workflow 机器验证的批准不得伪造到 `approval_ref
 ## Go / No-Go
 
 - **Deployment-validated Go**：`deployment` profile 的 common gates 与 HFS promotion 全部
-  `PASS`，两个外层 binary matrix 为预期 `skipped`，manifest 明确
+  `PASS`，外层 `server-bundles` job 为预期 `skipped`，manifest 明确
   `publishable=false, binary_count=0`，Space repo/runtime/source 三段回读一致。该结论不得提升为
   RC-ready 或 publish-ready。
 - **RC-ready Go**：15 个 always-required gate 全部 `PASS`，HFS 明确为未请求的 conditional

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import hashlib
 import json
 import re
 import textwrap
@@ -249,20 +250,18 @@ def test_release_candidate_requires_an_explicit_evidence_profile() -> None:
     assert "evidence_profile=${{ inputs.evidence_profile }}" in text.splitlines()[2]
 
 
-def test_deployment_profile_skips_release_binary_matrices_and_gates_hfs() -> None:
+def test_deployment_profile_skips_release_server_bundles_and_gates_hfs() -> None:
     text = _workflow("release-candidate.yml")
-    pyinstaller = _job(text, "pyinstaller", "nuitka")
-    nuitka = _job(text, "nuitka", "package")
+    server_bundles = _job(text, "server-bundles", "package")
     promotion_gate = _job(text, "promotion-gate", "hfs")
     hfs = _job(text, "hfs", "assemble-deployment")
 
     release_only = "if: ${{ inputs.evidence_profile == 'release' }}"
-    assert release_only in pyinstaller
-    assert release_only in nuitka
+    assert release_only in server_bundles
     assert "if: ${{ always() && inputs.deploy_hfs }}" in promotion_gate
     assert "PROFILE: ${{ inputs.evidence_profile }}" in promotion_gate
-    assert "deployment requires skipped binary release matrices" in promotion_gate
-    assert "release requires successful binary release matrices" in promotion_gate
+    assert "deployment requires the server-bundle release matrix to be skipped" in promotion_gate
+    assert "release requires the four-server-bundle matrix to succeed" in promotion_gate
     for gate in (
         "validate",
         "ci",
@@ -271,8 +270,7 @@ def test_deployment_profile_skips_release_binary_matrices_and_gates_hfs() -> Non
         "package",
         "clean-install",
         "container",
-        "pyinstaller",
-        "nuitka",
+        "server-bundles",
     ):
         assert gate in promotion_gate
     assert "needs: [validate, promotion-gate]" in hfs
@@ -289,16 +287,14 @@ def test_promotion_gate_descendants_always_run_to_observe_skipped_parents() -> N
         "ci",
         "source",
         "external",
-        "pyinstaller",
-        "nuitka",
+        "server-bundles",
         "package",
         "clean-install",
         "container",
     ]
-    # Deployment deliberately skips both release binary matrices. They must stay
+    # Deployment deliberately skips the release Server bundle matrix. It must stay an
     # ordinary parents so promotion-gate can explicitly verify that contract.
-    for binary_job in ("pyinstaller", "nuitka"):
-        assert graph[binary_job]["condition"] == "${{ inputs.evidence_profile == 'release' }}"
+    assert graph["server-bundles"]["condition"] == "${{ inputs.evidence_profile == 'release' }}"
 
     downstream = _downstream_jobs(graph, "promotion-gate")
     assert downstream == {"hfs", "assemble-deployment", "assemble", "publish"}
@@ -322,7 +318,7 @@ def test_deployment_evidence_is_non_publishable_and_contains_no_release_binaries
     assert "'publishable': False" in deployment
     assert "'binary_count': 0" in deployment
     assert "'status': 'NOT_RUN'" in deployment
-    assert "release binary matrix skipped" in deployment
+    assert "server-bundle release matrix skipped" in deployment
     assert "deployment evidence is missing required reports" in deployment
     assert "actions/attest-build-provenance@v4" in deployment
     assert "pattern: hf-space-local-*-report" in deployment
@@ -338,7 +334,9 @@ def test_deployment_evidence_is_non_publishable_and_contains_no_release_binaries
         assert release_binary_pattern not in deployment
 
     assert "inputs.evidence_profile == 'release'" in release
-    assert "if len(actual) != 24:" in release
+    assert "if len(actual) != 4:" in release
+    assert "'evidence_profile': 'release'" in release
+    assert "'publishable': os.environ['PUBLISH'] == 'true'" in release
     assert "release-manifest.json" in release
     assert "'product_name': os.environ['PRODUCT_NAME']" in release
     assert "'version': os.environ['VERSION']" in release
@@ -436,8 +434,7 @@ def test_deployment_manifest_builder_emits_bounded_non_release_contract(
     }
     needs.update(
         {
-            "pyinstaller": {"result": "skipped"},
-            "nuitka": {"result": "skipped"},
+            "server-bundles": {"result": "skipped"},
         }
     )
     environment = {
@@ -474,9 +471,9 @@ def test_deployment_manifest_builder_emits_bounded_non_release_contract(
     assert any(gate["id"] == "hfs_target_m1" for gate in manifest["gates"])
     assert manifest["binary_count"] == 0
     binary_gates = {
-        item["id"]: item for item in manifest["gates"] if item["id"] in {"pyinstaller", "nuitka"}
+        item["id"]: item for item in manifest["gates"] if item["id"] == "server-bundles"
     }
-    assert set(binary_gates) == {"pyinstaller", "nuitka"}
+    assert set(binary_gates) == {"server-bundles"}
     assert all(item["status"] == "NOT_RUN" for item in binary_gates.values())
     assert all(item["required"] is False for item in binary_gates.values())
     assert manifest["candidate_sha"] == candidate
@@ -490,7 +487,13 @@ def test_deployment_manifest_builder_emits_bounded_non_release_contract(
     }
     assert not any(
         item["path"].startswith(
-            ("souwen-linux-", "souwen-macos-", "souwen-windows-", "souwen-nuitka-")
+            (
+                "souwen-server-",
+                "souwen-linux-",
+                "souwen-macos-",
+                "souwen-windows-",
+                "souwen-nuitka-",
+            )
         )
         for item in manifest["evidence_files"]
     )
@@ -510,6 +513,181 @@ def test_deployment_manifest_builder_emits_bounded_non_release_contract(
     capability_path.unlink()
     with pytest.raises(SystemExit, match="missing required reports"):
         exec(compile(manifest_source, "release-candidate.yml:missing-report", "exec"), {})
+
+
+def test_release_manifest_builder_accepts_only_exact_four_server_bundle_evidence(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    text = _workflow("release-candidate.yml")
+    release = _job(text, "assemble", "publish")
+    manifest_step = release.split(
+        "- name: Verify four Server bundles and write release manifest", maxsplit=1
+    )[1]
+    manifest_source = _python_heredoc(manifest_step)
+    checksum_source = _python_heredoc(manifest_step, 1)
+
+    candidate = "a" * 40
+    verifier = "b" * 40
+    assets = tmp_path / "release-assets"
+    evidence = tmp_path / "release-evidence"
+    bundle_evidence = evidence / "server-bundles"
+    bundle_evidence.mkdir(parents=True)
+    assets.mkdir()
+    expected = {
+        "linux-amd64": "souwen-server-2.0.0rc2-linux-amd64.tar.gz",
+        "linux-arm64": "souwen-server-2.0.0rc2-linux-arm64.tar.gz",
+        "macos-arm64": "souwen-server-2.0.0rc2-macos-arm64.tar.gz",
+        "windows-amd64": "souwen-server-2.0.0rc2-windows-amd64.zip",
+    }
+    required_checks = (
+        "archive/inventory",
+        "archive/playwright-chromium",
+        "archive/source-provenance",
+        "runner/target-native",
+        "server/health",
+        "server/readiness-browser-worker",
+        "server/canonical-provider-api",
+        "server/api-major-fail-closed",
+        "server/admin-fail-closed",
+        "server/openapi-checksum",
+        "server/clean-termination",
+    )
+    openapi = assets / "souwen-openapi-2.0.0rc2.json"
+    openapi.write_bytes(b'{"info":{"version":"2.0.0rc2"}}')
+    openapi_sha256 = hashlib.sha256(openapi.read_bytes()).hexdigest()
+    bundles = []
+    for platform, name in expected.items():
+        path = assets / name
+        path.write_bytes(f"bundle:{platform}".encode())
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        report_name = f"server-bundle-smoke-{platform}.json"
+        (bundle_evidence / report_name).write_text(
+            json.dumps(
+                {
+                    "overall": "PASS",
+                    "target_native": True,
+                    "archive": name,
+                    "archive_sha256": digest,
+                    "candidate_sha": candidate,
+                    "checks": [{"name": check, "status": "PASS"} for check in required_checks],
+                }
+            ),
+            encoding="utf-8",
+        )
+        bundles.append(
+            {
+                "name": name,
+                "platform": platform,
+                "size": path.stat().st_size,
+                "sha256": digest,
+                "candidate_sha": candidate,
+                "api_major": 2,
+                "openapi_sha256": openapi_sha256,
+                "target_native": True,
+                "smoke_overall": "PASS",
+                "smoke_report": report_name,
+            }
+        )
+    (bundle_evidence / "server-bundle-inventory.json").write_text(
+        json.dumps(
+            {
+                "version": "2.0.0rc2",
+                "candidate_sha": candidate,
+                "verifier_sha": verifier,
+                "workflow_identity": ".github/workflows/build-pyinstaller-server.yml",
+                "api_major": 2,
+                "openapi_sha256": openapi_sha256,
+                "binary_count": 4,
+                "bundles": bundles,
+            }
+        ),
+        encoding="utf-8",
+    )
+    for name, payload in (
+        ("souwen-2.0.0rc2-py3-none-any.whl", b"wheel"),
+        ("souwen-2.0.0rc2.tar.gz", b"sdist"),
+        ("python-sbom.cdx.json", b"{}"),
+        ("panel-sbom.cdx.json", b"{}"),
+        ("release-evidence.tar.gz", b"evidence"),
+    ):
+        (assets / name).write_bytes(payload)
+    for kind in ("root", "hfs", "modelscope"):
+        (evidence / f"container-{kind}.json").write_text(
+            json.dumps(
+                {
+                    "kind": kind,
+                    "candidate_sha": candidate,
+                    "image_digest": f"sha256:{kind}",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    needs = {
+        job_id: {"result": "success"}
+        for job_id in (
+            "validate",
+            "ci",
+            "source",
+            "external",
+            "server-bundles",
+            "package",
+            "clean-install",
+            "container",
+        )
+    }
+    needs["hfs"] = {"result": "skipped"}
+    environment = {
+        "CANDIDATE_SHA": candidate,
+        "VERSION": "2.0.0rc2",
+        "PRODUCT_NAME": "Souwen v2rc2",
+        "API_MAJOR": "2",
+        "TAG": "v2.0.0rc2",
+        "PUBLISH": "false",
+        "DEPLOY_HFS": "false",
+        "NEEDS_JSON": json.dumps(needs),
+        "VERIFIER_SHA": verifier,
+        "RUN_URL": "https://github.example/actions/runs/2",
+        "HFS_SPACE_COMMIT_SHA": "",
+        "HFS_PROMOTION_CHANGED": "",
+        "HFS_PRIOR_SPACE_COMMIT_SHA": "",
+        "HFS_PRIOR_RUNTIME_COMMIT_SHA": "",
+        "HFS_PRIOR_SOUWEN_REF": "",
+        "HFS_PRIOR_RUNTIME_STAGE": "",
+    }
+    for name, value in environment.items():
+        monkeypatch.setenv(name, value)
+    monkeypatch.chdir(tmp_path)
+
+    exec(compile(manifest_source, "release-candidate.yml:release-manifest", "exec"), {})
+    exec(compile(checksum_source, "release-candidate.yml:release-checksums", "exec"), {})
+
+    manifest = json.loads((assets / "release-manifest.json").read_text(encoding="utf-8"))
+    assert manifest["evidence_profile"] == "release"
+    assert manifest["publishable"] is False
+    assert manifest["binary_count"] == 4
+    server_assets = [item for item in manifest["artifacts"] if item["kind"] == "server_bundle"]
+    assert {item["name"] for item in server_assets} == set(expected.values())
+    assert all(item["target_native_smoke"] for item in server_assets)
+    assert {path.name for path in assets.iterdir()} == {
+        *(item["name"] for item in manifest["artifacts"]),
+        "release-manifest.json",
+        "SHA256SUMS",
+    }
+
+    failed_report = bundle_evidence / "server-bundle-smoke-windows-amd64.json"
+    failed_payload = json.loads(failed_report.read_text(encoding="utf-8"))
+    failed_payload["checks"][-1]["status"] = "FAIL"
+    failed_report.write_text(json.dumps(failed_payload), encoding="utf-8")
+    with pytest.raises(SystemExit, match="smoke evidence mismatch"):
+        exec(compile(manifest_source, "release-candidate.yml:failed-smoke", "exec"), {})
+
+    failed_payload["checks"][-1]["status"] = "PASS"
+    failed_payload["checks"].append(dict(failed_payload["checks"][-1]))
+    failed_report.write_text(json.dumps(failed_payload), encoding="utf-8")
+    with pytest.raises(SystemExit, match="smoke evidence mismatch"):
+        exec(compile(manifest_source, "release-candidate.yml:duplicate-smoke", "exec"), {})
 
 
 def test_hfs_deployment_keeps_one_basic_pyinstaller_smoke() -> None:
@@ -564,28 +742,31 @@ def test_release_candidate_aggregates_all_release_gates() -> None:
     for call in (
         "uses: ./.github/workflows/v2-ci.yml",
         "uses: ./.github/workflows/external-smoke-gate.yml",
-        "uses: ./.github/workflows/build-pyinstaller.yml",
-        "uses: ./.github/workflows/build-nuitka.yml",
+        "uses: ./.github/workflows/build-pyinstaller-server.yml",
         "uses: ./.github/workflows/deploy-hf-space.yml",
     ):
         assert call in text
 
-    for gate in ("source", "external", "pyinstaller", "nuitka", "clean-install", "container"):
+    for gate in ("source", "external", "server-bundles", "clean-install", "container"):
         assert f"  {gate}:" in text
     assert "name: V2 source and Panel gates" in text
     assert "name: Broad CI, coverage, performance, audit, and container gates" in text
     assert "suite: release" in text
 
-    external = text.split("  external:", maxsplit=1)[1].split("  pyinstaller:", maxsplit=1)[0]
+    external = text.split("  external:", maxsplit=1)[1].split("  server-bundles:", maxsplit=1)[0]
     assert "permissions:\n      contents: read\n      issues: write" in external
 
     container = text.split("  container:", maxsplit=1)[1].split("  hfs:", maxsplit=1)[0]
     assert "ref: ${{ needs.validate.outputs.candidate_sha }}\n          fetch-depth: 0" in container
 
 
-def test_release_bundle_has_24_binaries_supply_chain_assets_and_attestation() -> None:
+def test_release_bundle_has_four_servers_openapi_supply_chain_assets_and_attestation() -> None:
     text = _workflow("release-candidate.yml")
-    assert "if len(actual) != 24:" in text
+    assert "if len(actual) != 4:" in text
+    assert "expected exactly four Server bundles" in text
+    assert "souwen-openapi-2.0.0rc2.json" in text
+    assert "immutable OpenAPI checksum differs from Server bundle smoke" in text
+    assert "release assets contain retired binary artifacts" in text
     assert "python-sbom.cdx.json" in text
     assert "panel-sbom.cdx.json" in text
     assert "release-manifest.json" in text


### PR DESCRIPTION
## Summary

- switch the central RC workflow from the retired 24-binary CLI/Nuitka path to the reusable four-platform PyInstaller Server bundle builder
- emit and verify the immutable RC2 OpenAPI artifact, exact bundle inventory, target-native smoke reports, checksums, manifest, and attestation inputs
- preserve the deployment-profile zero-binary contract and keep publication fail closed until the Phase 8 residue audit completes
- update release/deployment documentation and deterministic workflow contract tests

## Validation

- pytest tests/test_release_candidate_workflows.py -q
- pytest tests/test_binary_build_workflows.py -q
- pytest tests/ -q
- actionlint
- python3 tools/check_markdown_links.py
- python3 scripts/ci/check_architecture_dependencies.py
- ruff check src tests scripts tools deploy
- ruff format --check src tests scripts tools deploy
- PYTHONPATH=src python3 tools/gen_docs.py --check
- git diff --check

## Safety boundary

This PR does not create a tag or GitHub Release and does not promote HFS. The publish=true guard remains fail closed.