### PR TITLE
refactor: replace CLI delivery profiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,24 +162,24 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
-      - name: 安装 full runtime profile 依赖
+      - name: 安装 Provider runtime profile 依赖
         if: matrix.os == 'ubuntu-latest' && matrix.python == '3.11'
         run: pip install -e ".[dev,edition-full]"
 
-      - name: 运行 full runtime profile
+      - name: 运行 Provider runtime profile
         if: matrix.os == 'ubuntu-latest' && matrix.python == '3.11'
         run: |
           mkdir -p artifacts
           python scripts/ci/run_profile.py \
-            --profile full-cli \
-            --json-report artifacts/runtime-profile-full.json \
-            --markdown-report artifacts/runtime-profile-full.md
+            --profile provider-runtime \
+            --json-report artifacts/provider-runtime.json \
+            --markdown-report artifacts/provider-runtime.md
 
-      - name: 上传 full runtime profile 报告
+      - name: 上传 Provider runtime profile 报告
         if: always() && matrix.os == 'ubuntu-latest' && matrix.python == '3.11'
         uses: actions/upload-artifact@v7
         with:
-          name: runtime-profile-full-report
+          name: provider-runtime-report
           path: artifacts/
           if-no-files-found: warn
           retention-days: 7

--- a/.github/workflows/deploy-hf-space.yml
+++ b/.github/workflows/deploy-hf-space.yml
@@ -62,7 +62,7 @@ on:
       - "scripts/warp-init.sh"
       - "cloud/hfs/**"
       - ".github/workflows/deploy-hf-space.yml"
-      - ".github/workflows/build-pyinstaller.yml"
+      - ".github/workflows/build-pyinstaller-server.yml"
   workflow_dispatch:
 
 concurrency:
@@ -153,8 +153,8 @@ jobs:
           write_output(False, f"{event}:{ref}:local-preflight-only")
           PY
 
-  api-source-cli:
-    name: API surface and source CLI
+  delivery-contracts:
+    name: SDK and Server contracts
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -172,22 +172,22 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev,edition-pro]"
 
-      - name: Run API and source CLI profiles
+      - name: Run SDK and Server contracts
         env:
           PYTHONIOENCODING: utf-8
         run: |
           mkdir -p artifacts
           python scripts/ci/run_profile.py \
-            --profile pro-cli \
-            --profile basic-cli \
-            --json-report artifacts/api-source-cli-profile.json \
-            --markdown-report artifacts/api-source-cli-profile.md
+            --profile sdk-contract \
+            --profile server-contract \
+            --json-report artifacts/hfs-delivery-contracts.json \
+            --markdown-report artifacts/hfs-delivery-contracts.md
 
-      - name: Upload API and source CLI profile report
+      - name: Upload SDK and Server contract report
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: api-source-cli-profile-report
+          name: hfs-delivery-contracts-report
           path: artifacts/
           if-no-files-found: warn
           retention-days: 7
@@ -310,7 +310,7 @@ jobs:
         needs.detect-changes.outputs.deploy_changed == 'true' &&
         inputs.deploy_hfs
       }}
-    needs: [detect-changes, api-source-cli, docker-hfs]
+    needs: [detect-changes, delivery-contracts, docker-hfs]
     environment:
       name: hf
       deployment: false

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -681,10 +681,10 @@ jobs:
           name: ci-targeted-coverage
           path: deployment-evidence/coverage
 
-      - name: Download full runtime profile evidence
+      - name: Download provider runtime evidence
         uses: actions/download-artifact@v8
         with:
-          name: runtime-profile-full-report
+          name: provider-runtime-report
           path: deployment-evidence/runtime
 
       - name: Download HFS local preflight evidence
@@ -694,10 +694,10 @@ jobs:
           path: deployment-evidence/hfs-local
           merge-multiple: true
 
-      - name: Download HFS API and CLI profile evidence
+      - name: Download HFS SDK and Server contract evidence
         uses: actions/download-artifact@v8
         with:
-          name: api-source-cli-profile-report
+          name: hfs-delivery-contracts-report
           path: deployment-evidence/hfs-local
 
       - name: Download HFS live evidence
@@ -770,7 +770,7 @@ jobs:
               )
 
           required_reports = {
-              evidence_root / 'hfs-local' / 'api-source-cli-profile.json',
+              evidence_root / 'hfs-local' / 'hfs-delivery-contracts.json',
               evidence_root / 'hfs-local' / 'hf-space-local-surface-report.json',
               evidence_root / 'hfs' / 'hf-space-cd-surface-report.json',
               evidence_root / 'hfs' / 'hf-space-cd-capability-report.json',
@@ -1132,10 +1132,10 @@ jobs:
           name: ci-targeted-coverage
           path: release-evidence
 
-      - name: Download full runtime profile evidence
+      - name: Download provider runtime evidence
         uses: actions/download-artifact@v8
         with:
-          name: runtime-profile-full-report
+          name: provider-runtime-report
           path: release-evidence
 
       - name: Download optional HFS live evidence
@@ -1297,7 +1297,7 @@ jobs:
               ('panel', ('source',), ['release-evidence.tar.gz']),
               ('docs', ('source',), ['release-evidence.tar.gz']),
               ('clean_install', ('clean-install',), ['release-evidence.tar.gz']),
-              ('mcp_edition', ('clean-install', 'source'), ['release-evidence.tar.gz']),
+              ('sdk_contract', ('clean-install', 'source'), ['release-evidence.tar.gz']),
               ('package_contract', ('package',), ['wheel', 'sdist', 'SBOMs']),
               ('functional_fixtures', ('external',), ['release-evidence.tar.gz']),
               ('live_zero_key', ('external',), ['release-evidence.tar.gz']),

--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -253,8 +253,8 @@ jobs:
             tests/test_patentsview_provider_v2.py \
             -q
 
-  server_profile:
-    name: v2 pro-cli + basic-cli profile
+  delivery_contracts:
+    name: v2 SDK and Server contracts
     needs: [lane, bootstrap]
     if: needs.lane.outputs.full == 'true'
     runs-on: ubuntu-latest
@@ -276,26 +276,26 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev,edition-pro]"
 
-      - name: Run pro-cli and basic-cli profiles
+      - name: Run SDK and Server contracts
         run: |
           mkdir -p artifacts
           python scripts/ci/run_profile.py \
-            --profile pro-cli \
-            --profile basic-cli \
-            --json-report artifacts/v2-pro-basic-profile.json \
-            --markdown-report artifacts/v2-pro-basic-profile.md
+            --profile sdk-contract \
+            --profile server-contract \
+            --json-report artifacts/v2-delivery-contracts.json \
+            --markdown-report artifacts/v2-delivery-contracts.md
 
-      - name: Upload pro-cli and basic-cli profile report
+      - name: Upload SDK and Server contract report
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: v2-pro-basic-profile-report
+          name: v2-delivery-contracts-report
           path: artifacts/
           if-no-files-found: warn
           retention-days: 7
 
-  full_profile:
-    name: v2 full runtime profile
+  provider_runtime:
+    name: v2 provider runtime profile
     needs: [lane, bootstrap]
     if: needs.lane.outputs.full == 'true'
     runs-on: ubuntu-latest
@@ -317,19 +317,19 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev,edition-full]"
 
-      - name: Run full runtime profile
+      - name: Run provider runtime profile
         run: |
           mkdir -p artifacts
           python scripts/ci/run_profile.py \
-            --profile full-cli \
-            --json-report artifacts/v2-full-profile.json \
-            --markdown-report artifacts/v2-full-profile.md
+            --profile provider-runtime \
+            --json-report artifacts/v2-provider-runtime.json \
+            --markdown-report artifacts/v2-provider-runtime.md
 
-      - name: Upload full profile report
+      - name: Upload provider runtime report
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: v2-full-profile-report
+          name: v2-provider-runtime-report
           path: artifacts/
           if-no-files-found: warn
           retention-days: 7
@@ -382,8 +382,8 @@ jobs:
       - bootstrap
       - matrix_tests
       - provider_v2_conformance
-      - server_profile
-      - full_profile
+      - delivery_contracts
+      - provider_runtime
       - panel_build
     if: ${{ always() }}
     runs-on: ubuntu-latest
@@ -395,8 +395,8 @@ jobs:
           BOOTSTRAP_RESULT: ${{ needs.bootstrap.result }}
           MATRIX_RESULT: ${{ needs.matrix_tests.result }}
           PROVIDER_V2_RESULT: ${{ needs.provider_v2_conformance.result }}
-          SERVER_RESULT: ${{ needs.server_profile.result }}
-          FULL_RESULT: ${{ needs.full_profile.result }}
+          DELIVERY_RESULT: ${{ needs.delivery_contracts.result }}
+          PROVIDER_RUNTIME_RESULT: ${{ needs.provider_runtime.result }}
           PANEL_RESULT: ${{ needs.panel_build.result }}
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
@@ -409,8 +409,8 @@ jobs:
           | Bootstrap / import / wheel surface | $BOOTSTRAP_RESULT | v2 import surface, docs, registry baseline |
           | Full pytest matrix | $MATRIX_RESULT | Python 3.10-3.13 on Ubuntu, plus macOS/Windows 3.11 |
           | Provider v2 conformance | $PROVIDER_V2_RESULT | deterministic SPI, manifest, manager, OpenAlex, builtin Fetch, UniAPI, ERIC, and PatentsView contracts |
-          | pro-cli + basic-cli profile | $SERVER_RESULT | local API surface and CLI smoke |
-          | full-cli runtime profile | $FULL_RESULT | edition-full source, doctor, fetch handler, and feature matrix surface |
+          | SDK and Server contracts | $DELIVERY_RESULT | target contract/DTO prerequisites plus local Server/API surface |
+          | Provider runtime profile | $PROVIDER_RUNTIME_RESULT | provider imports, doctor, fetch handlers, and browser variant declarations |
           | Panel build | $PANEL_RESULT | TypeScript, Vitest, single-file panel artifact |
 
           External smoke, HF Space deploy, and binary build remain outside
@@ -419,7 +419,7 @@ jobs:
           EOF
 
           if [ "$FULL_LANE" = "true" ]; then
-            for result in "$BOOTSTRAP_RESULT" "$MATRIX_RESULT" "$PROVIDER_V2_RESULT" "$SERVER_RESULT" "$FULL_RESULT" "$PANEL_RESULT"; do
+            for result in "$BOOTSTRAP_RESULT" "$MATRIX_RESULT" "$PROVIDER_V2_RESULT" "$DELIVERY_RESULT" "$PROVIDER_RUNTIME_RESULT" "$PANEL_RESULT"; do
               if [ "$result" != "success" ]; then
                 echo "V2 release readiness gate failed (full lane): $result" >&2
                 exit 1
@@ -432,7 +432,7 @@ jobs:
                 exit 1
               fi
             done
-            for result in "$MATRIX_RESULT" "$SERVER_RESULT" "$FULL_RESULT" "$PANEL_RESULT"; do
+            for result in "$MATRIX_RESULT" "$DELIVERY_RESULT" "$PROVIDER_RUNTIME_RESULT" "$PANEL_RESULT"; do
               if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
                 echo "V2 fast lane unexpected full-gate result: $result" >&2
                 exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,9 +89,9 @@ Install commands may need network access unless dependencies are already cached.
 | `python tools/gen_docs.py -o docs/data-sources.md` | Regenerate source catalog docs | repo | Writes generated docs |
 | `python scripts/ci/check_no_legacy_terms.py` | Source catalog legacy term gate | repo | Deterministic |
 | `python scripts/ci/run_profile.py --list-profiles` | List CI profiles | repo | Deterministic |
-| `python scripts/ci/run_profile.py --profile basic-cli` | Basic CLI/source profile smoke | repo | Deterministic after deps installed |
-| `python scripts/ci/run_profile.py --profile pro-cli --profile basic-cli` | API plus source CLI profile smoke | repo | Requires pro extras installed |
-| `python scripts/ci/run_profile.py --profile full-cli` | Full import-surface runtime profile | repo | Requires full core runtime extras installed |
+| `python scripts/ci/run_profile.py --profile server-contract` | Server target-contract smoke | repo | Temporarily requires pro edition extras during A3c migration |
+| `python scripts/ci/run_profile.py --profile sdk-contract` | Target API-major/DTO prerequisite smoke; not generated-SDK proof | repo | Uses the current package/contract implementation until SDK generation lands |
+| `python scripts/ci/run_profile.py --profile provider-runtime` | Internal optional-provider runtime smoke | repo | Temporarily requires full edition extras; not a public product profile |
 | `cd panel && npm test` | Vitest suite | `panel/` | Deterministic after `npm ci` |
 | `cd panel && npm run build` | TypeScript build plus Vite build | `panel/` | Deterministic after `npm ci` |
 | `cd panel && npm run build:local && npm run check:artifact` | Rebuild embedded panel artifact | `panel/` | Writes `src/souwen/server/panel.html` |
@@ -150,7 +150,7 @@ Choose the narrowest validation that covers the changed surface.
    `python tools/gen_docs.py --check`, and
    `python scripts/ci/check_no_legacy_terms.py`.
 4. For server/API changes, run affected `tests/test_server` tests and consider
-   `python scripts/ci/run_profile.py --profile pro-cli --profile basic-cli`.
+   `python scripts/ci/run_profile.py --profile server-contract`.
 5. For package or wheel surface changes, run `pytest tests/test_import_surface.py -q`
    and consider the relevant `scripts/ci/run_profile.py` profile.
 6. For panel changes, run `cd panel && npm test` and/or `cd panel && npm run build`.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -33,8 +33,8 @@ gh workflow run release-candidate.yml \
   target-native smoke、同 candidate inventory 和一致的 OpenAPI checksum。Phase 8 residue audit
   完成前仍只能使用 `publish=false` 生成 RC evidence。
 - `deployment` 必须同时使用 `deploy_hfs=true, publish=false`。它跳过外层 `server-bundles`
-  release job，但保留全部非 binary gate、HFS reusable workflow 内的单次 Linux
-  `basic-cli` PyInstaller smoke、live promotion、rollback 和 readback，产出不可发布的
+  release job，但保留全部非 binary gate、HFS reusable workflow 的 target Server local preflight、
+  live promotion、rollback 和 readback，产出不可发布的
   `deployment-evidence-*` artifact。M1 起，assembler 还会解析 surface/capability JSON，要求
   target rollout、Browser Worker readiness、OpenAlex Search、builtin Fetch 与 Browser Fetch
   全部为 `PASS`；报告文件仅存在不再构成通过。
@@ -180,11 +180,12 @@ SOUWEN_ADMIN_PASSWORD=change-me uvicorn souwen.server.app:app --host 0.0.0.0 --p
 仓库的 `cloud/hfs/` 保存 Space 部署资源。部署前先本地跑：
 
 ```bash
-PYTHONPATH=src python3 scripts/ci/run_profile.py --profile pro-cli --profile basic-cli
+PYTHONPATH=src python3 scripts/ci/run_profile.py --profile server-contract
 ```
 
-旧 `server` / `minimal` 名称仍作为过渡 alias 可用，新文档和新 workflow 优先使用
-`pro-cli` / `basic-cli`。
+`server-contract` 是本地部署前的 Server contract 验证。`sdk-contract` 只验证 target
+OpenAPI、DTO 与 API-major prerequisite；它不表示 generated SDK 已经完成。A3c 暂时继续以
+edition extras 安装实现依赖，A4 才移除 editions 与相关 package matrix。
 
 PR 与直接运行 `HF Space CD` 只执行 local preflight。远端 promotion 只能由 central RC
 workflow 显式传 `deploy_hfs=true`，并按 [hf-space-cd.md](./hf-space-cd.md) 完成 private edge、

--- a/docs/hf-space-cd.md
+++ b/docs/hf-space-cd.md
@@ -26,17 +26,17 @@ private Space 的 edge 访问仍需 Hugging Face token；进入应用后，SouWe
 
 `.github/workflows/deploy-hf-space.yml` 同时承担 local preflight 与 reusable promotion：
 
-- `pull_request`：只运行本地 API/CLI、PyInstaller 和 HFS Docker smoke。
+- `pull_request`：只运行本地 SDK/Server contract 与 HFS Docker smoke；不执行远程部署。
 - 直接 `workflow_dispatch`：只运行本地 preflight，不写远端。
 - 合入或 push `main`：**不会自动部署**。
 - 远端 promotion：只能由 `.github/workflows/release-candidate.yml` 从当前 `main` control plane
   调用，并显式设置 `deploy_hfs=true`。
 
-Central workflow 要求显式选择 `evidence_profile`；哨兵值 `select` 不执行。Phase 8 前的
-`release` profile 仍是不可发布的历史 24-binary regression；`deployment` profile 必须使用
-`publish=false, deploy_hfs=true`，跳过外层 PyInstaller/Nuitka release matrix，只生成不可发布的
-deployment evidence。两种 profile 都继续运行非 binary gates；HFS reusable workflow 内的单次
-Linux `basic-cli` PyInstaller smoke 不会被跳过。`deploy_hfs=true` 时，candidate 必须等于当前
+Central workflow 要求显式选择 `evidence_profile`；哨兵值 `select` 不执行。`release` profile
+只接受四平台 PyInstaller Server bundle evidence；`deployment` profile 必须使用
+`publish=false, deploy_hfs=true`，跳过 outer Server bundle release matrix，只生成不可发布的
+deployment evidence。两种 profile 都继续运行非-binary gates；HFS reusable workflow 的 target
+Server local preflight 不会被跳过。`deploy_hfs=true` 时，candidate 必须等于当前
 `origin/main`；不能从未合入分支向持有 secrets 的部署 job 注入 verifier。Central caller 只在
 HFS reusable call 上使用一次 `secrets: inherit`。这是同仓 reusable workflow 读取
 environment-scoped secrets 的已知兼容处理（`actions/runner#4453`）；其他 reusable jobs 不得继承
@@ -51,9 +51,11 @@ secret 名称 fail fast，不输出值、长度或前缀。
 | Job | 覆盖内容 | 边界 |
 |---|---|---|
 | `Resolve deploy eligibility` | 解析入口与 candidate contract | direct dispatch 不具备远端写资格 |
-| `API surface and source CLI` | `pro-cli`、`basic-cli` profile | 不证明外部源在线 |
-| `PyInstaller CLI smoke` | `edition-basic` 单文件 binary | 不等于 24-binary release matrix |
+| `SDK and Server contracts` | `sdk-contract` + `server-contract` profiles | SDK 仅验证 target contract 前置条件；不证明 generated SDK 完成或外部源在线 |
 | `HF Space Docker surface smoke` | exact SHA 双进程启动、target/Worker readiness、docs/panel、49266 未发布 | 本地容器，不是 live Space |
+
+`server-contract` 在 A3c 迁移期仍通过现有 edition extras 安装所需实现；这不保留
+edition profile 作为产品 contract，A4 才负责删除 editions 与 package matrix。
 
 HFS Docker build 必须传 `SOUWEN_REF=<40位 candidate SHA>`。Dockerfile 的全零模板、短 SHA、
 分支名和 moving `main` 都 fail closed；detached checkout 会把 SHA 写入
@@ -158,7 +160,7 @@ IP 和速率限制影响；报告中的 `WARN` 是带时间戳观测，不是永
 
 ## 本地复现与失败处理
 
-- API/CLI：`python scripts/ci/run_profile.py --profile pro-cli --profile basic-cli`。
+- Target Server：`python scripts/ci/run_profile.py --profile server-contract`。
 - Docker：按 digest 拉取 base image，使用完整 SHA 重建 `cloud/hfs` context；没有 Docker daemon
   的机器不能把该层标为已验证。
 - PR preflight 失败：修代码、测试或 wrapper，不直接触发远端 promotion。

--- a/docs/internal/adr/0005-breaking-api-release-cutover.md
+++ b/docs/internal/adr/0005-breaking-api-release-cutover.md
@@ -18,9 +18,8 @@ Those current facts are not the desired product boundary:
   Search, LLM Search and Fetch contracts.
 - `src/souwen/server/schemas/common.py` currently defines a flat error body, while HLD §11.5 calls for a
   nested canonical error contract with stable codes and retry semantics.
-- `pyproject.toml` currently exposes direct Python library/CLI dependencies and current package version
-  `2.0.0rc2`; `.github/workflows/build-pyinstaller.yml` builds 3 CLI editions across 4 targets, and the
-  release workflow currently verifies 24 PyInstaller/Nuitka binaries.
+- The current package version is `2.0.0rc2`. Historical planning references to a
+  CLI-edition PyInstaller/Nuitka matrix are not current release-workflow evidence.
 - HLD §20 and §27 close Q-011: the target release surface is **four cross-platform PyInstaller server
   bundles**, with Nuitka and basic/full tiers retired. HLD §20 also selects the REST Client SDK as the
   default `souwen` Python distribution direction.
@@ -139,8 +138,9 @@ major, generate official clients from an immutable OpenAPI artifact and fail cli
 - [ADR 0002: current v2 RC release version](0002-versioning-policy.md)
 - Current app/auth/error evidence: `src/souwen/server/app.py`, `src/souwen/server/auth.py`,
   `src/souwen/server/schemas/common.py`
-- Current packaging/release evidence: `pyproject.toml`, `.github/workflows/build-pyinstaller.yml`,
-  `.github/workflows/build-nuitka.yml`, `.github/workflows/release-candidate.yml`
+- Current packaging/release evidence: `pyproject.toml`,
+  `.github/workflows/build-pyinstaller-server.yml`, `.github/actions/server-bundle-smoke/action.yml`,
+  `.github/workflows/release-candidate.yml`
 
 ## Review condition
 

--- a/docs/internal/development-branching.md
+++ b/docs/internal/development-branching.md
@@ -91,14 +91,15 @@ Since 2026-07-26 both workflows run in two lanes (owner-approved CI slimming):
 - Provider v2 conformance: deterministic SPI, manifest registry, Provider
   Manager, OpenAlex, builtin Fetch, UniAPI, ERIC, and PatentsView tests without network,
   browser runtime, or secrets.
-- `pro-cli` + `basic-cli` profile: local API surface tests and CLI smoke through
-  `scripts/ci/run_profile.py`; legacy `server` / `minimal` aliases remain
-  accepted during transition.
-- `full-cli` runtime profile: `edition-full` core source, doctor, and fetch
-  handler import surface through `scripts/ci/run_profile.py`, plus feature
-  matrix declarations for full-only providers. The legacy `full` alias remains
-  accepted during transition. The mutually exclusive `crawl4ai` / `scrapling`
-  browser runtime variants stay in their dedicated functional gates.
+- `server-contract`: local target API surface and Server prerequisite checks through
+  `scripts/ci/run_profile.py`.
+- `sdk-contract`: target OpenAPI, DTO and API-major prerequisite checks; this is
+  not a claim that a generated SDK is complete or published.
+- `provider-runtime`: internal optional-provider import, doctor and fetch-handler
+  surface, including feature-matrix declarations. The mutually exclusive
+  `crawl4ai` / `scrapling` browser runtime variants stay in dedicated functional gates.
+- A3c temporarily installs current edition extras to execute these checks. A4 owns
+  removal of the edition/package taxonomy; this branch policy does not pre-approve it.
 - panel build: TypeScript check, Vitest, single-file panel build, and
   `src/souwen/server/panel.html` artifact validation.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -17,7 +17,7 @@ GitHub Actions 中的 job 应尽量回答单一问题，避免把单元测试、
 | 单元测试 | 验证函数、模型、parser、配置合并等局部契约 | `pytest tests/` |
 | 集成测试 | 验证 server、registry、handler 等模块组合 | `server-test` |
 | 功能测试 | 验证真实 runtime / package 安装后的可用性 | `*_functional_check.py` |
-| 冒烟测试 | 验证 CLI、API surface、Docker/HF Space 入口仍活着 | `scripts/ci/run_profile.py`、`hf_space_smoke.py` |
+| 冒烟测试 | 验证 target API、Docker/HF Space 入口仍活着 | `scripts/ci/run_profile.py`、`hf_space_smoke.py` |
 | 系统测试 | 验证完整用户路径和多 profile 环境组合 | manual / nightly / release gate |
 
 ## 环境 Profile Runner
@@ -30,22 +30,22 @@ runner 只负责运行场景并输出 JSON/Markdown report。
 
 | Profile | 覆盖内容 | 运行位置 |
 |---|---|---|
-| `basic-cli` | `basic` edition 源码 CLI 的 help/version/sources/config 等无网络入口 | `V2 CI`、`HF Space CD / API surface and source CLI` |
-| `pro-cli` | `pro` edition 下 `tests/test_server` 与 `tests/test_hf_space_smoke.py` 的本地 API/smoke 契约 | `V2 CI`、`HF Space CD / API surface and source CLI` |
-| `full-cli` | `edition-full` 核心运行时、doctor/fetch handler import surface，以及 full-only provider 的 feature matrix 声明 | `V2 CI / v2 full runtime profile`、`CI / 测试 (Python 3.11, ubuntu-latest)` |
+| `server-contract` | target Server 的路由、认证、OpenAPI/API-major、HFS local surface 与 Panel runtime 前置契约 | V2 CI、HF Space CD local preflight |
+| `sdk-contract` | target wire contract 的 OpenAPI/DTO/API-major 前置验证；不宣称 generated SDK 已完成 | V2 CI、HF Space CD local preflight |
+| `provider-runtime` | 内部 optional provider 的 importability、feature matrix 与互斥 browser runtime | CI / provider-runtime gate |
 
-`minimal`、`server`、`full` 仍作为过渡 alias 可用，分别映射到
-`basic-cli`、`pro-cli`、`full-cli`。新文档和新 workflow 应优先使用 canonical
-profile 名称。
+`server-contract` 与 `sdk-contract` 是 A3c 的产品 contract 名称；
+`provider-runtime` 仅是内部实现验证，不能替代 package/SDK 证据。A3c 暂时继续使用
+现有 edition extras 作为安装实现；A4 负责删除 edition taxonomy 和对应 package matrix。
 
 示例：
 
 ```bash
 python scripts/ci/run_profile.py \
-  --profile pro-cli \
-  --profile basic-cli \
-  --json-report artifacts/api-source-cli-profile.json \
-  --markdown-report artifacts/api-source-cli-profile.md
+  --profile server-contract \
+  --profile sdk-contract \
+  --json-report artifacts/target-contract-profile.json \
+  --markdown-report artifacts/target-contract-profile.md
 ```
 
 ## 本地确定性测试
@@ -177,24 +177,13 @@ target-native runner：
 目录不构成发布证据。Smoke 必须覆盖 health/readiness、version/source/API-major、target rollout、
 Browser Worker、Admin fail-closed、Provider API、OpenAPI checksum 和 Supervisor 干净退出。
 
-`Build with PyInstaller` 和 `Build with Nuitka` 是旧 CLI edition rollback baseline，按三档构建：
+当前唯一 binary release evidence 是 `Build PyInstaller Server bundles` 的四平台
+target-native archive。旧 CLI edition/PyInstaller/Nuitka workflow 不构成 current evidence，
+也不能把任何 CLI binary 重新命名为 Server bundle。
 
-| Profile | 安装面 | 产物后缀 |
-|---|---|---|
-| `basic-cli` | `.[edition-basic]` | `basic-cli` |
-| `pro-cli` | `.[edition-pro]` | `pro-cli` |
-| `full-cli` | `.[edition-full]` | `full-cli` |
-
-`workflow_dispatch` 仍保留旧输入 `cli` / `server` / `full` 作为兼容 alias，
-分别映射到 `basic-cli` / `pro-cli` / `full-cli`。`pro-cli` 和 `full-cli`
-包含 API server / panel 入口，workflow 会先构建并校验 `panel.html`；
-`basic-cli` 保留 `builtin` / `site_crawler` 两个 basic fetch provider，同时物理裁剪 FastAPI server、LLM 和重型
-抓取模块。`full-cli` 使用
-`edition-full` 核心运行时，`crawl4ai` / `scrapling` 的互斥浏览器栈继续由
-专项 functional gate 验证。
-
-旧 workflow 在新的四 bundle proof 进入 `main` 且 central release 完成切换前保留，不能作为
-RC2 publish evidence；不能把旧 `pro-cli` binary重命名为 Server bundle。
+`server-contract` 与 `sdk-contract` 表达产品 contract；`provider-runtime` 表达内部可选
+provider runtime。A3c 仍用 `edition-pro` / `edition-full` extras 安装这些检查所需的
+实现依赖，这是迁移实现而非对外 profile 承诺；A4 才负责移除 editions 与其 package matrix。
 
 ## V2 / main 发布前 Gate
 
@@ -214,19 +203,19 @@ v2 release candidate 已合回 `main`。`V2 CI` 继续作为 v2 public surface �
 
 - bootstrap gate：registry/docs 测试、`tools/gen_docs.py --check`、import surface
   单测、wheel surface 检查和 registry baseline 输出。
-- full pytest matrix：安装 `.[dev,edition-pro]`，覆盖 Ubuntu Python
+- full pytest matrix：安装当前迁移期所需的 `.[dev,edition-pro]`，覆盖 Ubuntu Python
   3.10/3.11/3.12/3.13，以及 macOS/Windows Python 3.11；避免把缺少 Server
   或 scraper runtime 误报成产品行为回归。
 - Provider v2 conformance：单独运行 SPI、manifest registry、Provider Manager、
   OpenAlex、builtin Fetch、UniAPI、ERIC 与 PatentsView 的 deterministic tests；不访问网络、
   browser runtime 或 secret，并由 V2 readiness summary fail closed 汇总。
-- pro-cli + basic-cli profile：安装 API 测试依赖后运行 `pro-cli` 和 `basic-cli`
-  profile，并上传 JSON/Markdown report；`server` / `minimal` alias 仅用于过渡兼容。
-- full runtime profile：安装 `.[dev,edition-full]` 后运行 `full-cli` profile，覆盖核心
-  source、doctor 与 fetch handler import surface，并校验 full-only provider
-  仍由 feature matrix 声明；`crawl4ai` / `scrapling` 的互斥浏览器 runtime 由专项
-  functional gate 覆盖。`full` alias 仅用于过渡兼容。该 profile 上传 JSON/Markdown
-  report。
+- server contract：安装 API 测试依赖后运行 `server-contract`，上传 target Server
+  JSON/Markdown evidence。它覆盖 local API surface，不证明外部源在线。
+- SDK contract：验证 target OpenAPI、DTO 和 API-major prerequisite；在 generated SDK
+  实际生成并发布前，它不是 generated-SDK completion evidence。
+- provider runtime：在仍需 `.[dev,edition-full]` 的迁移期覆盖核心 source、doctor 与
+  fetch handler import surface，并校验 optional provider declaration；`crawl4ai` /
+  `scrapling` 的互斥 browser runtime 仍由专项 functional gate 覆盖。
 - panel build：`npm ci`、TypeScript check、Vitest、`npm run build:local` 和
   `src/souwen/server/panel.html` 产物验证。
 

--- a/scripts/ci/run_profile.py
+++ b/scripts/ci/run_profile.py
@@ -24,33 +24,19 @@ from scripts._functional_common import Outcome, ResultRecorder  # noqa: E402
 DEFAULT_TIMEOUT_SECONDS = 300.0
 OUTPUT_TAIL_CHARS = 4000
 PYTHON = sys.executable or "python"
-FULL_FETCH_PROVIDER_MODULES: Mapping[str, str] = {
+PROVIDER_RUNTIME_MODULES: Mapping[str, str] = {
     "crawl4ai": "souwen.web.crawl4ai_fetcher",
     "newspaper": "souwen.web.newspaper_fetcher",
     "readability": "souwen.web.readability_fetcher",
     "scrapling": "souwen.web.scrapling_fetcher",
 }
-FULL_FETCH_PROVIDER_MODULES_LITERAL = repr(dict(FULL_FETCH_PROVIDER_MODULES))
-FULL_CORE_FETCH_PROVIDERS = frozenset({"newspaper", "readability"})
-FULL_BROWSER_VARIANT_FETCH_PROVIDERS = frozenset({"crawl4ai", "scrapling"})
-FULL_CORE_FETCH_PROVIDERS_LITERAL = repr(tuple(sorted(FULL_CORE_FETCH_PROVIDERS)))
-FULL_BROWSER_VARIANT_FETCH_PROVIDERS_LITERAL = repr(
-    tuple(sorted(FULL_BROWSER_VARIANT_FETCH_PROVIDERS))
-)
+PROVIDER_RUNTIME_MODULES_LITERAL = repr(dict(PROVIDER_RUNTIME_MODULES))
+CORE_RUNTIME_PROVIDERS = frozenset({"newspaper", "readability"})
+BROWSER_VARIANT_RUNTIME_PROVIDERS = frozenset({"crawl4ai", "scrapling"})
+CORE_RUNTIME_PROVIDERS_LITERAL = repr(tuple(sorted(CORE_RUNTIME_PROVIDERS)))
+BROWSER_VARIANT_RUNTIME_PROVIDERS_LITERAL = repr(tuple(sorted(BROWSER_VARIANT_RUNTIME_PROVIDERS)))
 
-BASIC_RUNTIME_CODE = "\n".join(
-    [
-        "from souwen.feature_matrix import declared_fetch_provider_names, probe_capabilities",
-        "assert declared_fetch_provider_names('basic') == ('builtin', 'site_crawler')",
-        "probe = probe_capabilities('basic')",
-        "assert probe['fetch_providers'].declared == ('builtin', 'site_crawler')",
-        "assert probe['fetch_providers'].available == ('builtin', 'site_crawler')",
-        "print('basic fetch providers OK')",
-    ]
-)
-
-
-FULL_IMPORT_CODE = "\n".join(
+PROVIDER_RUNTIME_CODE = "\n".join(
     [
         "import importlib",
         "from souwen.config import get_config",
@@ -75,21 +61,21 @@ FULL_IMPORT_CODE = "\n".join(
         "    JinaReaderClient, web_search, fetch_content,",
         ")",
         "from souwen.doctor import check_all",
-        f"full_fetch_provider_modules = {FULL_FETCH_PROVIDER_MODULES_LITERAL}",
-        f"full_core_fetch_providers = set({FULL_CORE_FETCH_PROVIDERS_LITERAL})",
-        f"browser_variant_fetch_providers = set({FULL_BROWSER_VARIANT_FETCH_PROVIDERS_LITERAL})",
-        "for _provider, _module_name in full_fetch_provider_modules.items():",
+        f"provider_runtime_modules = {PROVIDER_RUNTIME_MODULES_LITERAL}",
+        f"core_runtime_providers = set({CORE_RUNTIME_PROVIDERS_LITERAL})",
+        f"browser_variant_providers = set({BROWSER_VARIANT_RUNTIME_PROVIDERS_LITERAL})",
+        "for _provider, _module_name in provider_runtime_modules.items():",
         "    importlib.import_module(_module_name)",
         "declared_fetch = set(declared_fetch_provider_names('full'))",
-        "missing_declared = set(full_fetch_provider_modules) - declared_fetch",
+        "missing_declared = set(provider_runtime_modules) - declared_fetch",
         "assert not missing_declared, sorted(missing_declared)",
         "probe = probe_capabilities('full')",
         "available_fetch = set(probe['fetch_providers'].available)",
-        "missing_core_importable = full_core_fetch_providers - available_fetch",
+        "missing_core_importable = core_runtime_providers - available_fetch",
         "assert not missing_core_importable, sorted(missing_core_importable)",
-        "available_browser_variants = browser_variant_fetch_providers & available_fetch",
+        "available_browser_variants = browser_variant_providers & available_fetch",
         "assert len(available_browser_variants) <= 1, sorted(available_browser_variants)",
-        "print('full core import surface and browser variant declarations OK')",
+        "print('provider runtime imports and browser variant declarations OK')",
     ]
 )
 
@@ -103,16 +89,23 @@ class CommandSpec:
 
 
 PROFILE_COMMANDS: Mapping[str, tuple[CommandSpec, ...]] = {
-    "basic-cli": (
+    "sdk-contract": (
         CommandSpec(
-            "mcp_runtime",
-            (PYTHON, "-c", BASIC_RUNTIME_CODE),
-            env=(("SOUWEN_EDITION", "basic"),),
+            "canonical_contract",
+            (
+                PYTHON,
+                "-m",
+                "pytest",
+                "tests/contracts/test_target_canonical_contract.py",
+                "tests/test_target_canonical_dto.py",
+                "-v",
+                "--tb=short",
+            ),
         ),
     ),
-    "pro-cli": (
+    "server-contract": (
         CommandSpec(
-            "api_surface_tests",
+            "api_surface",
             (
                 PYTHON,
                 "-m",
@@ -125,20 +118,15 @@ PROFILE_COMMANDS: Mapping[str, tuple[CommandSpec, ...]] = {
             env=(("SOUWEN_EDITION", "pro"),),
         ),
     ),
-    "full-cli": (
+    "provider-runtime": (
         CommandSpec(
-            "core_runtime_and_browser_declarations",
-            (PYTHON, "-c", FULL_IMPORT_CODE),
+            "imports_and_browser_declarations",
+            (PYTHON, "-c", PROVIDER_RUNTIME_CODE),
             env=(("SOUWEN_EDITION", "full"),),
         ),
     ),
 }
-PROFILE_ALIASES: Mapping[str, str] = {
-    "minimal": "basic-cli",
-    "server": "pro-cli",
-    "full": "full-cli",
-}
-PROFILE_CHOICES = tuple(sorted((*PROFILE_COMMANDS, *PROFILE_ALIASES)))
+PROFILE_CHOICES = tuple(sorted(PROFILE_COMMANDS))
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -192,8 +180,7 @@ def run_profiles(profiles: Sequence[str], *, timeout: float) -> ResultRecorder:
         environment={"profiles": list(profiles)},
     )
     for profile in profiles:
-        canonical_profile = PROFILE_ALIASES.get(profile, profile)
-        for command in PROFILE_COMMANDS[canonical_profile]:
+        for command in PROFILE_COMMANDS[profile]:
             _run_command(recorder, profile, command, timeout=timeout)
     return recorder
 

--- a/src/souwen/server/AGENTS.md
+++ b/src/souwen/server/AGENTS.md
@@ -27,4 +27,4 @@ Read this card for API lifecycle, auth, middleware, route registration, server s
 ## Validation
 
 - `pytest tests/test_server -v --tb=short`
-- Broader server profile: `python scripts/ci/run_profile.py --profile pro-cli --profile basic-cli`
+- Broader server profile: `python scripts/ci/run_profile.py --profile server-contract`

--- a/tests/test_ci_profile_runner.py
+++ b/tests/test_ci_profile_runner.py
@@ -21,20 +21,29 @@ EXTERNAL_RUNTIME_WORKFLOWS = (
     ".github/workflows/external-smoke-gate.yml",
 )
 PROFILE_RUNNER_WORKFLOWS = {
-    ".github/workflows/ci.yml": ("full-cli",),
-    ".github/workflows/v2-ci.yml": ("pro-cli", "basic-cli", "full-cli"),
-    ".github/workflows/deploy-hf-space.yml": ("pro-cli", "basic-cli"),
+    ".github/workflows/ci.yml": ("provider-runtime",),
+    ".github/workflows/v2-ci.yml": (
+        "sdk-contract",
+        "server-contract",
+        "provider-runtime",
+    ),
+    ".github/workflows/deploy-hf-space.yml": ("sdk-contract", "server-contract"),
 }
-LEGACY_CI_PROFILE_NAMES = ("minimal", "server", "full")
+RETIRED_CI_PROFILE_NAMES = (
+    "basic-cli",
+    "pro-cli",
+    "full-cli",
+    "minimal",
+    "server",
+    "full",
+)
 
 
 def test_list_profiles(capsys):
     assert run_profile.main(["--list-profiles"]) == 0
 
     output = set(capsys.readouterr().out.splitlines())
-    assert {"basic-cli", "pro-cli", "full-cli"} <= output
-    assert "plugin" not in output
-    assert {"minimal", "server", "full"} <= output
+    assert output == {"sdk-contract", "server-contract", "provider-runtime"}
 
 
 def test_main_requires_profile():
@@ -58,7 +67,7 @@ def test_run_profiles_records_success(monkeypatch, tmp_path):
     exit_code = run_profile.main(
         [
             "--profile",
-            "basic-cli",
+            "sdk-contract",
             "--json-report",
             str(json_report),
             "--markdown-report",
@@ -67,35 +76,22 @@ def test_run_profiles_records_success(monkeypatch, tmp_path):
     )
 
     assert exit_code == 0
-    assert len(calls) == len(run_profile.PROFILE_COMMANDS["basic-cli"])
+    assert len(calls) == len(run_profile.PROFILE_COMMANDS["sdk-contract"])
     payload = json.loads(json_report.read_text(encoding="utf-8"))
     assert payload["script"] == "ci_profile_runner"
-    assert payload["mode"] == "basic-cli"
+    assert payload["mode"] == "sdk-contract"
     assert payload["overall"] == "PASS"
-    assert payload["checks"][0]["name"].startswith("basic-cli/")
-    assert payload["environment"]["profiles"] == ["basic-cli"]
+    assert payload["checks"][0]["name"].startswith("sdk-contract/")
+    assert payload["environment"]["profiles"] == ["sdk-contract"]
     assert "Overall: **PASS**" in markdown_report.read_text(encoding="utf-8")
 
 
-def test_legacy_alias_runs_canonical_profile_but_preserves_report_name(monkeypatch):
-    calls: list[tuple[str, ...]] = []
-    editions: list[str] = []
+@pytest.mark.parametrize("profile", RETIRED_CI_PROFILE_NAMES)
+def test_retired_profile_names_are_rejected(profile):
+    with pytest.raises(SystemExit) as exc_info:
+        run_profile.main(["--profile", profile])
 
-    def fake_run(command, **kwargs):
-        calls.append(tuple(command))
-        editions.append(kwargs["env"]["SOUWEN_EDITION"])
-        return subprocess.CompletedProcess(command, 0, stdout="ok", stderr="")
-
-    monkeypatch.setattr(run_profile, "_run_subprocess", fake_run)
-
-    recorder = run_profile.run_profiles(["minimal"], timeout=1)
-
-    assert recorder.overall == Outcome.PASS
-    assert len(calls) == len(run_profile.PROFILE_COMMANDS["basic-cli"])
-    assert {check.name.split("/", maxsplit=1)[0] for check in recorder.checks} == {"minimal"}
-    assert set(editions) == {"basic"}
-    assert recorder.to_json()["mode"] == "minimal"
-    assert recorder.to_json()["environment"]["profiles"] == ["minimal"]
+    assert exc_info.value.code == 2
 
 
 def test_required_command_failure_sets_overall_fail(monkeypatch):
@@ -104,13 +100,13 @@ def test_required_command_failure_sets_overall_fail(monkeypatch):
 
     monkeypatch.setattr(run_profile, "_run_subprocess", fake_run)
 
-    recorder = run_profile.run_profiles(["server"], timeout=1)
+    recorder = run_profile.run_profiles(["server-contract"], timeout=1)
 
     assert recorder.overall == Outcome.FAIL
     assert recorder.exit_code() == 1
     assert recorder.checks[0].message == "exit code 2"
     assert recorder.checks[0].details["stderr_tail"] == "boom"
-    assert recorder.checks[0].name.startswith("server/")
+    assert recorder.checks[0].name.startswith("server-contract/")
 
 
 def test_main_returns_two_when_report_write_fails(monkeypatch, tmp_path, capsys):
@@ -126,7 +122,7 @@ def test_main_returns_two_when_report_write_fails(monkeypatch, tmp_path, capsys)
     exit_code = run_profile.main(
         [
             "--profile",
-            "basic-cli",
+            "sdk-contract",
             "--json-report",
             str(tmp_path / "profile.json"),
         ]
@@ -146,7 +142,7 @@ def test_profile_commands_prepend_source_pythonpath(monkeypatch):
     monkeypatch.setenv("PYTHONPATH", "existing")
     monkeypatch.setattr(run_profile, "_run_subprocess", fake_run)
 
-    recorder = run_profile.run_profiles(["full-cli"], timeout=1)
+    recorder = run_profile.run_profiles(["provider-runtime"], timeout=1)
 
     assert recorder.overall == Outcome.PASS
     assert captured_env["PYTHONPATH"].split(os.pathsep)[:2] == [
@@ -156,30 +152,38 @@ def test_profile_commands_prepend_source_pythonpath(monkeypatch):
     assert captured_env["SOUWEN_EDITION"] == "full"
 
 
-def test_full_import_code_covers_full_fetch_provider_modules() -> None:
-    assert run_profile.FULL_FETCH_PROVIDER_MODULES == {
+def test_provider_runtime_code_covers_optional_fetch_provider_modules() -> None:
+    assert run_profile.PROVIDER_RUNTIME_MODULES == {
         "crawl4ai": "souwen.web.crawl4ai_fetcher",
         "newspaper": "souwen.web.newspaper_fetcher",
         "readability": "souwen.web.readability_fetcher",
         "scrapling": "souwen.web.scrapling_fetcher",
     }
-    assert run_profile.FULL_CORE_FETCH_PROVIDERS == {
+    assert run_profile.CORE_RUNTIME_PROVIDERS == {
         "newspaper",
         "readability",
     }
-    assert run_profile.FULL_BROWSER_VARIANT_FETCH_PROVIDERS == {"crawl4ai", "scrapling"}
+    assert run_profile.BROWSER_VARIANT_RUNTIME_PROVIDERS == {"crawl4ai", "scrapling"}
     assert (
-        run_profile.FULL_CORE_FETCH_PROVIDERS | run_profile.FULL_BROWSER_VARIANT_FETCH_PROVIDERS
-        == set(run_profile.FULL_FETCH_PROVIDER_MODULES)
+        run_profile.CORE_RUNTIME_PROVIDERS | run_profile.BROWSER_VARIANT_RUNTIME_PROVIDERS
+        == set(run_profile.PROVIDER_RUNTIME_MODULES)
     )
 
-    assert "declared_fetch_provider_names" in run_profile.FULL_IMPORT_CODE
-    assert "probe_capabilities" in run_profile.FULL_IMPORT_CODE
-    assert "missing_core_importable" in run_profile.FULL_IMPORT_CODE
-    assert "len(available_browser_variants) <= 1" in run_profile.FULL_IMPORT_CODE
-    for provider, module in run_profile.FULL_FETCH_PROVIDER_MODULES.items():
-        assert provider in run_profile.FULL_IMPORT_CODE
-        assert module in run_profile.FULL_IMPORT_CODE
+    assert "declared_fetch_provider_names" in run_profile.PROVIDER_RUNTIME_CODE
+    assert "probe_capabilities" in run_profile.PROVIDER_RUNTIME_CODE
+    assert "missing_core_importable" in run_profile.PROVIDER_RUNTIME_CODE
+    assert "len(available_browser_variants) <= 1" in run_profile.PROVIDER_RUNTIME_CODE
+    for provider, module in run_profile.PROVIDER_RUNTIME_MODULES.items():
+        assert provider in run_profile.PROVIDER_RUNTIME_CODE
+        assert module in run_profile.PROVIDER_RUNTIME_CODE
+
+
+def test_sdk_contract_uses_only_target_contract_and_dto_tests() -> None:
+    command = run_profile.PROFILE_COMMANDS["sdk-contract"][0].command
+
+    assert "tests/contracts/test_target_canonical_contract.py" in command
+    assert "tests/test_target_canonical_dto.py" in command
+    assert not any("provider" in argument for argument in command if argument.startswith("tests/"))
 
 
 def test_workflows_install_full_profile_runtime_extras() -> None:
@@ -223,8 +227,8 @@ def test_ci_workflows_use_canonical_profile_names() -> None:
 
         for profile in expected_profiles:
             assert re.search(rf"--profile\s+{re.escape(profile)}(?=$|\s|\\)", text), relative
-        for legacy_profile in LEGACY_CI_PROFILE_NAMES:
-            assert not re.search(rf"--profile\s+{re.escape(legacy_profile)}(?=$|\s|\\)", text), (
+        for retired_profile in RETIRED_CI_PROFILE_NAMES:
+            assert not re.search(rf"--profile\s+{re.escape(retired_profile)}(?=$|\s|\\)", text), (
                 relative
             )
 
@@ -255,11 +259,11 @@ def test_agent_command_docs_use_canonical_profile_names() -> None:
 
     combined_text = "\n".join(path.read_text(encoding="utf-8") for path in agent_docs)
 
-    for profile in ("basic-cli", "pro-cli", "full-cli"):
+    for profile in ("sdk-contract", "server-contract", "provider-runtime"):
         assert re.search(rf"--profile\s+{re.escape(profile)}(?=$|\s|`)", combined_text)
-    for legacy_profile in LEGACY_CI_PROFILE_NAMES:
+    for retired_profile in RETIRED_CI_PROFILE_NAMES:
         assert not re.search(
-            rf"--profile\s+{re.escape(legacy_profile)}(?=$|\s|`)",
+            rf"--profile\s+{re.escape(retired_profile)}(?=$|\s|`)",
             combined_text,
         )
 
@@ -275,39 +279,33 @@ def test_timeout_is_recorded(monkeypatch):
 
     monkeypatch.setattr(run_profile, "_run_subprocess", fake_run)
 
-    recorder = run_profile.run_profiles(["full-cli"], timeout=3)
+    recorder = run_profile.run_profiles(["provider-runtime"], timeout=3)
 
     assert recorder.overall == Outcome.FAIL
     assert recorder.checks[0].message == "timeout after 3.0s"
     assert recorder.checks[0].details["stdout_tail"] == "partial"
 
 
-def test_canonical_profile_editions_are_explicit(monkeypatch):
-    captured: dict[str, str] = {}
+def test_canonical_profiles_keep_editions_as_internal_migration_details(monkeypatch):
+    captured: list[str | None] = []
 
     def fake_run(command, **kwargs):
-        if command[:2] == (run_profile.PYTHON, "-c"):
-            profile = command[-1]
-        elif command[:3] == (run_profile.PYTHON, "-m", "pytest"):
-            profile = "pytest"
-        else:
-            profile = command[1]
-        captured[profile] = kwargs["env"]["SOUWEN_EDITION"]
+        captured.append(kwargs["env"].get("SOUWEN_EDITION"))
         return subprocess.CompletedProcess(command, 0, stdout="ok", stderr="")
 
     monkeypatch.setattr(run_profile, "_run_subprocess", fake_run)
 
-    recorder = run_profile.run_profiles(["basic-cli", "pro-cli", "full-cli"], timeout=1)
+    recorder = run_profile.run_profiles(
+        ["sdk-contract", "server-contract", "provider-runtime"], timeout=1
+    )
 
     assert recorder.overall == Outcome.PASS
     assert {check.name.split("/", maxsplit=1)[0] for check in recorder.checks} == {
-        "basic-cli",
-        "pro-cli",
-        "full-cli",
+        "sdk-contract",
+        "server-contract",
+        "provider-runtime",
     }
-    assert captured[run_profile.BASIC_RUNTIME_CODE] == "basic"
-    assert captured["pytest"] == "pro"
-    assert captured[run_profile.FULL_IMPORT_CODE] == "full"
+    assert captured == [None, "pro", "full"]
 
 
 def test_tail_truncates_from_end():

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -322,7 +322,9 @@ def test_deployment_evidence_is_non_publishable_and_contains_no_release_binaries
     assert "deployment evidence is missing required reports" in deployment
     assert "actions/attest-build-provenance@v4" in deployment
     assert "pattern: hf-space-local-*-report" in deployment
-    assert "name: api-source-cli-profile-report" in deployment
+    assert "name: hfs-delivery-contracts-report" in deployment
+    assert "name: provider-runtime-report" in text
+    assert "runtime-profile-full-report" not in text
     assert "souwen-local-pyinstaller-cli" not in deployment
     for release_binary_pattern in (
         "pattern: souwen-linux-*",
@@ -338,6 +340,8 @@ def test_deployment_evidence_is_non_publishable_and_contains_no_release_binaries
     assert "'evidence_profile': 'release'" in release
     assert "'publishable': os.environ['PUBLISH'] == 'true'" in release
     assert "release-manifest.json" in release
+    assert "'sdk_contract'" in release
+    assert "mcp_edition" not in text
     assert "'product_name': os.environ['PRODUCT_NAME']" in release
     assert "'version': os.environ['VERSION']" in release
     assert "'api_major': int(os.environ['API_MAJOR'])" in release
@@ -382,7 +386,7 @@ def test_deployment_manifest_builder_emits_bounded_non_release_contract(
     hfs_local = evidence_root / "hfs-local"
     hfs_local.mkdir()
     for name in (
-        "api-source-cli-profile.json",
+        "hfs-delivery-contracts.json",
         "hf-space-local-pyinstaller.json",
         "hf-space-local-surface-report.json",
     ):
@@ -694,6 +698,9 @@ def test_hfs_deployment_does_not_keep_a_retired_cli_binary_smoke() -> None:
     text = _workflow("deploy-hf-space.yml")
     assert "pyinstaller-cli" not in text
     assert "souwen-local-pyinstaller" not in text
+    assert '- ".github/workflows/build-pyinstaller-server.yml"' in text
+    assert '- ".github/workflows/build-pyinstaller.yml"' not in text
+    assert "needs: [detect-changes, delivery-contracts, docker-hfs]" in text
 
 
 def test_hfs_required_fetch_fixture_change_triggers_workflow() -> None:
@@ -869,7 +876,7 @@ def test_ci_fast_lane_is_single_py313_ubuntu2404_and_full_lane_covers_release_an
     assert v2.count(gate) == 4
     for fast_job, next_job in (
         ("bootstrap", "matrix_tests"),
-        ("provider_v2_conformance", "server_profile"),
+        ("provider_v2_conformance", "delivery_contracts"),
     ):
         assert gate not in _job(v2, fast_job, next_job)
     summary = v2.split("  release_readiness_summary:", maxsplit=1)[1]


### PR DESCRIPTION
## Summary
- replace retired CLI/edition profile names with server-contract, sdk-contract, and internal provider-runtime
- keep four-platform Server bundle evidence intact and repair the HFS workflow path trigger
- rename V2, HFS, and release evidence artifacts atomically; retire the stale MCP edition gate label
- update tests and docs without claiming generated SDK completion

## Validation
- 2303 passed, 3 skipped
- 59 workflow/profile tests passed
- sdk-contract and server-contract passed
- provider-runtime passed in a clean edition-full virtual environment
- Ruff, actionlint, YAML parse, generated docs, Markdown links, legacy-term gate, and git diff --check passed