### PR TITLE
chore(ci): bump actions/setup-python to v7

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -31,7 +31,7 @@ jobs:
           ref: ${{ github.head_ref || github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.10'
           cache: 'pip'

--- a/.github/workflows/build-pyinstaller-server.yml
+++ b/.github/workflows/build-pyinstaller-server.yml
@@ -167,7 +167,7 @@ jobs:
           name: rc2-server-panel-html
           path: src/souwen/server
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           ref: ${{ inputs.candidate_sha || github.sha }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.10'
 
@@ -74,7 +74,7 @@ jobs:
         with:
           ref: ${{ inputs.candidate_sha || github.sha }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.10'
           cache: 'pip'
@@ -98,7 +98,7 @@ jobs:
         with:
           ref: ${{ inputs.candidate_sha || github.sha }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
           cache: pip
@@ -136,7 +136,7 @@ jobs:
         with:
           ref: ${{ inputs.candidate_sha || github.sha }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python }}
           cache: 'pip'
@@ -195,7 +195,7 @@ jobs:
         with:
           ref: ${{ inputs.candidate_sha || github.sha }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -253,7 +253,7 @@ jobs:
         with:
           ref: ${{ inputs.candidate_sha || github.sha }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
           cache: pip
@@ -310,7 +310,7 @@ jobs:
           name: ci-python-distributions
           path: dist
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 
@@ -358,7 +358,7 @@ jobs:
         with:
           ref: ${{ inputs.candidate_sha || github.sha }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
           cache: pip
@@ -450,7 +450,7 @@ jobs:
         with:
           ref: ${{ inputs.candidate_sha || github.sha }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
           cache: pip
@@ -492,7 +492,7 @@ jobs:
         with:
           ref: ${{ inputs.candidate_sha || github.sha }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
           cache: pip

--- a/.github/workflows/deploy-hf-space.yml
+++ b/.github/workflows/deploy-hf-space.yml
@@ -162,7 +162,7 @@ jobs:
         with:
           ref: ${{ inputs.candidate_sha || github.event.pull_request.head.sha || github.sha }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
           cache: pip
@@ -350,7 +350,7 @@ jobs:
           ref: ${{ inputs.candidate_sha || github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
           cache: pip
@@ -658,7 +658,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 
@@ -852,7 +852,7 @@ jobs:
     outputs:
       rollback_space_commit_sha: ${{ steps.restore.outputs.rollback_space_commit_sha }}
     steps:
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 
@@ -1074,7 +1074,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -206,7 +206,7 @@ jobs:
           )
           PY
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 
@@ -268,7 +268,7 @@ jobs:
         with:
           ref: ${{ needs.validate.outputs.candidate_sha }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
           cache: pip
@@ -363,7 +363,7 @@ jobs:
           name: release-python-distributions
           path: dist
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 

--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -54,7 +54,7 @@ jobs:
           ref: ${{ inputs.candidate_sha || github.sha }}
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
           cache: "pip"
@@ -246,7 +246,7 @@ jobs:
         with:
           ref: ${{ inputs.candidate_sha || github.sha }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python }}
           cache: "pip"
@@ -285,7 +285,7 @@ jobs:
         with:
           ref: ${{ inputs.candidate_sha || github.sha }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
           cache: "pip"
@@ -326,7 +326,7 @@ jobs:
         with:
           ref: ${{ inputs.candidate_sha || github.sha }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
           cache: "pip"
@@ -367,7 +367,7 @@ jobs:
         with:
           ref: ${{ inputs.candidate_sha || github.sha }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
           cache: "pip"

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -169,7 +169,7 @@ def test_release_candidate_strictly_validates_promotion_inputs() -> None:
     trust_step = text.split(
         "- name: Validate candidate trust, SHA, version, and promotion controls",
         maxsplit=1,
-    )[1].split("- uses: actions/setup-python@v6", maxsplit=1)[0]
+    )[1].split("- uses: actions/setup-python@v7", maxsplit=1)[0]
     assert "python3 -I - <<'PY'" in trust_step
     assert "python3 - <<'PY'" not in trust_step
     assert "re.fullmatch(r'[0-9a-f]{40}', candidate)" in text
@@ -262,7 +262,7 @@ def test_release_candidate_requires_an_explicit_evidence_profile() -> None:
     trust_step = text.split(
         "- name: Validate candidate trust, SHA, version, and promotion controls",
         maxsplit=1,
-    )[1].split("- uses: actions/setup-python@v6", maxsplit=1)[0]
+    )[1].split("- uses: actions/setup-python@v7", maxsplit=1)[0]
     assert "EVIDENCE_PROFILE: ${{ inputs.evidence_profile }}" in trust_step
     assert "evidence_profile not in {'deployment', 'release'}" in trust_step
     assert "deployment profile requires deploy_hfs=true" in trust_step
@@ -1122,7 +1122,7 @@ def test_hfs_rebuild_job_avoids_checkout_and_dependency_cache() -> None:
         "  post-deploy-smoke:", maxsplit=1
     )[0]
 
-    assert "actions/setup-python@v6" in rebuild
+    assert "actions/setup-python@v7" in rebuild
     assert "actions/checkout@" not in rebuild
     assert "cache: pip" not in rebuild
 


### PR DESCRIPTION
## Summary

- bump actions/setup-python from v6 to v7 in the six workflow files covered by Dependabot PR #251
- update the version-bound workflow contract assertions

## Validation

- pytest tests/test_release_candidate_workflows.py -v --tb=short (31 passed)
- pytest tests/ -q --tb=short (2693 passed, 2 skipped)
- ruff check src tests scripts
- ruff format --check src tests scripts
- actionlint on all six changed workflows

Replaces #251 after this PR is merged.