### PR TITLE
ci: enable owner-approved RC2 publication

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -68,6 +68,9 @@ jobs:
           EVIDENCE_PROFILE: ${{ inputs.evidence_profile }}
           PUBLISH: ${{ inputs.publish }}
           DEPLOY_HFS: ${{ inputs.deploy_hfs }}
+          DISPATCH_ACTOR: ${{ github.actor }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
           WORKFLOW_REF: ${{ github.ref }}
           WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
@@ -83,6 +86,9 @@ jobs:
           evidence_profile = os.environ['EVIDENCE_PROFILE']
           publish = os.environ['PUBLISH']
           deploy_hfs = os.environ['DEPLOY_HFS']
+          dispatch_actor = os.environ['DISPATCH_ACTOR']
+          triggering_actor = os.environ['TRIGGERING_ACTOR']
+          repository_owner = os.environ['REPOSITORY_OWNER']
           workflow_ref = os.environ['WORKFLOW_REF']
           workflow_sha = os.environ['WORKFLOW_SHA']
 
@@ -112,10 +118,12 @@ jobs:
               raise SystemExit('publish=true requires evidence_profile=release')
           if publish == 'true' and deploy_hfs != 'true':
               raise SystemExit('publish=true requires deploy_hfs=true and a successful live promotion')
-          if publish == 'true':
+          if publish == 'true' and any(
+              actor.casefold() != repository_owner.casefold()
+              for actor in (dispatch_actor, triggering_actor)
+          ):
               raise SystemExit(
-                  'RC2 publication remains disabled until Phase 8 removes legacy release '
-                  'residue and verifies the exact four-server-bundle release contract'
+                  'publish=true requires a repository-owner dispatch and owner-triggered rerun'
               )
 
           head = subprocess.check_output(['git', 'rev-parse', 'HEAD'], text=True).strip()

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -186,7 +186,12 @@ def test_release_candidate_strictly_validates_promotion_inputs() -> None:
     assert "current release surface only accepts version 2.0.0rc2" in text
     assert "product_name = 'Souwen v2rc2'" in text
     assert "api_major = 2" in text
-    assert "RC2 publication remains disabled until Phase 8" in text
+    assert "DISPATCH_ACTOR: ${{ github.actor }}" in trust_step
+    assert "TRIGGERING_ACTOR: ${{ github.triggering_actor }}" in trust_step
+    assert "REPOSITORY_OWNER: ${{ github.repository_owner }}" in trust_step
+    assert "for actor in (dispatch_actor, triggering_actor)" in trust_step
+    assert "repository-owner dispatch and owner-triggered rerun" in trust_step
+    assert "RC2 publication remains disabled" not in text
     assert '--title "$PRODUCT_NAME"' in text
     assert text.index("git', 'merge-base', '--is-ancestor'") < text.index(
         'pip install -e ".[server,tls,web,robots,scraper]"'
@@ -361,7 +366,8 @@ def test_deployment_evidence_is_non_publishable_and_contains_no_release_binaries
     assert "'api_major': int(os.environ['API_MAJOR'])" in release
     assert "name: release-candidate-${{ needs.validate.outputs.version }}" in release
     assert "needs: [validate, assemble]" in publish
-    assert "RC2 publication remains disabled until Phase 8" in text
+    assert "repository-owner dispatch and owner-triggered rerun" in text
+    assert "RC2 publication remains disabled" not in text
     assert "deployment-evidence-" not in publish
     assert "deployment-manifest.json" not in publish
 


### PR DESCRIPTION
## Summary
- replace the obsolete unconditional RC2 publish lock with an explicit repository-owner dispatch and owner-triggered rerun gate
- retain release profile, live HFS promotion, exact current-main SHA, existing-tag refusal, and release environment gates
- add deterministic workflow contract coverage

## Validation
- `pytest tests/test_release_candidate_workflows.py -q --tb=short` (`28 passed`)
- `actionlint .github/workflows/release-candidate.yml`
- `ruff check` / `ruff format --check`
- `gitleaks git --staged --redact --no-banner`