### PR TITLE
ci: fix RC2 release-only verification

### DIFF
--- a/.github/workflows/build-pyinstaller-server.yml
+++ b/.github/workflows/build-pyinstaller-server.yml
@@ -175,7 +175,7 @@ jobs:
       - name: Install target server build dependencies
         shell: bash
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip "ruff==0.15.22"
           pip install -e ".[server,tls,web,robots,scraper]"
           pip install "playwright>=1.40" "setuptools<82" pyinstaller
 

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -292,7 +292,7 @@ jobs:
 
       - name: Build wheel and sdist
         run: |
-          python -m pip install --upgrade pip build cyclonedx-bom
+          python -m pip install --upgrade pip build cyclonedx-bom "ruff==0.15.22"
           python -m build
           test "$(find dist -maxdepth 1 -name 'souwen-*.whl' | wc -l)" -eq 1
           test "$(find dist -maxdepth 1 -name 'souwen-*.tar.gz' | wc -l)" -eq 1
@@ -474,7 +474,9 @@ jobs:
                   --arg source_sha "${{ needs.validate.outputs.candidate_sha }}" \
                   '.ready == true and .version == $version and .source_sha == $source_sha' \
                   >/dev/null
-              curl -fsS "http://127.0.0.1:${{ matrix.port }}/panel" | grep -Eiq 'id="root"|SouWen|souwen'
+              panel_file="$RUNNER_TEMP/souwen-panel-${{ matrix.kind }}.html"
+              curl -fsS "http://127.0.0.1:${{ matrix.port }}/panel" -o "$panel_file"
+              grep -Eiq 'id="root"|SouWen|souwen' "$panel_file"
               curl -fsS "http://127.0.0.1:${{ matrix.port }}/openapi.json" | jq -e '.info.title == "SouWen API"' >/dev/null
               admin_status="$(curl -sS -o /dev/null -w '%{http_code}' \
                 "http://127.0.0.1:${{ matrix.port }}/api/v1/admin/ping")"

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -937,6 +937,18 @@ def test_ruff_toolchain_version_is_pinned_consistently() -> None:
         workflow = _workflow(workflow_name)
         assert f'pip install "ruff=={version}"' in workflow
         assert "pip install ruff\n" not in workflow
+    for workflow_name in ("release-candidate.yml", "build-pyinstaller-server.yml"):
+        workflow = _workflow(workflow_name)
+        assert f'"ruff=={version}"' in workflow
+        assert "pip install ruff\n" not in workflow
+
+
+def test_release_container_smoke_avoids_pipefail_broken_pipe_on_panel_html() -> None:
+    container = _job(_workflow("release-candidate.yml"), "container", "promotion-gate")
+
+    assert '/panel" | grep' not in container
+    assert 'curl -fsS "http://127.0.0.1:${{ matrix.port }}/panel" -o "$panel_file"' in container
+    assert 'grep -Eiq \'id="root"|SouWen|souwen\' "$panel_file"' in container
 
 
 def test_hfs_reusable_promotion_is_candidate_pinned_and_live_verified() -> None:


### PR DESCRIPTION
## Summary
- install the pinned Ruff formatter in release package and four-platform Server bundle jobs before SDK reproducibility checks
- avoid `curl | grep -q` broken-pipe failures in candidate Panel smoke by downloading the HTML first
- add workflow contract regression coverage

## Evidence
Run `30220115069` exposed both release-only failures: missing `ruff` during generated Python SDK checks and `curl: (23)` during root Panel smoke.

## Validation
- `pytest tests/test_release_candidate_workflows.py tests/test_binary_build_workflows.py -q --tb=short` (`34 passed`)
- `actionlint` on both changed workflows
- `ruff check` / `ruff format --check`
- `gitleaks git --staged --redact --no-banner`