### PR TITLE
feat(sdk): generate Python client from frozen contract

### DIFF
--- a/.github/actions/clean-wheel-smoke/action.yml
+++ b/.github/actions/clean-wheel-smoke/action.yml
@@ -34,6 +34,7 @@ runs:
         import importlib
         import importlib.resources
         import importlib.util
+        import hashlib
         import json
         import os
         import subprocess
@@ -85,6 +86,25 @@ runs:
         require(not leaked, "package/no-retired-imports", f"leaked={leaked}")
 
         if profile == "sdk-default":
+            from souwen import AsyncSouWenClient, SouWenClient
+            from souwen.delivery.client_sdk import OPENAPI_SHA256, SUPPORTED_API_MAJOR
+
+            require(SouWenClient.__name__ == "SouWenClient", "sdk/sync-client", "importable")
+            require(
+                AsyncSouWenClient.__name__ == "AsyncSouWenClient",
+                "sdk/async-client",
+                "importable",
+            )
+            require(SUPPORTED_API_MAJOR == 2, "sdk/api-major", str(SUPPORTED_API_MAJOR))
+            canonical_openapi = Path("contracts/openapi/souwen-openapi-2.0.0rc2.json")
+            expected_openapi_sha256 = hashlib.sha256(canonical_openapi.read_bytes()).hexdigest()
+            require(
+                OPENAPI_SHA256 == expected_openapi_sha256,
+                "sdk/openapi-sha256",
+                OPENAPI_SHA256,
+            )
+            sdk_client = SouWenClient("http://127.0.0.1:49265")
+            sdk_client.close()
             require(not find_spec("fastapi"), "sdk/no-fastapi", "fastapi absent")
         else:
             from souwen.server.app import app

--- a/README.en.md
+++ b/README.en.md
@@ -74,53 +74,37 @@ pip install -e ".[server,tls,web,robots,scraper,scrapling]"
 
 ## 🚀 Quick Start
 
-### Python Library
+### Python REST SDK
 
 ```python
-import asyncio
-from souwen import search_papers, search_patents
+from souwen import SouWenClient
+from souwen.delivery.client_sdk import SearchRequest
 
-async def main():
-    # Convenience entry point
-    resp = await search_papers("quantum computing", per_page=5)
-    for r in resp[0].results:
-        print(r.title, "—", r.doi)
-
-    # Application API
-    from souwen.search import search, search_all
-    from souwen.web.fetch import fetch_content
-    from souwen.web.wayback import WaybackClient
-
-    # Dispatch by domain + capability
-    papers = await search("transformer", domain="paper", limit=5)
-    articles = await search("AI news", domain="web", capability="search_news")
-    results = await search_all("quantum", domains=["paper", "web", "knowledge"])
-
-    # Fetch
-    resp = await fetch_content(["https://example.com"], providers=["builtin"])
-
-    # Wayback archive
-    async with WaybackClient() as wayback:
-        snapshots = await wayback.query_snapshots("https://example.com")
-
-asyncio.run(main())
+with SouWenClient("http://127.0.0.1:8000", token="your-user-token") as client:
+    page = client.search(SearchRequest(query="quantum computing", domains=["paper"]))
+    for item in page.items:
+        print(item.title, item.url)
 ```
+
+`AsyncSouWenClient` provides the async surface. Before the first business request, both clients
+verify API major 2 and target rollout through `/healthz`. See the
+[Python SDK guide](docs/python-sdk.md) for authentication, HFS dual-token use, and errors.
 
 ### API Server
 
 ```bash
-SOUWEN_ADMIN_PASSWORD=adminpass uvicorn souwen.server.app:app --host 0.0.0.0 --port 8000
+SOUWEN_V2_ROLLOUT=target SOUWEN_USER_PASSWORD=userpass SOUWEN_ADMIN_PASSWORD=adminpass \
+  uvicorn souwen.server.app:app --host 0.0.0.0 --port 8000
 ```
 
 Main endpoints:
 
 ```bash
-curl "http://localhost:8000/api/v1/search/paper?q=transformer&per_page=5"
-curl "http://localhost:8000/api/v1/search/web?q=python"
-curl "http://localhost:8000/api/v1/fetch" \
-  -H "Authorization: Bearer adminpass" \
+curl "http://localhost:8000/api/v1/search" \
+  -H "Authorization: Bearer userpass" \
+  -H "X-SouWen-API-Major: 2" \
   -H "Content-Type: application/json" \
-  -d '{"urls":["https://example.com"]}'
+  -d '{"query":"transformer","domains":["paper"]}'
 curl "http://localhost:8000/api/v1/wayback/cdx?url=https://example.com"
 curl "http://localhost:8000/api/v1/sources"
 ```

--- a/README.md
+++ b/README.md
@@ -74,53 +74,36 @@ pip install -e ".[server,tls,web,robots,scraper,scrapling]"
 
 ## 🚀 快速开始
 
-### Python 库
+### Python REST SDK
 
 ```python
-import asyncio
-from souwen import search_papers, search_patents
+from souwen import SouWenClient
+from souwen.delivery.client_sdk import SearchRequest
 
-async def main():
-    # 便捷入口
-    resp = await search_papers("quantum computing", per_page=5)
-    for r in resp[0].results:
-        print(r.title, "—", r.doi)
-
-    # 应用 API
-    from souwen.search import search, search_all
-    from souwen.web.fetch import fetch_content
-    from souwen.web.wayback import WaybackClient
-
-    # 按 domain + capability 派发
-    papers = await search("transformer", domain="paper", limit=5)
-    articles = await search("AI news", domain="web", capability="search_news")
-    results = await search_all("quantum", domains=["paper", "web", "knowledge"])
-
-    # 抓取
-    resp = await fetch_content(["https://example.com"], providers=["builtin"])
-
-    # Wayback 归档
-    async with WaybackClient() as wayback:
-        snapshots = await wayback.query_snapshots("https://example.com")
-
-asyncio.run(main())
+with SouWenClient("http://127.0.0.1:8000", token="your-user-token") as client:
+    page = client.search(SearchRequest(query="quantum computing", domains=["paper"]))
+    for item in page.items:
+        print(item.title, item.url)
 ```
+
+SDK 同时提供 `AsyncSouWenClient`，并在首次业务请求前以 `/healthz` 校验 API major 2 与
+target rollout。完整认证、HFS 双 token 和错误处理见 [Python SDK 文档](docs/python-sdk.md)。
 
 ### API Server
 
 ```bash
-SOUWEN_ADMIN_PASSWORD=adminpass uvicorn souwen.server.app:app --host 0.0.0.0 --port 8000
+SOUWEN_V2_ROLLOUT=target SOUWEN_USER_PASSWORD=userpass SOUWEN_ADMIN_PASSWORD=adminpass \
+  uvicorn souwen.server.app:app --host 0.0.0.0 --port 8000
 ```
 
 主要端点：
 
 ```bash
-curl "http://localhost:8000/api/v1/search/paper?q=transformer&per_page=5"
-curl "http://localhost:8000/api/v1/search/web?q=python"
-curl "http://localhost:8000/api/v1/fetch" \
-  -H "Authorization: Bearer adminpass" \
+curl "http://localhost:8000/api/v1/search" \
+  -H "Authorization: Bearer userpass" \
+  -H "X-SouWen-API-Major: 2" \
   -H "Content-Type: application/json" \
-  -d '{"urls":["https://example.com"]}'
+  -d '{"query":"transformer","domains":["paper"]}'
 curl "http://localhost:8000/api/v1/wayback/cdx?url=https://example.com"
 curl "http://localhost:8000/api/v1/sources"
 ```

--- a/contracts/openapi/README.md
+++ b/contracts/openapi/README.md
@@ -25,3 +25,13 @@ PYTHONPATH=src python3 tools/gen_openapi.py \
 
 Removed or changed operations/schemas and target metadata/security changes fail the semantic check.
 Additive operations and schemas are reported but do not fail it.
+
+The generated Python bindings consume this exact byte artifact:
+
+```bash
+PYTHONPATH=src python3 tools/gen_client_sdk.py --write
+PYTHONPATH=src python3 tools/gen_client_sdk.py --check
+```
+
+Generated bindings record this artifact's SHA-256, API major and version. The SDK generator rejects
+unknown operations, incompatible auth/header contracts and schema shapes it cannot map safely.

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ Public docs 不要求读者理解历史路径；需要保留背景材料时，�
 | [getting-started.md](./getting-started.md) | 安装、Python、API Server 的最短路径 |
 | [concepts.md](./concepts.md) | domain、capability、Source Catalog、频道配置等核心概念 |
 | [python-api.md](./python-api.md) | 推荐 Python API 入口与示例 |
+| [python-sdk.md](./python-sdk.md) | generated sync/async REST SDK、认证、兼容和错误合同 |
 
 ## 数据源与配置
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -184,9 +184,9 @@ PYTHONPATH=src python3 scripts/ci/run_profile.py --profile server-contract
 ```
 
 `server-contract` 是本地部署前的 Server contract 验证。`sdk-contract` 验证 frozen
-target-only OpenAPI artifact 的可重复生成、DTO 与 API-major prerequisite；它不表示
-generated SDK 已经完成。Server runtime 通过明确 leaf extras 安装，不使用 product tier 或
-edition package matrix。
+target-only OpenAPI 与 generated Python sync/async SDK 的可重复生成、API-major preflight、
+auth/error/request-ID 和 clean import。Server runtime 通过明确 leaf extras 安装，不使用
+product tier 或 edition package matrix。
 
 PR 与直接运行 `HF Space CD` 只执行 local preflight。远端 promotion 只能由 central RC
 workflow 显式传 `deploy_hfs=true`，并按 [hf-space-cd.md](./hf-space-cd.md) 完成 private edge、

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,29 +34,28 @@ pip install -e ".[server,tls,web,robots,scraper,crawl4ai]"
 pip install -e ".[server,tls,web,robots,scraper,scrapling]"
 ```
 
-## Python 调用
+## Python REST SDK
 
 ```python
-import asyncio
-
-from souwen.search import search, search_all
-from souwen.web.fetch import fetch_content
+from souwen import SouWenClient
+from souwen.delivery.client_sdk import SearchRequest
 
 
-async def main() -> None:
-    papers = await search("transformer", domain="paper", limit=5)
-    mixed = await search_all("quantum", domains=["paper", "web", "knowledge"], per_domain_limit=5)
-    pages = await fetch_content(["https://example.com"], providers=["builtin"])
-    print(papers[0].source, len(mixed), pages.total_ok)
-
-
-asyncio.run(main())
+with SouWenClient("http://127.0.0.1:8000", token="your-user-token") as client:
+    result = client.search(SearchRequest(query="transformer", domains=["paper"]))
+    print([item.title for item in result.items])
 ```
+
+异步代码使用 `AsyncSouWenClient`。SDK 只暴露 frozen OpenAPI 中的 Search、LLM Search、Fetch、
+Providers 与探针方法；没有任意 path/raw JSON 逃生口。首次业务调用先自动执行 `/healthz`
+preflight，并在解析响应前验证 API major、target rollout 和 request ID。详见
+[python-sdk.md](./python-sdk.md)。
 
 ## API Server
 
 ```bash
-SOUWEN_ADMIN_PASSWORD=adminpass uvicorn souwen.server.app:app --host 0.0.0.0 --port 8000
+SOUWEN_V2_ROLLOUT=target SOUWEN_USER_PASSWORD=userpass SOUWEN_ADMIN_PASSWORD=adminpass \
+  uvicorn souwen.server.app:app --host 0.0.0.0 --port 8000
 ```
 
 常用端点：

--- a/docs/hf-space-cd.md
+++ b/docs/hf-space-cd.md
@@ -51,7 +51,7 @@ secret 名称 fail fast，不输出值、长度或前缀。
 | Job | 覆盖内容 | 边界 |
 |---|---|---|
 | `Resolve deploy eligibility` | 解析入口与 candidate contract | direct dispatch 不具备远端写资格 |
-| `SDK and Server contracts` | `sdk-contract` + `server-contract` profiles | SDK 仅验证 target contract 前置条件；不证明 generated SDK 完成或外部源在线 |
+| `SDK and Server contracts` | `sdk-contract` + `server-contract` profiles | 验证 generated Python SDK 与本地 Server contract；不证明外部源在线 |
 | `HF Space Docker surface smoke` | exact SHA 双进程启动、target/Worker readiness、docs/panel、49266 未发布 | 本地容器，不是 live Space |
 
 `server-contract` 通过明确的 Server runtime leaf extras 安装所需实现；这不是新的

--- a/docs/internal/development-branching.md
+++ b/docs/internal/development-branching.md
@@ -94,8 +94,8 @@ Since 2026-07-26 both workflows run in two lanes (owner-approved CI slimming):
   matrix, builtin Fetch, and UniAPI tests without network, browser runtime, HOME, or secrets.
 - `server-contract`: local target API surface and Server prerequisite checks through
   `scripts/ci/run_profile.py`.
-- `sdk-contract`: target OpenAPI, DTO and API-major prerequisite checks; this is
-  not a claim that a generated SDK is complete or published.
+- `sdk-contract`: target OpenAPI plus generated Python sync/async SDK freshness,
+  API-major preflight, auth/error/request-ID and clean-import checks.
 - `provider-runtime`: internal optional-provider import, doctor and fetch-handler
   surface, including feature-matrix declarations. The mutually exclusive
   `crawl4ai` / `scrapling` browser runtime variants stay in dedicated functional gates.

--- a/docs/python-sdk.md
+++ b/docs/python-sdk.md
@@ -1,0 +1,65 @@
+# Python REST SDK
+
+SouWen v2rc2 的 Python SDK 由
+[`contracts/openapi/souwen-openapi-2.0.0rc2.json`](../contracts/openapi/souwen-openapi-2.0.0rc2.json)
+确定性生成。同步 `SouWenClient` 与异步 `AsyncSouWenClient` 覆盖同一组 8 个 operation，模型、
+operation mapping、SDK version、API major 与 OpenAPI SHA 都来自这一份 artifact。
+
+## 同步与异步调用
+
+```python
+from souwen import SouWenClient
+from souwen.delivery.client_sdk import SearchRequest
+
+with SouWenClient("https://souwen.example", token="your-user-token") as client:
+    page = client.search(SearchRequest(query="retrieval", domains=["paper", "web"]))
+```
+
+```python
+from souwen import AsyncSouWenClient
+from souwen.delivery.client_sdk import FetchRequest
+
+async with AsyncSouWenClient("https://souwen.example", token="your-user-token") as client:
+    batch = await client.fetch(FetchRequest(targets=["https://example.com"]))
+```
+
+客户端默认使用 `Authorization: Bearer`。当上游 private edge 占用该 header 时，必须显式使用
+两个独立 channel；SDK 不会在失败后自动 fallback：
+
+```python
+client = SouWenClient(
+    "https://private-space.example",
+    token="your-application-token",
+    auth_channel="x-souwen-token",
+    edge_token="your-private-edge-token",
+)
+```
+
+不要把 token 写入源码、日志、截图或报告；示例值仅表示参数位置。
+
+## 兼容与错误
+
+- SDK 固定支持 API major `2`，每个请求发送 `X-SouWen-API-Major: 2`。
+- 第一次 Data API 调用前自动请求 `/healthz`；major 缺失/不匹配时抛
+  `ApiMajorMismatchError`，legacy rollout 或 request/context 不一致时抛
+  `ContractViolationError`，业务 body 不会先行发送。
+- canonical 非 2xx 响应抛 `SouWenAPIError`，保留 typed `ErrorResponse`、request ID、
+  `Retry-After` 和 rate-limit headers。
+- 网络与 timeout 失败抛 `SouWenTransportError`。SDK 不自动重试 Search、LLM Search 或 Fetch，
+  避免静默重放配额或费用相关操作。
+- 默认 timeout 为 125 秒；每个 method 可显式覆盖。同步客户端使用 `close()`/`with`，异步客户端
+  使用 `aclose()`/`async with`。
+
+## 生成与验证
+
+生成文件不可手改。维护者在安装 dev 依赖后运行：
+
+```bash
+PYTHONPATH=src python3 tools/gen_client_sdk.py --write
+PYTHONPATH=src python3 tools/gen_client_sdk.py --check
+PYTHONPATH=src python3 scripts/ci/run_profile.py --profile sdk-contract
+```
+
+`--check` 会重新读取 canonical artifact，以仓库固定的 Ruff 版本格式化内存中的生成结果，再与
+tracked bindings 逐字节比较。未知 operation、非 target security/header、API major/version 漂移或
+无法安全映射的 schema 会 fail closed。

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -31,7 +31,7 @@ runner 只负责运行场景并输出 JSON/Markdown report。
 | Profile | 覆盖内容 | 运行位置 |
 |---|---|---|
 | `server-contract` | target Server 的路由、认证、OpenAPI/API-major、HFS local surface 与 Panel runtime 前置契约 | V2 CI、HF Space CD local preflight |
-| `sdk-contract` | target-only OpenAPI artifact 的可重复生成、semantic gate、DTO/API-major 前置验证；不宣称 generated SDK 已完成 | V2 CI、HF Space CD local preflight |
+| `sdk-contract` | target-only OpenAPI 与 generated Python sync/async SDK 的可重复生成、semantic/API-major、auth/error/clean import 合同 | V2 CI、HF Space CD local preflight |
 | `provider-runtime` | 内部 optional provider 的 importability、feature matrix 与互斥 browser runtime | CI / provider-runtime gate |
 
 `server-contract` 与 `sdk-contract` 是 A3c 的产品 contract 名称；
@@ -221,8 +221,8 @@ v2 release candidate 已合回 `main`。`V2 CI` 继续作为 v2 public surface �
   V2 readiness summary fail closed 汇总。
 - server contract：安装 API 测试依赖后运行 `server-contract`，上传 target Server
   JSON/Markdown evidence。它覆盖 local API surface，不证明外部源在线。
-- SDK contract：验证 target OpenAPI、DTO 和 API-major prerequisite；在 generated SDK
-  实际生成并发布前，它不是 generated-SDK completion evidence。
+- SDK contract：验证 target OpenAPI、generated Python bindings freshness、sync/async operation、
+  API-major preflight、auth/error/request-ID、无自动 retry 与 clean import；TypeScript SDK 仍由 C2c 交付。
 - provider runtime：使用明确 provider extras 覆盖核心 source、doctor 与
   fetch handler import surface，并校验 optional provider declaration；`crawl4ai` /
   `scrapling` 的互斥 browser runtime 仍由专项 functional gate 覆盖。

--- a/scripts/ci/run_profile.py
+++ b/scripts/ci/run_profile.py
@@ -114,6 +114,22 @@ PROFILE_COMMANDS: Mapping[str, tuple[CommandSpec, ...]] = {
                 "contracts/openapi/souwen-openapi-2.0.0rc2.json",
             ),
         ),
+        CommandSpec(
+            "python_sdk_reproducibility",
+            (PYTHON, "tools/gen_client_sdk.py", "--check"),
+        ),
+        CommandSpec(
+            "python_sdk_contract",
+            (
+                PYTHON,
+                "-m",
+                "pytest",
+                "tests/test_client_sdk_generator.py",
+                "tests/test_client_sdk_contract.py",
+                "-v",
+                "--tb=short",
+            ),
+        ),
     ),
     "server-contract": (
         CommandSpec(

--- a/src/souwen/__init__.py
+++ b/src/souwen/__init__.py
@@ -13,6 +13,7 @@ from souwen.citations import get_citation_count, get_incoming_citations, get_ref
 from souwen.wikisource import get_wikisource_page_detail
 from souwen.web.search import web_search
 from souwen.config import get_config, reload_config
+from souwen.delivery.client_sdk import AsyncSouWenClient, SouWenClient
 
 __all__ = [
     "search",
@@ -27,5 +28,7 @@ __all__ = [
     "web_search",
     "get_config",
     "reload_config",
+    "SouWenClient",
+    "AsyncSouWenClient",
     "__version__",
 ]

--- a/src/souwen/delivery/client_sdk/__init__.py
+++ b/src/souwen/delivery/client_sdk/__init__.py
@@ -1,3 +1,28 @@
-"""Client SDK boundary. Owner: Delivery Client SDK. Allowed dependencies: generated OpenAPI bindings."""
+"""Generated target REST SDK. Owner: Delivery Client SDK."""
 
-__all__: list[str] = []
+from ._generated_models import *  # noqa: F403
+from ._generated_models import __all__ as _model_exports
+from ._generated_operations import OPENAPI_SHA256, SDK_VERSION, SUPPORTED_API_MAJOR
+from .client import AsyncSouWenClient, SouWenClient
+from .errors import (
+    ApiMajorMismatchError,
+    ContractViolationError,
+    SouWenAPIError,
+    SouWenSDKError,
+    SouWenTransportError,
+)
+
+
+__all__ = [
+    "ApiMajorMismatchError",
+    "AsyncSouWenClient",
+    "ContractViolationError",
+    "OPENAPI_SHA256",
+    "SDK_VERSION",
+    "SUPPORTED_API_MAJOR",
+    "SouWenAPIError",
+    "SouWenClient",
+    "SouWenSDKError",
+    "SouWenTransportError",
+    *_model_exports,
+]

--- a/src/souwen/delivery/client_sdk/_generated_models.py
+++ b/src/souwen/delivery/client_sdk/_generated_models.py
@@ -1,0 +1,457 @@
+"""Generated from contracts/openapi/souwen-openapi-2.0.0rc2.json; do not edit."""
+
+# generator_version=1
+# openapi_sha256=e4343a549c99596244c5f7cf8bed0d1675641bb4eec1a44abbcc65f8f6f18de9
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import AnyUrl, BaseModel, ConfigDict, Field
+
+
+class _StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, hide_input_in_errors=True)
+
+
+class _OpenModel(BaseModel):
+    model_config = ConfigDict(extra="allow", frozen=True, hide_input_in_errors=True)
+
+
+class ClientRequestContext(_StrictModel):
+    "Client-supplied correlation subset without server-owned API state."
+
+    request_id: str | None = Field(default=None, min_length=1, max_length=128)
+    trace_id: str | None = Field(default=None, min_length=1, max_length=128)
+
+
+class ContentMetadata(_StrictModel):
+    "Safe normalized-content metadata for one Fetch result."
+
+    charset: str | None = Field(default=None, min_length=1, max_length=64)
+    content_length: int | None = Field(default=None, ge=0.0)
+    media_type: str = Field(min_length=1, max_length=128)
+    quality: Literal["high", "low"] | None = None
+    retrieved_at: datetime | None = None
+    truncated: bool
+
+
+class ErrorDetail(_StrictModel):
+    "Public error details with no upstream payload or diagnostic fields."
+
+    code: Literal[
+        "invalid_request",
+        "unauthenticated",
+        "forbidden",
+        "not_found",
+        "conflict",
+        "api_major_mismatch",
+        "rate_limited",
+        "payload_too_large",
+        "unsupported_media_type",
+        "worker_unavailable",
+        "worker_not_ready",
+        "worker_overloaded",
+        "worker_timeout",
+        "worker_protocol_mismatch",
+        "provider_timeout",
+        "provider_unavailable",
+        "policy_blocked",
+        "internal_error",
+    ]
+    message: str = Field(min_length=1, max_length=512)
+    provider: str | None = Field(default=None, min_length=1, max_length=128)
+    request_id: str = Field(min_length=1, max_length=128)
+    retryable: bool
+
+
+class ErrorResponse(_StrictModel):
+    "Target External Data API error envelope."
+
+    context: RequestContext
+    error: ErrorDetail
+
+
+class EvidenceItem(_StrictModel):
+    "Verifiable public evidence attached to an LLM Search item."
+
+    id: str = Field(min_length=1, max_length=512)
+    item_id: str = Field(min_length=1, max_length=512)
+    provider: str = Field(min_length=1, max_length=128)
+    public_url: AnyUrl = Field(min_length=1)
+    retrieved_at: datetime
+    title_or_snippet: str = Field(min_length=1, max_length=20000)
+
+
+class FetchBatch(_StrictModel):
+    "Canonical Fetch batch emitted by a Fetch provider or Core module."
+
+    context: RequestContext
+    items: list[FetchResult]
+    meta: FetchMeta
+
+
+class FetchContentOptions(_StrictModel):
+    "Bounded normalized-content extraction options."
+
+    max_code_points: int | None = Field(default=None, ge=1.0, le=1000000.0)
+
+
+class FetchMeta(_StrictModel):
+    "Batch-level Fetch outcome summary."
+
+    partial: bool = False
+
+
+class FetchPolicyOptions(_StrictModel):
+    "Policy options that cannot disable server-side Fetch protections."
+
+    respect_robots: Literal[True] | None = None
+
+
+class FetchRequest(_StrictModel):
+    "Canonical Fetch input; target validation does not replace SSRF controls."
+
+    content: FetchContentOptions | None = None
+    policy: FetchPolicyOptions | None = None
+    providers: list[ProviderRef] | None = None
+    strategy: Literal["fallback", "fanout"] | None = None
+    targets: list[AnyUrl] = Field(min_length=1, max_length=20)
+
+
+class FetchResult(_StrictModel):
+    "One per-target Fetch outcome, including its own provenance or safe error."
+
+    content: str | None = Field(default=None, max_length=1000000)
+    content_metadata: ContentMetadata | None = None
+    error: ErrorDetail | None = None
+    final_url: AnyUrl | None = Field(default=None, min_length=1)
+    provenance: list[Provenance] = Field(min_length=1)
+    status: Literal["success", "failed", "blocked"]
+    target: AnyUrl = Field(min_length=1)
+    title: str | None = Field(default=None, max_length=2048)
+
+
+class HTTPValidationError(_OpenModel):
+    detail: list[ValidationError] | None = None
+
+
+class LLMFetchOptions(_StrictModel):
+    "Bounded request to enable a separately secured downstream Fetch step."
+
+    enabled: bool = True
+
+
+class LLMSearchBudget(_StrictModel):
+    "Execution limits, not a billing promise."
+
+    max_attempts: int | None = Field(default=None, ge=1.0)
+    timeout_seconds: float | None = Field(default=None, le=120.0, gt=0.0)
+
+
+class LLMSearchRequest(_StrictModel):
+    "Canonical single-operation LLM Search input."
+
+    budget: LLMSearchBudget | None = None
+    fetch: LLMFetchOptions | None = None
+    max_results_per_provider: int | None = Field(default=None, ge=1.0)
+    providers: list[ProviderRef] = Field(min_length=1)
+    query: str = Field(min_length=1, max_length=4096)
+    strategy: Literal["single", "fanout", "first_success"]
+    synthesis_profile: str | None = Field(default=None, min_length=1, max_length=128)
+
+
+class LLMSearchResult(_StrictModel):
+    "Canonical LLM Search result with evidence and always-present usage."
+
+    answer: str | None = Field(default=None, max_length=100000)
+    context: RequestContext
+    evidence: list[EvidenceItem]
+    items: list[SearchItem]
+    meta: SearchMeta
+    query: str = Field(min_length=1, max_length=4096)
+    usage: Usage
+
+
+class PageInfo(_StrictModel):
+    "Opaque continuation information for a canonical page."
+
+    limit: int = Field(ge=1.0, le=100.0)
+    next_cursor: str | None = Field(default=None, min_length=1, max_length=2048)
+    total: int | None = Field(default=None, ge=0.0)
+
+
+class ProbeResponse(_StrictModel):
+    "Superset payload shared by canonical probes and their 2.x aliases."
+
+    components: (
+        dict[str, Literal["ready", "not_ready", "optional_unavailable", "disabled"]] | None
+    ) = None
+    config_revision: str | None = Field(default=None, min_length=1, max_length=128)
+    context: RequestContext
+    error: str | None = Field(default=None, min_length=1, max_length=256)
+    ready: bool
+    rollout_mode: RolloutMode
+    source_sha: str | None = Field(default=None, min_length=40, max_length=40)
+    status: Literal["ok", "ready", "not_ready"]
+    version: str = Field(min_length=1, max_length=64)
+    worker_source_sha: str | None = Field(default=None, min_length=40, max_length=40)
+    wrapper_sha: str | None = Field(default=None, min_length=40, max_length=40)
+
+
+class Provenance(_StrictModel):
+    "Safe public provenance for one canonical result."
+
+    attempt: int | None = Field(default=None, ge=1.0)
+    outcome: Literal["success", "empty", "failed"]
+    provider: str = Field(min_length=1, max_length=128)
+    retrieved_at: datetime | None = None
+
+
+class ProviderCatalog(_StrictModel):
+    "Migrated Provider v2 catalog without legacy source or config readback fields."
+
+    context: RequestContext
+    items: list[ProviderCatalogItem]
+
+
+class ProviderCatalogItem(_StrictModel):
+    "Safe Provider v2 availability without config or secret values."
+
+    availability: Literal["available", "unavailable"]
+    capabilities: list[Literal["search", "llm_search", "fetch"]] = Field(min_length=1)
+    missing_fields: list[str] = Field(default_factory=list)
+    provenance: list[Provenance] = Field(min_length=1)
+    provider: str = Field(min_length=1, max_length=128)
+    reason: Literal["available", "disabled", "missing_configuration", "not_eligible"]
+
+
+class ProviderFailure(_StrictModel):
+    "A machine-readable provider failure retained in partial results."
+
+    code: Literal[
+        "invalid_request",
+        "unauthenticated",
+        "forbidden",
+        "not_found",
+        "conflict",
+        "api_major_mismatch",
+        "rate_limited",
+        "payload_too_large",
+        "unsupported_media_type",
+        "worker_unavailable",
+        "worker_not_ready",
+        "worker_overloaded",
+        "worker_timeout",
+        "worker_protocol_mismatch",
+        "provider_timeout",
+        "provider_unavailable",
+        "policy_blocked",
+        "internal_error",
+    ]
+    provider: str = Field(min_length=1, max_length=128)
+
+
+class ProviderRef(_StrictModel):
+    "A public, stable provider identity; never a model, URL, or secret reference."
+
+    display_name: str | None = Field(default=None, min_length=1, max_length=256)
+    id: str = Field(min_length=1, max_length=128, pattern="^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+    kind: Literal["search", "llm_search", "fetch"]
+
+
+class RequestContext(_StrictModel):
+    "Correlation data carried by every canonical response."
+
+    api_major: Literal[2] = 2
+    request_id: str = Field(min_length=1, max_length=128)
+    trace_id: str | None = Field(default=None, min_length=1, max_length=128)
+
+
+RolloutMode = Literal["legacy", "target"]
+
+
+class SearchAttributes(_StrictModel):
+    "Explicit additive metadata shared by the first Provider v2 slices."
+
+    authors: list[str] = Field(default_factory=list)
+    citation_count: int | None = Field(default=None, ge=0.0)
+    identifiers: list[SearchIdentifier] = Field(default_factory=list)
+    language: str | None = Field(default=None, min_length=2, max_length=35)
+    open_access: bool | None = None
+    resource_type: str | None = Field(default=None, min_length=1, max_length=64)
+    year: int | None = Field(default=None, ge=0.0, le=9999.0)
+
+
+class SearchFilters(_StrictModel):
+    "Schema-listed filters for the initial canonical Search surface."
+
+    language: str | None = Field(default=None, min_length=2, max_length=35)
+    open_access: bool | None = None
+    resource_type: str | None = Field(default=None, min_length=1, max_length=64)
+    year_from: int | None = Field(default=None, ge=0.0, le=9999.0)
+    year_to: int | None = Field(default=None, ge=0.0, le=9999.0)
+
+
+class SearchIdentifier(_StrictModel):
+    "A stable domain identifier such as DOI or OpenAlex ID."
+
+    scheme: str = Field(min_length=1, max_length=32, pattern="^[a-z][a-z0-9_.-]*$")
+    value: str = Field(min_length=1, max_length=512)
+
+
+class SearchItem(_StrictModel):
+    "One normalized Search result without provider-private payloads."
+
+    attributes: SearchAttributes | None = None
+    id: str = Field(min_length=1, max_length=512)
+    provenance: list[Provenance] = Field(min_length=1)
+    rank: int | None = Field(default=None, ge=1.0)
+    snippet: str | None = Field(default=None, max_length=20000)
+    title: str = Field(min_length=1, max_length=2048)
+    url: AnyUrl | None = Field(default=None, min_length=1)
+
+
+class SearchMeta(_StrictModel):
+    "Provider outcome summary for Search and LLM Search results."
+
+    failed: list[ProviderFailure] = Field(default_factory=list)
+    partial: bool = False
+    requested: list[str] = Field(default_factory=list)
+    succeeded: list[str] = Field(default_factory=list)
+
+
+class SearchPage(_StrictModel):
+    "Canonical Search page emitted by a Search provider or Core module."
+
+    context: RequestContext
+    items: list[SearchItem]
+    meta: SearchMeta
+    page: PageInfo
+
+
+class SearchPageRequest(_StrictModel):
+    "Client paging input; the cursor remains opaque to the client."
+
+    cursor: str | None = Field(default=None, min_length=1, max_length=2048)
+    limit: int = Field(ge=1.0, le=100.0)
+
+
+class SearchRequest(_StrictModel):
+    "Canonical Search use-case input."
+
+    domains: list[
+        Literal[
+            "paper",
+            "book",
+            "research_output",
+            "patent",
+            "web",
+            "news",
+            "images",
+            "videos",
+            "social",
+            "office",
+            "developer",
+            "cn_tech",
+            "knowledge",
+        ]
+    ] = Field(min_length=1)
+    filters: SearchFilters | None = None
+    page: SearchPageRequest | None = None
+    providers: list[ProviderRef] | None = None
+    query: str = Field(min_length=1, max_length=4096)
+    request_context: ClientRequestContext | None = None
+
+
+class Usage(_StrictModel):
+    "Provider-reported usage only; unknown values are represented by ``None``."
+
+    cost: float | None = Field(default=None, ge=0.0)
+    currency: str | None = Field(default=None, min_length=1, max_length=16)
+    input_tokens: int | None = Field(default=None, ge=0.0)
+    output_tokens: int | None = Field(default=None, ge=0.0)
+
+
+class ValidationError(_OpenModel):
+    ctx: dict[str, Any] | None = None
+    input: Any | None = None
+    loc: list[str | int]
+    msg: str
+    type: str
+
+
+ClientRequestContext.model_rebuild()
+ContentMetadata.model_rebuild()
+ErrorDetail.model_rebuild()
+ErrorResponse.model_rebuild()
+EvidenceItem.model_rebuild()
+FetchBatch.model_rebuild()
+FetchContentOptions.model_rebuild()
+FetchMeta.model_rebuild()
+FetchPolicyOptions.model_rebuild()
+FetchRequest.model_rebuild()
+FetchResult.model_rebuild()
+HTTPValidationError.model_rebuild()
+LLMFetchOptions.model_rebuild()
+LLMSearchBudget.model_rebuild()
+LLMSearchRequest.model_rebuild()
+LLMSearchResult.model_rebuild()
+PageInfo.model_rebuild()
+ProbeResponse.model_rebuild()
+Provenance.model_rebuild()
+ProviderCatalog.model_rebuild()
+ProviderCatalogItem.model_rebuild()
+ProviderFailure.model_rebuild()
+ProviderRef.model_rebuild()
+RequestContext.model_rebuild()
+SearchAttributes.model_rebuild()
+SearchFilters.model_rebuild()
+SearchIdentifier.model_rebuild()
+SearchItem.model_rebuild()
+SearchMeta.model_rebuild()
+SearchPage.model_rebuild()
+SearchPageRequest.model_rebuild()
+SearchRequest.model_rebuild()
+Usage.model_rebuild()
+ValidationError.model_rebuild()
+
+
+__all__ = [
+    "ClientRequestContext",
+    "ContentMetadata",
+    "ErrorDetail",
+    "ErrorResponse",
+    "EvidenceItem",
+    "FetchBatch",
+    "FetchContentOptions",
+    "FetchMeta",
+    "FetchPolicyOptions",
+    "FetchRequest",
+    "FetchResult",
+    "HTTPValidationError",
+    "LLMFetchOptions",
+    "LLMSearchBudget",
+    "LLMSearchRequest",
+    "LLMSearchResult",
+    "PageInfo",
+    "ProbeResponse",
+    "Provenance",
+    "ProviderCatalog",
+    "ProviderCatalogItem",
+    "ProviderFailure",
+    "ProviderRef",
+    "RequestContext",
+    "RolloutMode",
+    "SearchAttributes",
+    "SearchFilters",
+    "SearchIdentifier",
+    "SearchItem",
+    "SearchMeta",
+    "SearchPage",
+    "SearchPageRequest",
+    "SearchRequest",
+    "Usage",
+    "ValidationError",
+]

--- a/src/souwen/delivery/client_sdk/_generated_operations.py
+++ b/src/souwen/delivery/client_sdk/_generated_operations.py
@@ -1,0 +1,58 @@
+"""Generated from contracts/openapi/souwen-openapi-2.0.0rc2.json; do not edit."""
+
+# generator_version=1
+# openapi_sha256=e4343a549c99596244c5f7cf8bed0d1675641bb4eec1a44abbcc65f8f6f18de9
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+SDK_VERSION = "2.0.0rc2"
+SUPPORTED_API_MAJOR = 2
+OPENAPI_SHA256 = "e4343a549c99596244c5f7cf8bed0d1675641bb4eec1a44abbcc65f8f6f18de9"
+
+
+class Operation(NamedTuple):
+    method: str
+    path: str
+    request_model: str | None
+    response_model: str
+    response_statuses: tuple[int, ...]
+
+
+FETCH = Operation("POST", "/api/v1/fetch", "FetchRequest", "FetchBatch", (200,))
+LLM_SEARCH = Operation("POST", "/api/v1/llm-search", "LLMSearchRequest", "LLMSearchResult", (200,))
+LIST_PROVIDERS = Operation("GET", "/api/v1/providers", None, "ProviderCatalog", (200,))
+SEARCH = Operation("POST", "/api/v1/search", "SearchRequest", "SearchPage", (200,))
+HEALTH_LEGACY_ALIAS = Operation("GET", "/health", None, "ProbeResponse", (200,))
+HEALTHZ = Operation("GET", "/healthz", None, "ProbeResponse", (200,))
+READINESS_LEGACY_ALIAS = Operation("GET", "/readiness", None, "ProbeResponse", (200, 503))
+READYZ = Operation("GET", "/readyz", None, "ProbeResponse", (200, 503))
+
+OPERATIONS = {
+    "fetch": FETCH,
+    "llmSearch": LLM_SEARCH,
+    "listProviders": LIST_PROVIDERS,
+    "search": SEARCH,
+    "healthLegacyAlias": HEALTH_LEGACY_ALIAS,
+    "healthz": HEALTHZ,
+    "readinessLegacyAlias": READINESS_LEGACY_ALIAS,
+    "readyz": READYZ,
+}
+
+
+__all__ = [
+    "FETCH",
+    "HEALTHZ",
+    "HEALTH_LEGACY_ALIAS",
+    "LIST_PROVIDERS",
+    "LLM_SEARCH",
+    "OPENAPI_SHA256",
+    "OPERATIONS",
+    "Operation",
+    "READINESS_LEGACY_ALIAS",
+    "READYZ",
+    "SDK_VERSION",
+    "SEARCH",
+    "SUPPORTED_API_MAJOR",
+]

--- a/src/souwen/delivery/client_sdk/client.py
+++ b/src/souwen/delivery/client_sdk/client.py
@@ -1,0 +1,590 @@
+"""Thin sync and async transports over generated target operations and DTOs."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import threading
+from collections.abc import Mapping
+from types import TracebackType
+from typing import Literal, TypeVar
+from uuid import uuid4
+
+import httpx
+from pydantic import BaseModel, ValidationError
+
+from . import _generated_operations as operations
+from ._generated_models import (
+    ErrorResponse,
+    FetchBatch,
+    FetchRequest,
+    LLMSearchRequest,
+    LLMSearchResult,
+    ProbeResponse,
+    ProviderCatalog,
+    SearchPage,
+    SearchRequest,
+)
+from .errors import (
+    ApiMajorMismatchError,
+    ContractViolationError,
+    SouWenAPIError,
+    SouWenTransportError,
+)
+
+
+ResponseT = TypeVar("ResponseT", bound=BaseModel)
+AuthChannel = Literal["authorization", "x-souwen-token"]
+TimeoutValue = float | httpx.Timeout | None
+DEFAULT_TIMEOUT_SECONDS = 125.0
+_REQUEST_ID = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+_RESERVED_HEADERS = frozenset(
+    {"authorization", "x-souwen-token", "x-souwen-api-major", "x-request-id"}
+)
+_RATE_LIMIT_HEADERS = (
+    "X-RateLimit-Limit",
+    "X-RateLimit-Remaining",
+    "X-RateLimit-Reset",
+)
+
+
+def _normalize_base_url(value: str) -> str:
+    try:
+        url = httpx.URL(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("base_url must be a valid HTTP(S) URL") from exc
+    if url.scheme not in {"http", "https"} or not url.host:
+        raise ValueError("base_url must be an absolute HTTP(S) URL")
+    if url.username or url.password or url.query or url.fragment:
+        raise ValueError("base_url cannot contain userinfo, query, or fragment")
+    return str(url).rstrip("/")
+
+
+def _validate_headers(headers: Mapping[str, str] | None) -> dict[str, str]:
+    normalized = dict(headers or {})
+    conflicts = sorted(name for name in normalized if name.lower() in _RESERVED_HEADERS)
+    if conflicts:
+        raise ValueError(f"reserved SDK headers cannot be overridden: {', '.join(conflicts)}")
+    return normalized
+
+
+def _validate_request_id(value: str | None) -> str:
+    request_id = value or uuid4().hex
+    if not _REQUEST_ID.fullmatch(request_id):
+        raise ValueError("request_id must match [A-Za-z0-9_-]{1,64}")
+    return request_id
+
+
+def _auth_headers(
+    token: str | None,
+    auth_channel: AuthChannel,
+    edge_token: str | None,
+) -> dict[str, str]:
+    if auth_channel not in {"authorization", "x-souwen-token"}:
+        raise ValueError("auth_channel must be 'authorization' or 'x-souwen-token'")
+    if token == "" or edge_token == "":
+        raise ValueError("token values cannot be empty")
+    if edge_token is not None and token is not None and auth_channel == "authorization":
+        raise ValueError(
+            "edge_token occupies Authorization; use auth_channel='x-souwen-token' "
+            "for the application token"
+        )
+    headers: dict[str, str] = {}
+    if edge_token is not None:
+        headers["Authorization"] = f"Bearer {edge_token}"
+    if token is not None:
+        name = "Authorization" if auth_channel == "authorization" else "X-SouWen-Token"
+        headers[name] = f"Bearer {token}" if name == "Authorization" else token
+    return headers
+
+
+def _request_headers(
+    base_headers: Mapping[str, str],
+    auth_headers: Mapping[str, str],
+    request_id: str,
+) -> dict[str, str]:
+    return {
+        **base_headers,
+        **auth_headers,
+        "Accept": "application/json",
+        "X-SouWen-API-Major": str(operations.SUPPORTED_API_MAJOR),
+        "X-Request-ID": request_id,
+    }
+
+
+def _verify_contract_headers(response: httpx.Response) -> str:
+    received_major = response.headers.get("X-SouWen-API-Major")
+    if received_major != str(operations.SUPPORTED_API_MAJOR):
+        raise ApiMajorMismatchError(operations.SUPPORTED_API_MAJOR, received_major)
+    rollout = response.headers.get("X-SouWen-Rollout-Mode")
+    if rollout != "target":
+        raise ContractViolationError(
+            f"target SDK received invalid X-SouWen-Rollout-Mode {rollout!r}"
+        )
+    request_id = response.headers.get("X-Request-ID")
+    if request_id is None or not _REQUEST_ID.fullmatch(request_id):
+        raise ContractViolationError("response is missing a valid X-Request-ID")
+    return request_id
+
+
+def _response_json(response: httpx.Response) -> object:
+    try:
+        return response.json()
+    except (ValueError, UnicodeError) as exc:
+        raise ContractViolationError("response body is not canonical JSON") from exc
+
+
+def _check_context(payload: BaseModel, request_id: str) -> None:
+    context = getattr(payload, "context", None)
+    if context is None or getattr(context, "request_id", None) != request_id:
+        raise ContractViolationError("response context does not match X-Request-ID")
+    if getattr(context, "api_major", None) != operations.SUPPORTED_API_MAJOR:
+        raise ContractViolationError("response context carries the wrong API major")
+    if isinstance(payload, ErrorResponse) and payload.error.request_id != request_id:
+        raise ContractViolationError("error request_id does not match X-Request-ID")
+    if isinstance(payload, ProbeResponse) and payload.rollout_mode != "target":
+        raise ContractViolationError("probe payload does not identify target rollout")
+
+
+def _decode_response(
+    response: httpx.Response,
+    model: type[ResponseT],
+    response_statuses: tuple[int, ...],
+) -> ResponseT:
+    request_id = _verify_contract_headers(response)
+    data = _response_json(response)
+    if response.status_code not in response_statuses:
+        try:
+            error = ErrorResponse.model_validate(data)
+        except ValidationError as exc:
+            raise ContractViolationError(
+                "non-success response is not canonical ErrorResponse"
+            ) from exc
+        _check_context(error, request_id)
+        rate_limit = {
+            name: value
+            for name in _RATE_LIMIT_HEADERS
+            if (value := response.headers.get(name)) is not None
+        }
+        raise SouWenAPIError(
+            response.status_code,
+            error,
+            retry_after=response.headers.get("Retry-After"),
+            rate_limit=rate_limit,
+        )
+    try:
+        payload = model.model_validate(data)
+    except ValidationError as exc:
+        raise ContractViolationError(
+            f"success response does not match generated {model.__name__}"
+        ) from exc
+    _check_context(payload, request_id)
+    return payload
+
+
+def _payload_json(payload: BaseModel | None) -> dict | None:
+    return payload.model_dump(mode="json", exclude_none=True) if payload is not None else None
+
+
+class SouWenClient:
+    """Synchronous target REST client generated against API major 2."""
+
+    def __init__(
+        self,
+        base_url: str,
+        token: str | None = None,
+        *,
+        auth_channel: AuthChannel = "authorization",
+        edge_token: str | None = None,
+        timeout: float | httpx.Timeout = DEFAULT_TIMEOUT_SECONDS,
+        headers: Mapping[str, str] | None = None,
+        transport: httpx.BaseTransport | None = None,
+        http_client: httpx.Client | None = None,
+    ) -> None:
+        if transport is not None and http_client is not None:
+            raise ValueError("transport and http_client are mutually exclusive")
+        self._base_url = _normalize_base_url(base_url)
+        self._headers = _validate_headers(headers)
+        self._auth_headers = _auth_headers(token, auth_channel, edge_token)
+        self._owns_client = http_client is None
+        self._client = http_client or httpx.Client(
+            timeout=timeout,
+            transport=transport,
+            follow_redirects=False,
+        )
+        if any(name.lower() in _RESERVED_HEADERS for name in self._client.headers):
+            raise ValueError("injected http_client cannot preconfigure reserved SDK headers")
+        self._compatibility_verified = False
+        self._preflight_lock = threading.Lock()
+
+    def _send(
+        self,
+        operation: operations.Operation,
+        response_model: type[ResponseT],
+        *,
+        payload: BaseModel | None = None,
+        request_id: str | None = None,
+        timeout: TimeoutValue = None,
+    ) -> ResponseT:
+        effective_request_id = _validate_request_id(request_id)
+        request_kwargs: dict[str, object] = {
+            "headers": _request_headers(
+                self._headers,
+                self._auth_headers,
+                effective_request_id,
+            ),
+            "json": _payload_json(payload),
+        }
+        if timeout is not None:
+            request_kwargs["timeout"] = timeout
+        try:
+            response = self._client.request(
+                operation.method,
+                f"{self._base_url}{operation.path}",
+                **request_kwargs,
+            )
+        except httpx.RequestError as exc:
+            raise SouWenTransportError("SouWen HTTP request failed") from exc
+        return _decode_response(response, response_model, operation.response_statuses)
+
+    def preflight(self, *, timeout: TimeoutValue = None) -> ProbeResponse:
+        with self._preflight_lock:
+            if self._compatibility_verified:
+                return self._send(operations.HEALTHZ, ProbeResponse, timeout=timeout)
+            response = self._send(operations.HEALTHZ, ProbeResponse, timeout=timeout)
+            self._compatibility_verified = True
+            return response
+
+    def _ensure_compatible(self, timeout: TimeoutValue) -> None:
+        if not self._compatibility_verified:
+            self.preflight(timeout=timeout)
+
+    def search(
+        self,
+        payload: SearchRequest,
+        *,
+        request_id: str | None = None,
+        timeout: TimeoutValue = None,
+    ) -> SearchPage:
+        self._ensure_compatible(timeout)
+        return self._send(
+            operations.SEARCH,
+            SearchPage,
+            payload=payload,
+            request_id=request_id,
+            timeout=timeout,
+        )
+
+    def llm_search(
+        self,
+        payload: LLMSearchRequest,
+        *,
+        request_id: str | None = None,
+        timeout: TimeoutValue = None,
+    ) -> LLMSearchResult:
+        self._ensure_compatible(timeout)
+        return self._send(
+            operations.LLM_SEARCH,
+            LLMSearchResult,
+            payload=payload,
+            request_id=request_id,
+            timeout=timeout,
+        )
+
+    def fetch(
+        self,
+        payload: FetchRequest,
+        *,
+        request_id: str | None = None,
+        timeout: TimeoutValue = None,
+    ) -> FetchBatch:
+        self._ensure_compatible(timeout)
+        return self._send(
+            operations.FETCH,
+            FetchBatch,
+            payload=payload,
+            request_id=request_id,
+            timeout=timeout,
+        )
+
+    def list_providers(
+        self,
+        *,
+        request_id: str | None = None,
+        timeout: TimeoutValue = None,
+    ) -> ProviderCatalog:
+        self._ensure_compatible(timeout)
+        return self._send(
+            operations.LIST_PROVIDERS,
+            ProviderCatalog,
+            request_id=request_id,
+            timeout=timeout,
+        )
+
+    def health(
+        self, *, request_id: str | None = None, timeout: TimeoutValue = None
+    ) -> ProbeResponse:
+        return self._send(
+            operations.HEALTH_LEGACY_ALIAS,
+            ProbeResponse,
+            request_id=request_id,
+            timeout=timeout,
+        )
+
+    def healthz(
+        self, *, request_id: str | None = None, timeout: TimeoutValue = None
+    ) -> ProbeResponse:
+        response = self._send(
+            operations.HEALTHZ,
+            ProbeResponse,
+            request_id=request_id,
+            timeout=timeout,
+        )
+        self._compatibility_verified = True
+        return response
+
+    def readiness(
+        self,
+        *,
+        request_id: str | None = None,
+        timeout: TimeoutValue = None,
+    ) -> ProbeResponse:
+        return self._send(
+            operations.READINESS_LEGACY_ALIAS,
+            ProbeResponse,
+            request_id=request_id,
+            timeout=timeout,
+        )
+
+    def readyz(
+        self, *, request_id: str | None = None, timeout: TimeoutValue = None
+    ) -> ProbeResponse:
+        return self._send(
+            operations.READYZ,
+            ProbeResponse,
+            request_id=request_id,
+            timeout=timeout,
+        )
+
+    def close(self) -> None:
+        if self._owns_client:
+            self._client.close()
+
+    def __enter__(self) -> SouWenClient:
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        _exc: BaseException | None,
+        _traceback: TracebackType | None,
+    ) -> None:
+        self.close()
+
+
+class AsyncSouWenClient:
+    """Asynchronous target REST client generated against API major 2."""
+
+    def __init__(
+        self,
+        base_url: str,
+        token: str | None = None,
+        *,
+        auth_channel: AuthChannel = "authorization",
+        edge_token: str | None = None,
+        timeout: float | httpx.Timeout = DEFAULT_TIMEOUT_SECONDS,
+        headers: Mapping[str, str] | None = None,
+        transport: httpx.AsyncBaseTransport | None = None,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        if transport is not None and http_client is not None:
+            raise ValueError("transport and http_client are mutually exclusive")
+        self._base_url = _normalize_base_url(base_url)
+        self._headers = _validate_headers(headers)
+        self._auth_headers = _auth_headers(token, auth_channel, edge_token)
+        self._owns_client = http_client is None
+        self._client = http_client or httpx.AsyncClient(
+            timeout=timeout,
+            transport=transport,
+            follow_redirects=False,
+        )
+        if any(name.lower() in _RESERVED_HEADERS for name in self._client.headers):
+            raise ValueError("injected http_client cannot preconfigure reserved SDK headers")
+        self._compatibility_verified = False
+        self._preflight_lock = asyncio.Lock()
+
+    async def _send(
+        self,
+        operation: operations.Operation,
+        response_model: type[ResponseT],
+        *,
+        payload: BaseModel | None = None,
+        request_id: str | None = None,
+        timeout: TimeoutValue = None,
+    ) -> ResponseT:
+        effective_request_id = _validate_request_id(request_id)
+        request_kwargs: dict[str, object] = {
+            "headers": _request_headers(
+                self._headers,
+                self._auth_headers,
+                effective_request_id,
+            ),
+            "json": _payload_json(payload),
+        }
+        if timeout is not None:
+            request_kwargs["timeout"] = timeout
+        try:
+            response = await self._client.request(
+                operation.method,
+                f"{self._base_url}{operation.path}",
+                **request_kwargs,
+            )
+        except httpx.RequestError as exc:
+            raise SouWenTransportError("SouWen HTTP request failed") from exc
+        return _decode_response(response, response_model, operation.response_statuses)
+
+    async def preflight(self, *, timeout: TimeoutValue = None) -> ProbeResponse:
+        async with self._preflight_lock:
+            if self._compatibility_verified:
+                return await self._send(operations.HEALTHZ, ProbeResponse, timeout=timeout)
+            response = await self._send(operations.HEALTHZ, ProbeResponse, timeout=timeout)
+            self._compatibility_verified = True
+            return response
+
+    async def _ensure_compatible(self, timeout: TimeoutValue) -> None:
+        if not self._compatibility_verified:
+            await self.preflight(timeout=timeout)
+
+    async def search(
+        self,
+        payload: SearchRequest,
+        *,
+        request_id: str | None = None,
+        timeout: TimeoutValue = None,
+    ) -> SearchPage:
+        await self._ensure_compatible(timeout)
+        return await self._send(
+            operations.SEARCH,
+            SearchPage,
+            payload=payload,
+            request_id=request_id,
+            timeout=timeout,
+        )
+
+    async def llm_search(
+        self,
+        payload: LLMSearchRequest,
+        *,
+        request_id: str | None = None,
+        timeout: TimeoutValue = None,
+    ) -> LLMSearchResult:
+        await self._ensure_compatible(timeout)
+        return await self._send(
+            operations.LLM_SEARCH,
+            LLMSearchResult,
+            payload=payload,
+            request_id=request_id,
+            timeout=timeout,
+        )
+
+    async def fetch(
+        self,
+        payload: FetchRequest,
+        *,
+        request_id: str | None = None,
+        timeout: TimeoutValue = None,
+    ) -> FetchBatch:
+        await self._ensure_compatible(timeout)
+        return await self._send(
+            operations.FETCH,
+            FetchBatch,
+            payload=payload,
+            request_id=request_id,
+            timeout=timeout,
+        )
+
+    async def list_providers(
+        self,
+        *,
+        request_id: str | None = None,
+        timeout: TimeoutValue = None,
+    ) -> ProviderCatalog:
+        await self._ensure_compatible(timeout)
+        return await self._send(
+            operations.LIST_PROVIDERS,
+            ProviderCatalog,
+            request_id=request_id,
+            timeout=timeout,
+        )
+
+    async def health(
+        self,
+        *,
+        request_id: str | None = None,
+        timeout: TimeoutValue = None,
+    ) -> ProbeResponse:
+        return await self._send(
+            operations.HEALTH_LEGACY_ALIAS,
+            ProbeResponse,
+            request_id=request_id,
+            timeout=timeout,
+        )
+
+    async def healthz(
+        self,
+        *,
+        request_id: str | None = None,
+        timeout: TimeoutValue = None,
+    ) -> ProbeResponse:
+        response = await self._send(
+            operations.HEALTHZ,
+            ProbeResponse,
+            request_id=request_id,
+            timeout=timeout,
+        )
+        self._compatibility_verified = True
+        return response
+
+    async def readiness(
+        self,
+        *,
+        request_id: str | None = None,
+        timeout: TimeoutValue = None,
+    ) -> ProbeResponse:
+        return await self._send(
+            operations.READINESS_LEGACY_ALIAS,
+            ProbeResponse,
+            request_id=request_id,
+            timeout=timeout,
+        )
+
+    async def readyz(
+        self,
+        *,
+        request_id: str | None = None,
+        timeout: TimeoutValue = None,
+    ) -> ProbeResponse:
+        return await self._send(
+            operations.READYZ,
+            ProbeResponse,
+            request_id=request_id,
+            timeout=timeout,
+        )
+
+    async def aclose(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def __aenter__(self) -> AsyncSouWenClient:
+        return self
+
+    async def __aexit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        _exc: BaseException | None,
+        _traceback: TracebackType | None,
+    ) -> None:
+        await self.aclose()
+
+
+__all__ = ["AsyncSouWenClient", "SouWenClient"]

--- a/src/souwen/delivery/client_sdk/errors.py
+++ b/src/souwen/delivery/client_sdk/errors.py
@@ -1,0 +1,58 @@
+"""Stable public errors for the generated target REST SDK."""
+
+from __future__ import annotations
+
+from ._generated_models import ErrorResponse
+
+
+class SouWenSDKError(Exception):
+    """Base class for SDK-owned failures."""
+
+
+class ApiMajorMismatchError(SouWenSDKError):
+    """The server did not prove support for the SDK wire major."""
+
+    def __init__(self, expected: int, received: str | None) -> None:
+        self.expected = expected
+        self.received = received
+        super().__init__(f"SouWen API major mismatch: expected {expected}, received {received!r}")
+
+
+class ContractViolationError(SouWenSDKError):
+    """The response violated the frozen target contract."""
+
+
+class SouWenTransportError(SouWenSDKError):
+    """The HTTP exchange failed before a canonical response was available."""
+
+
+class SouWenAPIError(SouWenSDKError):
+    """A canonical non-success response from the target API."""
+
+    def __init__(
+        self,
+        status_code: int,
+        payload: ErrorResponse,
+        *,
+        retry_after: str | None = None,
+        rate_limit: dict[str, str] | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self.payload = payload
+        self.request_id = payload.context.request_id
+        self.retry_after = retry_after
+        self.rate_limit = dict(rate_limit or {})
+        detail = payload.error
+        super().__init__(
+            f"SouWen API error {status_code} {detail.code}: {detail.message} "
+            f"(request_id={self.request_id})"
+        )
+
+
+__all__ = [
+    "ApiMajorMismatchError",
+    "ContractViolationError",
+    "SouWenAPIError",
+    "SouWenSDKError",
+    "SouWenTransportError",
+]

--- a/tests/test_ci_profile_runner.py
+++ b/tests/test_ci_profile_runner.py
@@ -195,6 +195,15 @@ def test_sdk_contract_uses_target_contract_dto_and_openapi_artifact_checks() -> 
         "--semantic-check",
         "contracts/openapi/souwen-openapi-2.0.0rc2.json",
     )
+    assert commands[3].name == "python_sdk_reproducibility"
+    assert commands[3].command == (
+        run_profile.PYTHON,
+        "tools/gen_client_sdk.py",
+        "--check",
+    )
+    assert commands[4].name == "python_sdk_contract"
+    assert "tests/test_client_sdk_generator.py" in commands[4].command
+    assert "tests/test_client_sdk_contract.py" in commands[4].command
 
 
 def test_v2_ci_checks_reproducibility_and_pr_semantic_openapi_compatibility() -> None:

--- a/tests/test_client_sdk_contract.py
+++ b/tests/test_client_sdk_contract.py
@@ -1,0 +1,414 @@
+"""Sync/async conformance for the generated target REST SDK."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+from pydantic import ValidationError
+
+from souwen.delivery.client_sdk import (
+    ApiMajorMismatchError,
+    AsyncSouWenClient,
+    ContractViolationError,
+    FetchRequest,
+    LLMSearchRequest,
+    ProviderRef,
+    SearchPage,
+    SearchRequest,
+    SouWenAPIError,
+    SouWenClient,
+    SouWenTransportError,
+)
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _headers(request_id: str, *, major: str = "2", rollout: str = "target") -> dict[str, str]:
+    return {
+        "X-SouWen-API-Major": major,
+        "X-SouWen-Rollout-Mode": rollout,
+        "X-Request-ID": request_id,
+    }
+
+
+def _context(request: httpx.Request) -> dict[str, object]:
+    return {
+        "request_id": request.headers["X-Request-ID"],
+        "api_major": 2,
+        "trace_id": None,
+    }
+
+
+def _probe(request: httpx.Request, *, ready: bool = True) -> httpx.Response:
+    request_id = request.headers["X-Request-ID"]
+    path = request.url.path.removeprefix("/root")
+    return httpx.Response(
+        200 if ready else 503,
+        headers=_headers(request_id),
+        json={
+            "status": (
+                "ok" if path in {"/health", "/healthz"} else ("ready" if ready else "not_ready")
+            ),
+            "ready": ready,
+            "version": "2.0.0rc2",
+            "rollout_mode": "target",
+            "components": {"api": "ready"},
+            "context": _context(request),
+        },
+    )
+
+
+def _success(request: httpx.Request) -> httpx.Response:
+    path = request.url.path.removeprefix("/root")
+    if path in {"/health", "/healthz", "/readiness", "/readyz"}:
+        return _probe(request)
+    payloads = {
+        "/api/v1/search": {
+            "items": [],
+            "page": {"limit": 10},
+            "meta": {},
+            "context": _context(request),
+        },
+        "/api/v1/llm-search": {
+            "query": "fixture",
+            "items": [],
+            "evidence": [],
+            "meta": {},
+            "usage": {},
+            "context": _context(request),
+        },
+        "/api/v1/fetch": {
+            "items": [],
+            "meta": {},
+            "context": _context(request),
+        },
+        "/api/v1/providers": {
+            "items": [],
+            "context": _context(request),
+        },
+    }
+    return httpx.Response(
+        200,
+        headers=_headers(request.headers["X-Request-ID"]),
+        json=payloads[path],
+    )
+
+
+def test_sync_client_covers_all_generated_operations_and_payloads() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return _success(request)
+
+    client = SouWenClient(
+        "https://example.test/root/",
+        token="application-fixture",
+        transport=httpx.MockTransport(handler),
+    )
+
+    assert client.health(request_id="health-id").status == "ok"
+    assert client.healthz(request_id="healthz-id").status == "ok"
+    assert client.readiness(request_id="readiness-id").ready is True
+    assert client.readyz(request_id="readyz-id").ready is True
+    assert (
+        client.search(
+            SearchRequest(query="fixture", domains=["paper"]), request_id="search-id"
+        ).page.limit
+        == 10
+    )
+    assert (
+        client.llm_search(
+            LLMSearchRequest(
+                query="fixture",
+                providers=[ProviderRef(id="llm", kind="llm_search")],
+                strategy="single",
+            ),
+            request_id="llm-id",
+        ).query
+        == "fixture"
+    )
+    assert (
+        client.fetch(FetchRequest(targets=["https://example.com"]), request_id="fetch-id").items
+        == []
+    )
+    assert client.list_providers(request_id="providers-id").items == []
+
+    assert [(request.method, request.url.path) for request in requests] == [
+        ("GET", "/root/health"),
+        ("GET", "/root/healthz"),
+        ("GET", "/root/readiness"),
+        ("GET", "/root/readyz"),
+        ("POST", "/root/api/v1/search"),
+        ("POST", "/root/api/v1/llm-search"),
+        ("POST", "/root/api/v1/fetch"),
+        ("GET", "/root/api/v1/providers"),
+    ]
+    assert requests[4].headers["Authorization"] == "Bearer application-fixture"
+    assert requests[4].headers["X-SouWen-API-Major"] == "2"
+    assert json.loads(requests[4].content) == {"domains": ["paper"], "query": "fixture"}
+    client.close()
+
+
+def test_first_business_request_preflights_before_sending_body() -> None:
+    paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        paths.append(request.url.path)
+        return httpx.Response(
+            200,
+            headers=_headers(request.headers["X-Request-ID"], major="3"),
+            content=b"not-json",
+        )
+
+    client = SouWenClient("https://example.test", transport=httpx.MockTransport(handler))
+
+    with pytest.raises(ApiMajorMismatchError) as exc_info:
+        client.search(SearchRequest(query="fixture", domains=["paper"]))
+
+    assert exc_info.value.expected == 2
+    assert exc_info.value.received == "3"
+    assert paths == ["/healthz"]
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected"),
+    [
+        ({"token": "app"}, ("Bearer app", None)),
+        (
+            {"token": "app", "auth_channel": "x-souwen-token"},
+            (None, "app"),
+        ),
+        (
+            {"token": "app", "auth_channel": "x-souwen-token", "edge_token": "edge"},
+            ("Bearer edge", "app"),
+        ),
+    ],
+)
+def test_auth_channels_are_explicit_and_never_fallback(kwargs, expected) -> None:
+    observed: list[tuple[str | None, str | None]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        observed.append(
+            (
+                request.headers.get("Authorization"),
+                request.headers.get("X-SouWen-Token"),
+            )
+        )
+        return _probe(request)
+
+    client = SouWenClient(
+        "https://example.test",
+        transport=httpx.MockTransport(handler),
+        **kwargs,
+    )
+    client.healthz()
+
+    assert observed == [expected]
+
+
+def test_auth_and_reserved_header_conflicts_fail_before_network() -> None:
+    with pytest.raises(ValueError, match="edge_token occupies Authorization"):
+        SouWenClient("https://example.test", token="app", edge_token="edge")
+    with pytest.raises(ValueError, match="reserved SDK headers"):
+        SouWenClient(
+            "https://example.test",
+            headers={"Authorization": "Bearer hidden"},
+        )
+
+
+def test_canonical_api_error_preserves_safe_rate_limit_metadata_without_retry() -> None:
+    paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        paths.append(request.url.path)
+        if request.url.path == "/healthz":
+            return _probe(request)
+        request_id = request.headers["X-Request-ID"]
+        return httpx.Response(
+            429,
+            headers={
+                **_headers(request_id),
+                "Retry-After": "5",
+                "X-RateLimit-Limit": "10",
+                "X-RateLimit-Remaining": "0",
+                "X-RateLimit-Reset": "123",
+            },
+            json={
+                "error": {
+                    "code": "rate_limited",
+                    "message": "rate limited",
+                    "retryable": True,
+                    "request_id": request_id,
+                },
+                "context": _context(request),
+            },
+        )
+
+    client = SouWenClient("https://example.test", transport=httpx.MockTransport(handler))
+
+    with pytest.raises(SouWenAPIError) as exc_info:
+        client.search(SearchRequest(query="fixture", domains=["paper"]))
+
+    error = exc_info.value
+    assert error.status_code == 429
+    assert error.payload.error.code == "rate_limited"
+    assert error.retry_after == "5"
+    assert error.rate_limit == {
+        "X-RateLimit-Limit": "10",
+        "X-RateLimit-Remaining": "0",
+        "X-RateLimit-Reset": "123",
+    }
+    assert paths == ["/healthz", "/api/v1/search"]
+
+
+def test_response_correlation_and_rollout_are_fail_closed() -> None:
+    def wrong_context(request: httpx.Request) -> httpx.Response:
+        response = _probe(request)
+        data = response.json()
+        data["context"]["request_id"] = "different"
+        return httpx.Response(response.status_code, headers=response.headers, json=data)
+
+    with pytest.raises(ContractViolationError, match="context"):
+        SouWenClient(
+            "https://example.test",
+            transport=httpx.MockTransport(wrong_context),
+        ).healthz()
+
+    def legacy_rollout(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers=_headers(request.headers["X-Request-ID"], rollout="legacy"),
+            json={},
+        )
+
+    with pytest.raises(ContractViolationError, match="Rollout-Mode"):
+        SouWenClient(
+            "https://example.test",
+            transport=httpx.MockTransport(legacy_rollout),
+        ).healthz()
+
+
+def test_readiness_503_uses_its_generated_probe_response_model() -> None:
+    client = SouWenClient(
+        "https://example.test",
+        transport=httpx.MockTransport(lambda request: _probe(request, ready=False)),
+    )
+
+    response = client.readyz()
+
+    assert response.ready is False
+    assert response.status == "not_ready"
+
+
+def test_transport_error_and_client_ownership_are_explicit() -> None:
+    def disconnected(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("offline", request=request)
+
+    owned = SouWenClient(
+        "https://example.test",
+        transport=httpx.MockTransport(disconnected),
+    )
+    with pytest.raises(SouWenTransportError):
+        owned.healthz()
+    owned.close()
+    assert owned._client.is_closed is True
+
+    injected = httpx.Client(transport=httpx.MockTransport(_success))
+    borrowed = SouWenClient("https://example.test", http_client=injected)
+    borrowed.close()
+    assert injected.is_closed is False
+    injected.close()
+
+
+def test_default_timeout_covers_server_budget_and_allows_explicit_override() -> None:
+    observed: list[dict[str, float]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        observed.append(request.extensions["timeout"])
+        return _probe(request)
+
+    client = SouWenClient(
+        "https://example.test",
+        transport=httpx.MockTransport(handler),
+    )
+
+    client.healthz()
+    client.healthz(timeout=7)
+
+    assert observed[0] == {"connect": 125.0, "read": 125.0, "write": 125.0, "pool": 125.0}
+    assert observed[1] == {"connect": 7, "read": 7, "write": 7, "pool": 7}
+
+
+@pytest.mark.asyncio
+async def test_async_client_preflights_and_does_not_close_injected_client() -> None:
+    paths: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        paths.append(request.url.path)
+        return _success(request)
+
+    injected = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    client = AsyncSouWenClient("https://example.test", http_client=injected)
+
+    page = await client.search(SearchRequest(query="fixture", domains=["paper"]))
+
+    assert page.page.limit == 10
+    assert paths == ["/healthz", "/api/v1/search"]
+    await client.aclose()
+    assert injected.is_closed is False
+    await injected.aclose()
+
+
+def test_generated_models_validate_goldens_and_forbid_unknown_fields() -> None:
+    goldens = json.loads(
+        (REPOSITORY_ROOT / "tests/contracts/fixtures/target_api_contract_v2.json").read_text(
+            encoding="utf-8"
+        )
+    )["goldens"]
+
+    assert SearchPage.model_validate(goldens["search_partial_success"]).meta.partial is True
+    with pytest.raises(ValidationError):
+        SearchRequest(query="fixture", domains=["paper"], unknown="value")
+
+
+def test_sdk_import_does_not_load_server_or_fastapi(tmp_path: Path) -> None:
+    script = """
+import json
+import sys
+from souwen.delivery.client_sdk import AsyncSouWenClient, SouWenClient
+print(json.dumps({
+    'sync': SouWenClient.__name__,
+    'async': AsyncSouWenClient.__name__,
+    'fastapi': 'fastapi' in sys.modules,
+    'server': 'souwen.server.app' in sys.modules,
+}))
+"""
+    env = {
+        **os.environ,
+        "HOME": str(tmp_path),
+        "USERPROFILE": str(tmp_path),
+        "PYTHONPATH": str(REPOSITORY_ROOT / "src"),
+    }
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert json.loads(completed.stdout) == {
+        "sync": "SouWenClient",
+        "async": "AsyncSouWenClient",
+        "fastapi": False,
+        "server": False,
+    }

--- a/tests/test_client_sdk_generator.py
+++ b/tests/test_client_sdk_generator.py
@@ -1,0 +1,139 @@
+"""Deterministic Python SDK generation from the frozen OpenAPI artifact."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+
+from souwen.delivery.client_sdk import OPENAPI_SHA256, SDK_VERSION, SUPPORTED_API_MAJOR
+from souwen.delivery.client_sdk import _generated_models as models
+from souwen.delivery.client_sdk._generated_operations import OPERATIONS
+from tools import gen_client_sdk
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+ARTIFACT = REPOSITORY_ROOT / "contracts/openapi/souwen-openapi-2.0.0rc2.json"
+GENERATED_ROOT = REPOSITORY_ROOT / "src/souwen/delivery/client_sdk"
+
+
+def test_generated_sdk_files_are_current_and_record_exact_artifact() -> None:
+    artifact_payload = ARTIFACT.read_bytes()
+    document = json.loads(artifact_payload)
+
+    assert gen_client_sdk.main(["--check"]) == 0
+    assert OPENAPI_SHA256 == hashlib.sha256(artifact_payload).hexdigest()
+    assert SDK_VERSION == document["info"]["version"] == "2.0.0rc2"
+    assert SUPPORTED_API_MAJOR == document["x-souwen-api-major"] == 2
+    assert set(models.__all__) == set(document["components"]["schemas"])
+    assert set(OPERATIONS) == {
+        operation["operationId"]
+        for path_item in document["paths"].values()
+        for method, operation in path_item.items()
+        if method in gen_client_sdk.HTTP_METHODS
+    }
+    assert OPERATIONS["readyz"].response_statuses == (200, 503)
+    assert OPERATIONS["readinessLegacyAlias"].response_statuses == (200, 503)
+
+
+def test_generator_reproduces_tracked_bindings_in_a_fresh_directory(tmp_path: Path) -> None:
+    output = tmp_path / "sdk"
+
+    assert gen_client_sdk.main(["--write", "--output", str(output)]) == 0
+    assert gen_client_sdk.main(["--check", "--output", str(output)]) == 0
+
+    for name in ("_generated_models.py", "_generated_operations.py"):
+        assert (output / name).read_bytes() == (GENERATED_ROOT / name).read_bytes()
+
+
+def test_generator_fails_closed_for_unapproved_operations(tmp_path: Path) -> None:
+    document = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+    document["paths"]["/api/v1/legacy"] = {
+        "get": {
+            "operationId": "legacy",
+            "security": [{"UserToken": []}],
+            "responses": {
+                "200": {
+                    "description": "legacy",
+                    "headers": {
+                        name: {"$ref": f"#/components/headers/{name}"}
+                        for name in (
+                            "X-SouWen-API-Major",
+                            "X-Request-ID",
+                            "X-SouWen-Rollout-Mode",
+                        )
+                    },
+                    "content": {
+                        "application/json": {
+                            "schema": {"$ref": "#/components/schemas/ProbeResponse"}
+                        }
+                    },
+                }
+            },
+        }
+    }
+    artifact = tmp_path / "invalid.json"
+    artifact.write_text(json.dumps(document), encoding="utf-8")
+
+    assert (
+        gen_client_sdk.main(
+            [
+                "--write",
+                "--artifact",
+                str(artifact),
+                "--output",
+                str(tmp_path / "output"),
+            ]
+        )
+        == 2
+    )
+    assert not (tmp_path / "output").exists()
+
+
+def test_generator_fails_closed_for_duplicate_operation_id(tmp_path: Path) -> None:
+    document = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+    duplicate = copy.deepcopy(document["paths"]["/api/v1/search"]["post"])
+    document["paths"] = {
+        "/api/v1/unexpected": {"get": duplicate},
+        **document["paths"],
+    }
+    artifact = tmp_path / "invalid.json"
+    artifact.write_text(json.dumps(document), encoding="utf-8")
+
+    assert (
+        gen_client_sdk.main(
+            [
+                "--write",
+                "--artifact",
+                str(artifact),
+                "--output",
+                str(tmp_path / "output"),
+            ]
+        )
+        == 2
+    )
+    assert not (tmp_path / "output").exists()
+
+
+def test_generator_fails_closed_for_unsupported_schema_shape(tmp_path: Path) -> None:
+    document = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+    document["components"]["schemas"]["SearchRequest"]["properties"]["query"] = {
+        "oneOf": [{"type": "string"}, {"type": "integer"}]
+    }
+    artifact = tmp_path / "invalid.json"
+    artifact.write_text(json.dumps(document), encoding="utf-8")
+
+    assert (
+        gen_client_sdk.main(
+            [
+                "--write",
+                "--artifact",
+                str(artifact),
+                "--output",
+                str(tmp_path / "output"),
+            ]
+        )
+        == 2
+    )
+    assert not (tmp_path / "output").exists()

--- a/tests/test_import_surface.py
+++ b/tests/test_import_surface.py
@@ -18,6 +18,7 @@ def test_new_public_import_surface():
     from souwen.search import search, search_all, search_by_capability, search_domain
     from souwen.web.fetch import fetch_content
     from souwen.web.wayback import WaybackClient
+    from souwen import AsyncSouWenClient, SouWenClient
 
     assert callable(search)
     assert callable(search_all)
@@ -29,6 +30,8 @@ def test_new_public_import_surface():
     assert BaseScraper.__name__ == "BaseScraper"
     assert WaybackClient.__name__ == "WaybackClient"
     assert LocalCatalog.__name__ == "LocalCatalog"
+    assert SouWenClient.__name__ == "SouWenClient"
+    assert AsyncSouWenClient.__name__ == "AsyncSouWenClient"
 
 
 def test_import_registry_does_not_scan_entry_points():

--- a/tests/test_phase2_module_skeleton.py
+++ b/tests/test_phase2_module_skeleton.py
@@ -55,6 +55,7 @@ SKELETON_PACKAGES = (
 IMPLEMENTED_PACKAGES = frozenset(
     {
         "souwen.delivery.api",
+        "souwen.delivery.client_sdk",
         "souwen.modules.search.api",
         "souwen.modules.search.application",
         "souwen.modules.llm_search.api",

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -1081,6 +1081,10 @@ def test_clean_wheel_composite_enforces_runtime_and_package_boundaries() -> None
     for contract in (
         "package/panel",
         "package/no-retired-imports",
+        "sdk/sync-client",
+        "sdk/async-client",
+        "sdk/api-major",
+        "sdk/openapi-sha256",
         "sdk/no-fastapi",
         "server/import",
         "server/import-{module}",
@@ -1090,3 +1094,5 @@ def test_clean_wheel_composite_enforces_runtime_and_package_boundaries() -> None
         assert contract in text
     assert "souwen.editions" not in text
     assert "CLEAN_WHEEL_PROFILE" in text
+    assert "from souwen import AsyncSouWenClient, SouWenClient" in text
+    assert "from souwen.delivery.client_sdk import OPENAPI_SHA256, SUPPORTED_API_MAJOR" in text

--- a/tools/gen_client_sdk.py
+++ b/tools/gen_client_sdk.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+"""Generate the dependency-light Python SDK bindings from canonical OpenAPI."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_ARTIFACT = REPOSITORY_ROOT / "contracts/openapi/souwen-openapi-2.0.0rc2.json"
+DEFAULT_OUTPUT = REPOSITORY_ROOT / "src/souwen/delivery/client_sdk"
+GENERATOR_VERSION = 1
+EXPECTED_VERSION = "2.0.0rc2"
+EXPECTED_API_MAJOR = 2
+EXPECTED_OPERATIONS = {
+    "fetch": ("POST", "/api/v1/fetch", "FetchRequest", "FetchBatch", (200,)),
+    "llmSearch": (
+        "POST",
+        "/api/v1/llm-search",
+        "LLMSearchRequest",
+        "LLMSearchResult",
+        (200,),
+    ),
+    "listProviders": ("GET", "/api/v1/providers", None, "ProviderCatalog", (200,)),
+    "search": ("POST", "/api/v1/search", "SearchRequest", "SearchPage", (200,)),
+    "healthLegacyAlias": ("GET", "/health", None, "ProbeResponse", (200,)),
+    "healthz": ("GET", "/healthz", None, "ProbeResponse", (200,)),
+    "readinessLegacyAlias": ("GET", "/readiness", None, "ProbeResponse", (200, 503)),
+    "readyz": ("GET", "/readyz", None, "ProbeResponse", (200, 503)),
+}
+HTTP_METHODS = {"delete", "get", "head", "options", "patch", "post", "put", "trace"}
+
+
+class GenerationError(ValueError):
+    """The canonical artifact cannot be mapped without widening its contract."""
+
+
+def _load_document(path: Path) -> tuple[dict[str, Any], bytes]:
+    try:
+        payload = path.read_bytes()
+        document = json.loads(payload)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise GenerationError(f"cannot read canonical OpenAPI artifact {path}: {exc}") from exc
+    if not isinstance(document, dict):
+        raise GenerationError("canonical OpenAPI root must be an object")
+    return document, payload
+
+
+def _ref_name(schema: dict[str, Any] | None) -> str | None:
+    if not schema:
+        return None
+    ref = schema.get("$ref")
+    prefix = "#/components/schemas/"
+    if not isinstance(ref, str) or not ref.startswith(prefix):
+        raise GenerationError(f"operation schema must use a component ref: {schema!r}")
+    return ref.removeprefix(prefix)
+
+
+def _validate_document(document: dict[str, Any]) -> None:
+    if document.get("info", {}).get("version") != EXPECTED_VERSION:
+        raise GenerationError(f"SDK requires OpenAPI version {EXPECTED_VERSION}")
+    if document.get("x-souwen-api-major") != EXPECTED_API_MAJOR:
+        raise GenerationError(f"SDK requires API major {EXPECTED_API_MAJOR}")
+    if document.get("x-souwen-rollout-mode") != "target":
+        raise GenerationError("SDK can only be generated from target rollout OpenAPI")
+    security = document.get("components", {}).get("securitySchemes", {}).get("UserToken")
+    if security != {"type": "http", "scheme": "bearer"}:
+        raise GenerationError("UserToken must remain an HTTP bearer security scheme")
+
+    observed: dict[str, tuple[str, str, str | None, str, tuple[int, ...]]] = {}
+    observed_signatures: set[tuple[str, str, str]] = set()
+    for path, path_item in document.get("paths", {}).items():
+        if not isinstance(path_item, dict):
+            raise GenerationError(f"invalid path item: {path}")
+        for method, operation in path_item.items():
+            if method not in HTTP_METHODS:
+                continue
+            if not isinstance(operation, dict) or not isinstance(operation.get("operationId"), str):
+                raise GenerationError(f"operationId is required for {method.upper()} {path}")
+            request_schema = (
+                operation.get("requestBody", {})
+                .get("content", {})
+                .get("application/json", {})
+                .get("schema")
+            )
+            responses = operation.get("responses", {})
+            response_schema = (
+                responses.get("200", {})
+                .get("content", {})
+                .get("application/json", {})
+                .get("schema")
+            )
+            operation_id = operation["operationId"]
+            if operation_id in observed:
+                raise GenerationError(f"duplicate operationId: {operation_id}")
+            observed_signatures.add((method.upper(), path, operation_id))
+            response_model = _ref_name(response_schema)
+            model_statuses: list[int] = []
+            for status, response in responses.items():
+                try:
+                    status_code = int(status)
+                except (TypeError, ValueError) as exc:
+                    raise GenerationError(
+                        f"operation {operation_id} uses non-numeric response status {status!r}"
+                    ) from exc
+                schema = response.get("content", {}).get("application/json", {}).get("schema")
+                model = _ref_name(schema)
+                if model == response_model:
+                    model_statuses.append(status_code)
+                elif model != "ErrorResponse":
+                    raise GenerationError(
+                        f"unsupported response model {model!r} for {operation_id} status {status}"
+                    )
+            observed[operation_id] = (
+                method.upper(),
+                path,
+                _ref_name(request_schema),
+                response_model,
+                tuple(sorted(model_statuses)),
+            )
+            expected_security = [{"UserToken": []}] if path.startswith("/api/v1/") else []
+            if operation.get("security") != expected_security:
+                raise GenerationError(f"unexpected security contract for {operation_id}")
+            for response in operation.get("responses", {}).values():
+                headers = response.get("headers", {}) if isinstance(response, dict) else {}
+                if not {
+                    "X-SouWen-API-Major",
+                    "X-Request-ID",
+                    "X-SouWen-Rollout-Mode",
+                } <= set(headers):
+                    raise GenerationError(f"missing canonical response headers for {operation_id}")
+    if observed != EXPECTED_OPERATIONS:
+        raise GenerationError(f"unexpected target operation set: {sorted(observed)}")
+    expected_signatures = {
+        (method, path, operation_id)
+        for operation_id, (method, path, *_models) in EXPECTED_OPERATIONS.items()
+    }
+    if observed_signatures != expected_signatures:
+        raise GenerationError(
+            f"unexpected target operation signatures: {sorted(observed_signatures)}"
+        )
+
+
+def _literal(values: list[Any]) -> str:
+    return f"Literal[{', '.join(repr(value) for value in values)}]"
+
+
+def _annotation(schema: dict[str, Any]) -> str:
+    if "$ref" in schema:
+        name = _ref_name(schema)
+        if name is None:
+            raise GenerationError(f"invalid schema ref: {schema!r}")
+        return name
+    if "anyOf" in schema:
+        variants = schema["anyOf"]
+        if not isinstance(variants, list) or not variants:
+            raise GenerationError(f"invalid anyOf: {schema!r}")
+        annotations = [_annotation(variant) for variant in variants]
+        return " | ".join(dict.fromkeys(annotations))
+    if "enum" in schema:
+        values = schema["enum"]
+        if not isinstance(values, list) or not values:
+            raise GenerationError(f"invalid enum: {schema!r}")
+        return _literal(values)
+    if "const" in schema:
+        return _literal([schema["const"]])
+
+    schema_type = schema.get("type")
+    if schema_type == "null":
+        return "None"
+    if schema_type == "string":
+        if schema.get("format") == "date-time":
+            return "datetime"
+        if schema.get("format") == "uri":
+            return "AnyUrl"
+        if schema.get("format") not in {None, "date-time", "uri"}:
+            raise GenerationError(f"unsupported string format: {schema.get('format')}")
+        return "str"
+    if schema_type == "integer":
+        return "int"
+    if schema_type == "number":
+        return "float"
+    if schema_type == "boolean":
+        return "bool"
+    if schema_type == "array":
+        items = schema.get("items")
+        if not isinstance(items, dict):
+            raise GenerationError(f"array items are required: {schema!r}")
+        return f"list[{_annotation(items)}]"
+    if schema_type == "object":
+        additional = schema.get("additionalProperties")
+        if isinstance(additional, dict):
+            return f"dict[str, {_annotation(additional)}]"
+        if not schema.get("properties"):
+            return "dict[str, Any]"
+        raise GenerationError("inline object models are not supported")
+    if schema_type is None and set(schema) <= {"title"}:
+        return "Any"
+    raise GenerationError(f"unsupported schema shape: {schema!r}")
+
+
+def _value_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    variants = schema.get("anyOf")
+    if not isinstance(variants, list):
+        return schema
+    non_null = [variant for variant in variants if variant.get("type") != "null"]
+    return non_null[0] if len(non_null) == 1 else schema
+
+
+def _field_arguments(schema: dict[str, Any]) -> list[str]:
+    value_schema = _value_schema(schema)
+    mapping = (
+        ("minLength", "min_length"),
+        ("maxLength", "max_length"),
+        ("minItems", "min_length"),
+        ("maxItems", "max_length"),
+        ("minimum", "ge"),
+        ("maximum", "le"),
+        ("exclusiveMinimum", "gt"),
+        ("exclusiveMaximum", "lt"),
+        ("pattern", "pattern"),
+    )
+    arguments = [
+        f"{target}={value_schema[source]!r}" for source, target in mapping if source in value_schema
+    ]
+    if isinstance(schema.get("description"), str):
+        arguments.append(f"description={schema['description']!r}")
+    return arguments
+
+
+def _field_line(name: str, schema: dict[str, Any], required: bool) -> str:
+    annotation = _annotation(schema)
+    arguments = _field_arguments(schema)
+    if "default" in schema:
+        default = schema["default"]
+        if default == []:
+            default_expr = "Field(default_factory=list"
+            return f"    {name}: {annotation} = {default_expr}{', ' if arguments else ''}{', '.join(arguments)})"
+        if default == {}:
+            default_expr = "Field(default_factory=dict"
+            return f"    {name}: {annotation} = {default_expr}{', ' if arguments else ''}{', '.join(arguments)})"
+        if arguments:
+            return f"    {name}: {annotation} = Field(default={default!r}, {', '.join(arguments)})"
+        return f"    {name}: {annotation} = {default!r}"
+    if required:
+        if arguments:
+            return f"    {name}: {annotation} = Field({', '.join(arguments)})"
+        return f"    {name}: {annotation}"
+    if "None" not in annotation.split(" | "):
+        annotation = f"{annotation} | None"
+    if arguments:
+        return f"    {name}: {annotation} = Field(default=None, {', '.join(arguments)})"
+    return f"    {name}: {annotation} = None"
+
+
+def _generated_header(artifact_sha: str) -> list[str]:
+    return [
+        '"""Generated from contracts/openapi/souwen-openapi-2.0.0rc2.json; do not edit."""',
+        "",
+        f"# generator_version={GENERATOR_VERSION}",
+        f"# openapi_sha256={artifact_sha}",
+        "",
+    ]
+
+
+def _render_models(document: dict[str, Any], artifact_sha: str) -> str:
+    schemas = document.get("components", {}).get("schemas", {})
+    if not isinstance(schemas, dict) or not schemas:
+        raise GenerationError("OpenAPI components.schemas must be a non-empty object")
+    lines = _generated_header(artifact_sha)
+    lines.extend(
+        [
+            "from __future__ import annotations",
+            "",
+            "from datetime import datetime",
+            "from typing import Any, Literal",
+            "",
+            "from pydantic import AnyUrl, BaseModel, ConfigDict, Field",
+            "",
+            "",
+            "class _StrictModel(BaseModel):",
+            '    model_config = ConfigDict(extra="forbid", frozen=True, hide_input_in_errors=True)',
+            "",
+            "",
+            "class _OpenModel(BaseModel):",
+            '    model_config = ConfigDict(extra="allow", frozen=True, hide_input_in_errors=True)',
+            "",
+        ]
+    )
+    model_names: list[str] = []
+    alias_names: list[str] = []
+    for name, schema in schemas.items():
+        if not isinstance(schema, dict):
+            raise GenerationError(f"schema {name} must be an object")
+        if schema.get("type") != "object":
+            lines.extend(["", f"{name} = {_annotation(schema)}"])
+            alias_names.append(name)
+            continue
+        base = "_StrictModel" if schema.get("additionalProperties") is False else "_OpenModel"
+        lines.extend(["", "", f"class {name}({base}):"])
+        description = schema.get("description")
+        if isinstance(description, str):
+            lines.append(f"    {description!r}")
+        properties = schema.get("properties", {})
+        required = set(schema.get("required", []))
+        if not isinstance(properties, dict):
+            raise GenerationError(f"schema {name}.properties must be an object")
+        if not properties:
+            lines.append("    pass")
+        for field_name, field_schema in properties.items():
+            if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", field_name):
+                raise GenerationError(f"unsupported Python field name: {name}.{field_name}")
+            if not isinstance(field_schema, dict):
+                raise GenerationError(f"field schema must be an object: {name}.{field_name}")
+            lines.append(_field_line(field_name, field_schema, field_name in required))
+        model_names.append(name)
+    lines.extend(["", ""])
+    for name in model_names:
+        lines.append(f"{name}.model_rebuild()")
+    exported = sorted([*model_names, *alias_names])
+    lines.extend(["", "", f"__all__ = {exported!r}", ""])
+    return "\n".join(lines)
+
+
+def _constant_name(operation_id: str) -> str:
+    return re.sub(r"(?<!^)(?=[A-Z])", "_", operation_id).upper()
+
+
+def _render_operations(document: dict[str, Any], artifact_sha: str) -> str:
+    lines = _generated_header(artifact_sha)
+    lines.extend(
+        [
+            "from __future__ import annotations",
+            "",
+            "from typing import NamedTuple",
+            "",
+            f'SDK_VERSION = "{document["info"]["version"]}"',
+            f"SUPPORTED_API_MAJOR = {document['x-souwen-api-major']}",
+            f'OPENAPI_SHA256 = "{artifact_sha}"',
+            "",
+            "",
+            "class Operation(NamedTuple):",
+            "    method: str",
+            "    path: str",
+            "    request_model: str | None",
+            "    response_model: str",
+            "    response_statuses: tuple[int, ...]",
+            "",
+        ]
+    )
+    constants: list[str] = []
+    for operation_id, value in EXPECTED_OPERATIONS.items():
+        constant = _constant_name(operation_id)
+        constants.append(constant)
+        lines.append(f"{constant} = Operation{value!r}")
+    lines.extend(
+        [
+            "",
+            "OPERATIONS = {",
+            *[
+                f'    "{operation_id}": {_constant_name(operation_id)},'
+                for operation_id in EXPECTED_OPERATIONS
+            ],
+            "}",
+            "",
+            "",
+            f"__all__ = {sorted([*constants, 'OPENAPI_SHA256', 'OPERATIONS', 'Operation', 'SDK_VERSION', 'SUPPORTED_API_MAJOR'])!r}",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _rendered_files(document: dict[str, Any], artifact_payload: bytes) -> dict[str, bytes]:
+    artifact_sha = hashlib.sha256(artifact_payload).hexdigest()
+    rendered = {
+        "_generated_models.py": _render_models(document, artifact_sha),
+        "_generated_operations.py": _render_operations(document, artifact_sha),
+    }
+    formatted: dict[str, bytes] = {}
+    for name, source in rendered.items():
+        try:
+            result = subprocess.run(
+                [sys.executable, "-m", "ruff", "format", "--stdin-filename", name, "-"],
+                input=source,
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+        except OSError as exc:
+            raise GenerationError(f"cannot run pinned Ruff formatter: {exc}") from exc
+        if result.returncode != 0:
+            raise GenerationError(
+                f"cannot format generated binding {name}: {result.stderr.strip()}"
+            )
+        formatted[name] = result.stdout.encode("utf-8")
+    return formatted
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    action = parser.add_mutually_exclusive_group(required=True)
+    action.add_argument("--write", action="store_true", help="write generated SDK bindings")
+    action.add_argument("--check", action="store_true", help="verify generated SDK bindings")
+    parser.add_argument("--artifact", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        document, artifact_payload = _load_document(args.artifact)
+        _validate_document(document)
+        rendered = _rendered_files(document, artifact_payload)
+    except GenerationError as exc:
+        print(f"Python SDK generation failed: {exc}", file=sys.stderr)
+        return 2
+
+    if args.write:
+        args.output.mkdir(parents=True, exist_ok=True)
+        for name, payload in rendered.items():
+            (args.output / name).write_bytes(payload)
+        print(f"wrote {len(rendered)} Python SDK binding files to {args.output}")
+        return 0
+
+    stale = [
+        name
+        for name, payload in rendered.items()
+        if not (args.output / name).is_file() or (args.output / name).read_bytes() != payload
+    ]
+    if stale:
+        print(f"generated Python SDK bindings are stale: {', '.join(stale)}", file=sys.stderr)
+        return 1
+    print(f"generated Python SDK bindings are reproducible: {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- generate 35 Pydantic DTOs and 8 operation bindings from the frozen `2.0.0rc2` OpenAPI artifact
- add sync and async `httpx` clients with target/API-major preflight, explicit auth channels, request-ID correlation, typed errors, and no automatic retries
- extend deterministic SDK profiles, import-surface tests, clean-wheel smoke, and public SDK documentation
- fail closed on unknown or duplicate operations and unsupported schema shapes

## Verification

- `PYTHONPATH=src pytest tests/ -q --tb=short` — 3482 passed, 3 skipped
- `PYTHONPATH=src python3 scripts/ci/run_profile.py --profile sdk-contract --profile server-contract`
- `ruff check src tests scripts tools`
- `ruff format --check src tests scripts tools`
- architecture, provider migration inventory, generated docs, Markdown links, `actionlint`, and `git diff --check`
- independent generator/client review completed; duplicate-operation finding reproduced, fixed, and reverified
