### PR TITLE
ci: stabilize RC2 release matrix across platforms

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
 # Panel HTML is not tracked in git (built in CI / local dev)
+
+# Generated contracts must compare byte-for-byte on Windows release runners.
+contracts/openapi/*.json text eol=lf
+src/souwen/delivery/client_sdk/_generated_*.py text eol=lf
+panel/src/core/sdk/index.ts text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -595,7 +595,9 @@ jobs:
               curl -fsS "http://127.0.0.1:${{ matrix.port }}/readyz" | \
                 jq -e --arg source_sha "$SOURCE_SHA" \
                   '.ready == true and .source_sha == $source_sha' >/dev/null
-              curl -fsS "http://127.0.0.1:${{ matrix.port }}/panel" | grep -Eiq 'id="root"|SouWen|souwen'
+              panel_file="$RUNNER_TEMP/souwen-panel-${{ matrix.kind }}.html"
+              curl -fsS "http://127.0.0.1:${{ matrix.port }}/panel" -o "$panel_file"
+              grep -Eiq 'id="root"|SouWen|souwen' "$panel_file"
               curl -fsS "http://127.0.0.1:${{ matrix.port }}/openapi.json" | jq -e '.info.title == "SouWen API"' >/dev/null
               status="$(curl -sS -o /dev/null -w '%{http_code}' \
                 "http://127.0.0.1:${{ matrix.port }}/api/v1/admin/ping")"

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -943,12 +943,27 @@ def test_ruff_toolchain_version_is_pinned_consistently() -> None:
         assert "pip install ruff\n" not in workflow
 
 
-def test_release_container_smoke_avoids_pipefail_broken_pipe_on_panel_html() -> None:
-    container = _job(_workflow("release-candidate.yml"), "container", "promotion-gate")
+def test_container_smokes_avoid_pipefail_broken_pipe_on_panel_html() -> None:
+    containers = (
+        _job(_workflow("release-candidate.yml"), "container", "promotion-gate"),
+        _job(_workflow("ci.yml"), "container-surface", "aggregate"),
+    )
 
-    assert '/panel" | grep' not in container
-    assert 'curl -fsS "http://127.0.0.1:${{ matrix.port }}/panel" -o "$panel_file"' in container
-    assert 'grep -Eiq \'id="root"|SouWen|souwen\' "$panel_file"' in container
+    for container in containers:
+        assert '/panel" | grep' not in container
+        assert 'curl -fsS "http://127.0.0.1:${{ matrix.port }}/panel" -o "$panel_file"' in container
+        assert 'grep -Eiq \'id="root"|SouWen|souwen\' "$panel_file"' in container
+
+
+def test_generated_contracts_pin_lf_for_windows_reproducibility() -> None:
+    attributes = (REPO_ROOT / ".gitattributes").read_text(encoding="utf-8")
+
+    for rule in (
+        "contracts/openapi/*.json text eol=lf",
+        "src/souwen/delivery/client_sdk/_generated_*.py text eol=lf",
+        "panel/src/core/sdk/index.ts text eol=lf",
+    ):
+        assert rule in attributes
 
 
 def test_hfs_reusable_promotion_is_candidate_pinned_and_live_verified() -> None:


### PR DESCRIPTION
## Summary
- pin LF checkout semantics for generated OpenAPI, Python SDK, and TypeScript SDK artifacts so Windows byte-for-byte reproducibility checks match Linux/macOS
- avoid the same `curl | grep -q` broken-pipe failure in broad CI container smoke
- add cross-platform and workflow regression coverage

## Evidence
Release dry-run `30220115069` showed CRLF-only generated artifact mismatches on both Windows full matrices and `curl: (23)` in all broad container smokes.

## Validation
- `pytest tests/test_release_candidate_workflows.py tests/test_client_sdk_generator.py tests/test_typescript_sdk_generator.py -q --tb=short` (`43 passed`)
- `git check-attr text eol` confirms `eol=lf` on all generated contract surfaces
- `actionlint .github/workflows/ci.yml`
- `ruff check` / `ruff format --check`
- `gitleaks git --staged --redact --no-banner`