### PR TITLE
fix(release): install candidate before OpenAPI export

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -300,6 +300,12 @@ jobs:
           test "$(find dist -maxdepth 1 -name 'souwen-*.whl' | wc -l)" -eq 1
           test "$(find dist -maxdepth 1 -name 'souwen-*.tar.gz' | wc -l)" -eq 1
 
+      - name: Install built candidate for OpenAPI materialization
+        run: |
+          wheel="$(find "$GITHUB_WORKSPACE/dist" -maxdepth 1 -name 'souwen-*.whl' -print -quit)"
+          test -n "$wheel"
+          python -m pip install "${wheel}[server]"
+
       - name: Materialize immutable target OpenAPI artifact
         env:
           SOUWEN_V2_ROLLOUT: target

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -765,6 +765,8 @@ def test_release_bundle_has_four_servers_openapi_supply_chain_assets_and_attesta
     assert "if len(actual) != 4:" in text
     assert "expected exactly four Server bundles" in text
     assert "souwen-openapi-2.0.0rc2.json" in text
+    assert "Install built candidate for OpenAPI materialization" in text
+    assert 'python -m pip install "${wheel}[server]"' in text
     assert "immutable OpenAPI checksum differs from Server bundle smoke" in text
     assert "release assets contain retired binary artifacts" in text
     assert "python-sbom.cdx.json" in text


### PR DESCRIPTION
## Summary

- install the freshly built RC2 wheel with the server extra before importing the runtime to materialize OpenAPI
- keep OpenAPI generation bound to the exact candidate distribution rather than relying on ambient source-path state
- add a deterministic workflow contract assertion for the install step

## Failure evidence

Central release run 30164631117 failed in Python distributions and SBOMs with ModuleNotFoundError: No module named souwen during immutable OpenAPI materialization. The failed run was cancelled after the deterministic failure was captured; it created no tag, Release, or HFS mutation.

## Validation

- pytest tests/test_release_candidate_workflows.py -q
- actionlint .github/workflows/release-candidate.yml
- ruff check tests/test_release_candidate_workflows.py
- ruff format --check tests/test_release_candidate_workflows.py
- git diff --check