### PR TITLE
fix(ci): align container smoke with canonical API title

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -598,7 +598,8 @@ jobs:
               panel_file="$RUNNER_TEMP/souwen-panel-${{ matrix.kind }}.html"
               curl -fsS "http://127.0.0.1:${{ matrix.port }}/panel" -o "$panel_file"
               grep -Eiq 'id="root"|SouWen|souwen' "$panel_file"
-              curl -fsS "http://127.0.0.1:${{ matrix.port }}/openapi.json" | jq -e '.info.title == "SouWen API"' >/dev/null
+              curl -fsS "http://127.0.0.1:${{ matrix.port }}/openapi.json" | \
+                jq -e '.info.title == "SouWen External Data API"' >/dev/null
               status="$(curl -sS -o /dev/null -w '%{http_code}' \
                 "http://127.0.0.1:${{ matrix.port }}/api/v1/admin/ping")"
               test "$status" = 401

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -477,7 +477,8 @@ jobs:
               panel_file="$RUNNER_TEMP/souwen-panel-${{ matrix.kind }}.html"
               curl -fsS "http://127.0.0.1:${{ matrix.port }}/panel" -o "$panel_file"
               grep -Eiq 'id="root"|SouWen|souwen' "$panel_file"
-              curl -fsS "http://127.0.0.1:${{ matrix.port }}/openapi.json" | jq -e '.info.title == "SouWen API"' >/dev/null
+              curl -fsS "http://127.0.0.1:${{ matrix.port }}/openapi.json" | \
+                jq -e '.info.title == "SouWen External Data API"' >/dev/null
               admin_status="$(curl -sS -o /dev/null -w '%{http_code}' \
                 "http://127.0.0.1:${{ matrix.port }}/api/v1/admin/ping")"
               test "$admin_status" = 401

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -955,6 +955,20 @@ def test_container_smokes_avoid_pipefail_broken_pipe_on_panel_html() -> None:
         assert 'grep -Eiq \'id="root"|SouWen|souwen\' "$panel_file"' in container
 
 
+def test_container_smokes_require_the_canonical_openapi_title() -> None:
+    contract = json.loads(
+        (REPO_ROOT / "contracts/openapi/souwen-openapi-2.0.0rc2.json").read_text(encoding="utf-8")
+    )
+    expected_assertion = f'.info.title == "{contract["info"]["title"]}"'
+    containers = (
+        _job(_workflow("release-candidate.yml"), "container", "promotion-gate"),
+        _job(_workflow("ci.yml"), "container-surface", "aggregate"),
+    )
+
+    for container in containers:
+        assert expected_assertion in container
+
+
 def test_generated_contracts_pin_lf_for_windows_reproducibility() -> None:
     attributes = (REPO_ROOT / ".gitattributes").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

- align release-candidate and broad CI container smoke assertions with the canonical OpenAPI title
- add a regression test that derives the expected title from the checked-in RC2 OpenAPI contract

## Evidence

- release dry-run 30220645960 passed all package, Python matrix, V2, Panel, clean-install, and four-platform Server bundle gates
- its six container jobs all reached healthy `/healthz`, `/readyz`, `/panel`, and `/openapi.json` before failing only on the stale title assertion
- aggregate and release-evidence failures were downstream consequences of those container failures

## Validation

- `PYTHONPATH=src python3 -m pytest tests/test_release_candidate_workflows.py -q --tb=short` (31 passed)
- `python3 -m ruff check tests/test_release_candidate_workflows.py`
- `python3 -m ruff format --check tests/test_release_candidate_workflows.py`
- `actionlint .github/workflows/ci.yml .github/workflows/release-candidate.yml`
- `git diff --check`