### PR TITLE
fix(release): close HFS live smoke gaps

### DIFF
--- a/.github/workflows/deploy-hf-space.yml
+++ b/.github/workflows/deploy-hf-space.yml
@@ -768,7 +768,7 @@ jobs:
           EXPECTED_SOUWEN_WRAPPER_SHA: ${{ needs.sync-hfs-wrapper.outputs.space_commit_sha }}
           SOUWEN_HF_SPACE_URL: https://blueskyxn-souwen.hf.space
           SOUWEN_HF_SPACE_TOKEN: ${{ secrets.HF_SPACE_READ_TOKEN }}
-          SOUWEN_SMOKE_REQUEST_TIMEOUT: "20"
+          SOUWEN_SMOKE_REQUEST_TIMEOUT: "60"
           SOUWEN_SMOKE_WARP_MODES: auto
           SOUWEN_SMOKE_FAIL_ADMIN_OPEN: "1"
           SOUWEN_SMOKE_REPORT_FILE: ${{ github.workspace }}/${{ matrix.report }}

--- a/scripts/hf_space_smoke.py
+++ b/scripts/hf_space_smoke.py
@@ -99,12 +99,13 @@ def _record(checks: list[Check], name: str, callback, *, required: bool = True) 
     started = time.perf_counter()
     try:
         detail, value = callback()
-    except Exception as exc:  # noqa: BLE001 - public report retains only bounded exception type.
+    except Exception as exc:  # noqa: BLE001 - reports retain only bounded, controlled detail.
+        detail = str(exc)[:200] if isinstance(exc, SmokeFailure) else type(exc).__name__
         checks.append(
             Check(
                 name=name,
                 outcome="FAIL" if required else "WARN",
-                detail=type(exc).__name__,
+                detail=detail,
                 required=required,
                 duration_seconds=time.perf_counter() - started,
             )
@@ -216,6 +217,22 @@ def _first_available(items: list[dict], capability: str, preferred: tuple[str, .
     raise SmokeFailure(f"no available {capability} provider")
 
 
+def _preferred_available(
+    items: list[dict], capability: str, preferred: tuple[str, ...]
+) -> tuple[str, ...]:
+    available = {
+        item.get("provider")
+        for item in items
+        if item.get("availability") == "available" and capability in item.get("capabilities", [])
+    }
+    selected = tuple(provider for provider in preferred if provider in available)
+    if selected:
+        return selected
+    if available:
+        return (sorted(available)[0],)
+    raise SmokeFailure(f"no available {capability} provider")
+
+
 def _capability_checks(
     client: Client,
     args: argparse.Namespace,
@@ -223,19 +240,26 @@ def _capability_checks(
     providers: list[dict],
 ) -> None:
     def search():
-        search_provider = _first_available(providers, "search", ("openalex", "duckduckgo"))
-        status, _headers, payload = client.json(
-            "/api/v1/search",
-            method="POST",
-            payload={
-                "query": "retrieval augmented generation",
-                "domains": ["paper"],
-                "providers": [{"id": search_provider, "kind": "search"}],
-                "page": {"limit": 3},
-            },
-        )
-        _expect(status == 200 and isinstance(payload.get("items"), list), f"search {status}")
-        return f"{search_provider}: {len(payload['items'])} results", payload
+        failures: list[str] = []
+        for search_provider in _preferred_available(
+            providers,
+            "search",
+            ("openalex", "crossref", "semantic_scholar"),
+        ):
+            status, _headers, payload = client.json(
+                "/api/v1/search",
+                method="POST",
+                payload={
+                    "query": "retrieval augmented generation",
+                    "domains": ["paper"],
+                    "providers": [{"id": search_provider, "kind": "search"}],
+                    "page": {"limit": 3},
+                },
+            )
+            if status == 200 and isinstance(payload.get("items"), list):
+                return f"{search_provider}: {len(payload['items'])} results", payload
+            failures.append(f"{search_provider}={status}")
+        raise SmokeFailure(f"search providers failed: {', '.join(failures)}")
 
     _record(checks, "search_live", search)
 

--- a/src/souwen/providers/llm_sources/uniapi_ark_annotations/adapter.py
+++ b/src/souwen/providers/llm_sources/uniapi_ark_annotations/adapter.py
@@ -37,7 +37,6 @@ from souwen.platform.provider_spi import (
 from .manifest import DEEPSEEK_ADAPTER_ID, DOUBAO_ADAPTER_ID
 
 
-_RESPONSE_PATH = "/v1/responses"
 _DEFAULT_TIMEOUT_SECONDS = 45.0
 _DEFAULT_MAX_KEYWORD = 10
 _MAX_RESULTS = 50
@@ -80,6 +79,7 @@ class _UniApiArkAnnotationsProvider:
     ) -> None:
         self._enabled, self._max_keyword, timeout = _validated_configuration(configuration)
         api_key, base_url = _validated_secrets(secrets)
+        self._response_path = _responses_path(base_url)
         self._transport = transport or HttpTransport(
             base_url=base_url,
             headers={
@@ -121,11 +121,12 @@ class _UniApiArkAnnotationsProvider:
             "model": self.MODEL_ID,
             "input": request.query,
             "tools": [{"type": "web_search", "max_keyword": max_results}],
+            "tool_choice": {"type": "web_search"},
         }
         try:
             response = await _await_with_execution(
                 self._transport.post(
-                    _RESPONSE_PATH,
+                    self._response_path,
                     json=payload,
                     retry_policy="single_attempt",
                 ),
@@ -272,6 +273,12 @@ def _validated_secrets(secrets: Mapping[str, str]) -> tuple[str, str]:
     return api_key.strip(), base_url.strip().rstrip("/")
 
 
+def _responses_path(base_url: str) -> str:
+    """Join against either a gateway root or an OpenAI-compatible ``/v1`` base."""
+    path = urlsplit(base_url).path.rstrip("/")
+    return "responses" if path.endswith("/v1") else "v1/responses"
+
+
 async def _await_with_execution(
     value: Any,
     execution: ExecutionContext,
@@ -402,10 +409,10 @@ def _structured_annotations(output: list[Any]) -> tuple[Mapping[str, Any], ...]:
     for item in output:
         if not isinstance(item, Mapping) or item.get("status") not in {"completed", "incomplete"}:
             continue
-        message = item.get("message")
-        if not isinstance(message, Mapping):
-            continue
-        content = message.get("content")
+        content = item.get("content")
+        if not isinstance(content, list):
+            message = item.get("message")
+            content = message.get("content") if isinstance(message, Mapping) else None
         if not isinstance(content, list):
             continue
         for part in content:

--- a/src/souwen/providers/runtime_clients/web/llm_search/schemes/ark_annotations.py
+++ b/src/souwen/providers/runtime_clients/web/llm_search/schemes/ark_annotations.py
@@ -58,7 +58,6 @@ ARK_ANNOTATIONS_DOUBAO = ConcreteSearchSourceSpec(
 )
 ARK_ANNOTATIONS_SOURCES = (ARK_ANNOTATIONS_DEEPSEEK, ARK_ANNOTATIONS_DOUBAO)
 
-_ARK_RESPONSE_PATH = "/v1/responses"
 _ARK_MAX_KEYWORD_DEFAULT = 10
 _ARK_MAX_RESULTS = 50
 
@@ -86,6 +85,7 @@ def build_ark_request(query: str, model_id: str, *, max_keyword: int = 10) -> di
         "model": model_id,
         "input": query.strip(),
         "tools": [{"type": "web_search", "max_keyword": max_keyword}],
+        "tool_choice": {"type": "web_search"},
     }
 
 
@@ -169,10 +169,10 @@ def _message_annotations(payload: Mapping[str, Any]) -> list[Mapping[str, Any]]:
     for item in output:
         if not isinstance(item, Mapping) or item.get("status") not in {"completed", "incomplete"}:
             continue
-        message = item.get("message")
-        if not isinstance(message, Mapping):
-            continue
-        content = message.get("content")
+        content = item.get("content")
+        if not isinstance(content, list):
+            message = item.get("message")
+            content = message.get("content") if isinstance(message, Mapping) else None
         if not isinstance(content, list):
             continue
         for part in content:
@@ -267,6 +267,8 @@ class ArkAnnotationsClient(SouWenHttpClient):
             timeout=self.resolved.timeout_seconds,
             source_name=self.resolved.source_id,
         )
+        base_path = urlsplit(self.resolved.base_url or "").path.rstrip("/")
+        self._response_path = "responses" if base_path.endswith("/v1") else "v1/responses"
 
     @classmethod
     def _resolve_config(cls) -> ResolvedConcreteSearchConfig:
@@ -292,7 +294,7 @@ class ArkAnnotationsClient(SouWenHttpClient):
         )
         payload = build_ark_request(query, self.resolved.model_id, max_keyword=max_keyword)
         response = await self.post(
-            _ARK_RESPONSE_PATH,
+            self._response_path,
             json=payload,
             retry_policy="single_attempt",
         )

--- a/tests/test_hf_space_smoke.py
+++ b/tests/test_hf_space_smoke.py
@@ -178,5 +178,59 @@ def test_missing_required_llm_provider_is_reported_as_a_failed_check(monkeypatch
     checks = {item["name"]: item for item in payload["checks"]}
     assert checks["search_live"]["outcome"] == "PASS"
     assert checks["llm_search_live"]["outcome"] == "FAIL"
-    assert checks["llm_search_live"]["detail"] == "SmokeFailure"
+    assert checks["llm_search_live"]["detail"] == "no available llm_search provider"
     assert checks["fetch_live"]["outcome"] == "PASS"
+
+
+def test_search_live_uses_bounded_provider_fallback(monkeypatch, tmp_path) -> None:
+    providers = [
+        {
+            "provider": provider,
+            "availability": "available",
+            "capabilities": ["search"],
+        }
+        for provider in ("openalex", "crossref", "semantic_scholar")
+    ]
+    providers.extend(
+        [
+            {
+                "provider": "fixture-llm",
+                "availability": "available",
+                "capabilities": ["llm_search"],
+            },
+            {
+                "provider": "builtin-fetch",
+                "availability": "available",
+                "capabilities": ["fetch"],
+            },
+        ]
+    )
+    calls: list[str] = []
+
+    class Client:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def json(self, path, **kwargs):
+            if path == "/api/v1/search":
+                provider = kwargs["payload"]["providers"][0]["id"]
+                calls.append(provider)
+                if provider == "openalex":
+                    return 503, {}, {"error": {"code": "upstream_unavailable"}}
+                return 200, {}, {"items": []}
+            if path == "/api/v1/llm-search":
+                return 200, {}, {"evidence": [], "usage": {}}
+            if path == "/api/v1/fetch":
+                return 200, {}, {"items": [{"status": "success", "content": "fixture"}]}
+            raise AssertionError(path)
+
+    monkeypatch.setattr(smoke, "Client", Client)
+    monkeypatch.setattr(smoke, "_surface_checks", lambda _client, _args, _checks: providers)
+    report = tmp_path / "capability.json"
+
+    assert smoke.main(["--mode", "capability", "--json-report", str(report)]) == 0
+    assert calls == ["openalex", "crossref"]
+    checks = {
+        item["name"]: item for item in json.loads(report.read_text(encoding="utf-8"))["checks"]
+    }
+    assert checks["search_live"]["detail"] == "crossref: 0 results"

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -1072,6 +1072,7 @@ def test_hfs_reusable_promotion_is_candidate_pinned_and_live_verified() -> None:
     )[0]
     assert "ref: ${{ inputs.verifier_sha }}" in post_deploy
     assert "cd trusted-verifier" in post_deploy
+    assert 'SOUWEN_SMOKE_REQUEST_TIMEOUT: "60"' in post_deploy
     assert "ref: ${{ inputs.candidate_sha || github.sha }}" not in post_deploy
 
 

--- a/tests/test_uniapi_ark_provider_v2.py
+++ b/tests/test_uniapi_ark_provider_v2.py
@@ -81,15 +81,13 @@ def _payload(
         {
             "type": "message",
             "status": "completed",
-            "message": {
-                "content": [
-                    {
-                        "type": "output_text",
-                        "text": "Untrusted answer https://must-not-be-inferred.example/",
-                        "annotations": annotations or [],
-                    }
-                ]
-            },
+            "content": [
+                {
+                    "type": "output_text",
+                    "text": "Untrusted answer https://must-not-be-inferred.example/",
+                    "annotations": annotations or [],
+                }
+            ],
         }
     )
     return {
@@ -199,17 +197,50 @@ async def test_each_adapter_executes_one_bound_request_and_emits_evidence_usage(
     assert result.usage.cost is None
     assert transport.calls == [
         {
-            "url": "/v1/responses",
+            "url": "v1/responses",
             "json": {
                 "model": model_id,
                 "input": "canonical query",
                 "tools": [{"type": "web_search", "max_keyword": 2}],
+                "tool_choice": {"type": "web_search"},
             },
             "data": None,
             "headers": None,
             "retry_policy": "single_attempt",
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_v1_gateway_base_url_does_not_duplicate_the_version_path() -> None:
+    transport = _Transport(
+        _payload(
+            "deepseek-v3-2-251201",
+            annotations=[
+                {
+                    "type": "url_citation",
+                    "title": "Structured source",
+                    "url": "https://example.com/source",
+                }
+            ],
+        )
+    )
+    provider = UniApiArkAnnotationsDeepSeekProvider(
+        {"enabled": True},
+        {
+            "UNIAPI_API_KEY": "fixture-secret",
+            "UNIAPI_BASE_URL": "https://gateway.example.test/v1",
+        },
+        transport=transport,
+    )
+
+    await provider.search(
+        _request(DEEPSEEK_ADAPTER_ID),
+        RequestContext(request_id="provider-v2-base-url"),
+        ExecutionContext.with_timeout(5),
+    )
+
+    assert transport.calls[0]["url"] == "responses"
 
 
 @pytest.mark.asyncio

--- a/tests/test_uniapi_llm_search_vertical_v2.py
+++ b/tests/test_uniapi_llm_search_vertical_v2.py
@@ -34,19 +34,17 @@ class _Response:
                 {
                     "type": "message",
                     "status": "completed",
-                    "message": {
-                        "content": [
-                            {
-                                "annotations": [
-                                    {
-                                        "type": "url_citation",
-                                        "title": "Vertical fixture",
-                                        "url": "https://example.com/vertical",
-                                    }
-                                ]
-                            }
-                        ]
-                    },
+                    "content": [
+                        {
+                            "annotations": [
+                                {
+                                    "type": "url_citation",
+                                    "title": "Vertical fixture",
+                                    "url": "https://example.com/vertical",
+                                }
+                            ]
+                        }
+                    ],
                 },
             ],
             "usage": {},


### PR DESCRIPTION
## Summary

- resolve OpenAI-compatible `responses` paths correctly for gateway roots and `/v1` base URLs
- force the configured UniAPI Ark model to execute `web_search` and parse the live Responses content shape
- make HFS Search smoke try a bounded paper-provider fallback and retain bounded failure details
- raise the live capability request timeout to 60 seconds

## Evidence

- reproduced formal release run `30222149609` rollback: Search and LLM Search live smoke failed while health, readiness, Panel, auth, providers, and Fetch passed
- verified the UniAPI `/v1` gateway returned `404` through the old doubled request path
- verified the updated local SouWen `/api/v1/llm-search` returned HTTP 200 with structured evidence using the deployment credential
- `88 passed` across Provider, LLM Search vertical/module, HFS smoke, release workflow, and Delivery API tests
- Ruff check/format and `git diff --check` passed

`actionlint` reports the repository's existing `environment.deployment: false` keys as unsupported; the workflow is accepted and executed by GitHub Actions, and this PR does not change those keys.
