### PR TITLE
fix(hfs): sync managed Space secrets

### DIFF
--- a/.github/workflows/deploy-hf-space.yml
+++ b/.github/workflows/deploy-hf-space.yml
@@ -331,9 +331,10 @@ jobs:
           HF_SPACE_READ_TOKEN: ${{ secrets.HF_SPACE_READ_TOKEN }}
           SOUWEN_SMOKE_BEARER_TOKEN: ${{ secrets.SOUWEN_SMOKE_BEARER_TOKEN }}
           SOUWEN_CONFIG_B64: ${{ secrets.SOUWEN_CONFIG_B64 }}
+          UNIAPI_API_KEY: ${{ secrets.UNIAPI_API_KEY }}
         run: |
           missing=()
-          for name in HF_TOKEN HF_SPACE_READ_TOKEN SOUWEN_SMOKE_BEARER_TOKEN SOUWEN_CONFIG_B64; do
+          for name in HF_TOKEN HF_SPACE_READ_TOKEN SOUWEN_SMOKE_BEARER_TOKEN SOUWEN_CONFIG_B64 UNIAPI_API_KEY; do
             if [ -z "${!name}" ]; then
               missing+=("$name")
             fi
@@ -519,6 +520,70 @@ jobs:
               f"captured rollback point space={prior_space_sha}, "
               f"runtime={runtime_sha}, stage={stage}, source={matches[0]}"
           )
+          PY
+
+      - name: Sync managed HFS Space secrets
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_SPACE_ID: BlueSkyXN/SouWen
+          SOUWEN_ADMIN_PASSWORD: ${{ secrets.SOUWEN_SMOKE_BEARER_TOKEN }}
+          SOUWEN_CONFIG_B64: ${{ secrets.SOUWEN_CONFIG_B64 }}
+          UNIAPI_API_KEY: ${{ secrets.UNIAPI_API_KEY }}
+        run: |
+          python -I - <<'PY'
+          import os
+
+          from huggingface_hub import HfApi
+          from huggingface_hub.utils import build_hf_headers, get_session, hf_raise_for_status
+
+          token = os.environ["HF_TOKEN"]
+          space_id = os.environ["HF_SPACE_ID"]
+          managed = {
+              "SOUWEN_ADMIN_PASSWORD": os.environ["SOUWEN_ADMIN_PASSWORD"],
+              "SOUWEN_CONFIG_B64": os.environ["SOUWEN_CONFIG_B64"],
+              "UNIAPI_API_KEY": os.environ["UNIAPI_API_KEY"],
+          }
+          expected_names = set(managed)
+          api = HfApi(token=token)
+
+          def read_secret_names() -> set[str]:
+              response = get_session().get(
+                  f"{api.endpoint}/api/spaces/{space_id}/secrets",
+                  headers=build_hf_headers(token=token),
+                  timeout=30.0,
+              )
+              hf_raise_for_status(response)
+              payload = response.json()
+              if not isinstance(payload, dict) or not all(
+                  isinstance(name, str) for name in payload
+              ):
+                  raise SystemExit("Space Secret name readback returned an unexpected schema")
+              return set(payload)
+
+          existing_names = read_secret_names()
+          unexpected_names = existing_names - expected_names
+          if unexpected_names:
+              raise SystemExit(
+                  "refusing to modify Space settings with unregistered Secret names: "
+                  + ", ".join(sorted(unexpected_names))
+              )
+
+          for key, value in managed.items():
+              api.add_space_secret(
+                  repo_id=space_id,
+                  key=key,
+                  value=value,
+                  description="Managed by the SouWen deployment transaction",
+              )
+
+          actual_names = read_secret_names()
+          if actual_names != expected_names:
+              missing = ", ".join(sorted(expected_names - actual_names)) or "none"
+              extra = ", ".join(sorted(actual_names - expected_names)) or "none"
+              raise SystemExit(
+                  f"managed Space Secret name readback mismatch: missing={missing}; extra={extra}"
+              )
+          print("Managed Space Secret names: " + ", ".join(sorted(actual_names)))
           PY
 
       - name: Sync changed HFS wrapper files

--- a/docs/hf-space-cd.md
+++ b/docs/hf-space-cd.md
@@ -40,11 +40,12 @@ Server local preflight 不会被跳过。`deploy_hfs=true` 时，candidate 必�
 `origin/main`；不能从未合入分支向持有 secrets 的部署 job 注入 verifier。Central caller 只在
 HFS reusable call 上使用一次 `secrets: inherit`。这是同仓 reusable workflow 读取
 environment-scoped secrets 的已知兼容处理（`actions/runner#4453`）；其他 reusable jobs 不得继承
-secrets。这四个 environment secrets 不能同时声明为 required `workflow_call` secrets：GitHub 会在
+secrets。这五个 environment secrets 不能同时声明为 required `workflow_call` secrets：GitHub 会在
 called job 绑定 `environment: hf` 之前校验该 contract，因而把实际存在的 environment secrets 误判为
 未传入。`deploy-hf-space.yml` 改为由 `environment: hf` 解析 `HF_TOKEN`、
-`HF_SPACE_READ_TOKEN`、`SOUWEN_SMOKE_BEARER_TOKEN` 与 `SOUWEN_CONFIG_B64`，并在 checkout 和任何 HF API 调用前按
-secret 名称 fail fast，不输出值、长度或前缀。
+`HF_SPACE_READ_TOKEN`、`SOUWEN_SMOKE_BEARER_TOKEN`、`SOUWEN_CONFIG_B64` 与
+`UNIAPI_API_KEY`，并在 checkout 和任何 HF API 调用前按 secret 名称 fail fast，不输出值、
+长度或前缀。
 
 ### Local preflight
 
@@ -74,6 +75,7 @@ Hugging Face 官方 private Space HTTP 入口占用标准 `Authorization: Bearer
 | `HF_SPACE_READ_TOKEN` | 通过 private Space edge | `Authorization: Bearer ...`；目标权限只需 READ，最小 bootstrap 可暂时复用已确认 write token |
 | `SOUWEN_SMOKE_BEARER_TOKEN` | SouWen 应用 admin password | `X-SouWen-Token: ...` |
 | `SOUWEN_CONFIG_B64` | 与 Space 同源的 RC4 配置；promotion 前验证 exact 一个 LLM Search Provider 与 gateway 结构 | 仅 workflow 内存预检；`${VAR}` 是否解析由 post-deploy live smoke 证明 |
+| `UNIAPI_API_KEY` | RC4 UniAPI gateway credential | workflow 将其写入同名 Space Secret；只回读 Secret 名称，不读取或记录值 |
 
 SouWen 仍以标准 `Authorization: Bearer <password>` 作为普通部署的首选应用鉴权。只有上游
 代理已经占用 `Authorization` 时才使用 `X-SouWen-Token`；显式 custom header 优先，若其值
@@ -112,12 +114,16 @@ SHA。
 2. 记录 `prior_space_commit_sha`、`prior_runtime_commit_sha`、`prior_souwen_ref`。旧部署没有
    immutable source pin 时，在写入前停止，不能回退到 floating `main`；同时记录
    `prior_runtime_stage` 供 manifest 和恢复审计。
-3. 只同步受管的四个 wrapper 文件；diff 固定读取 prior revision，`create_commit` 使用
+3. rollback point 稳定后，workflow 将 `SOUWEN_SMOKE_BEARER_TOKEN` 映射为 Space
+   `SOUWEN_ADMIN_PASSWORD`，并同步 `SOUWEN_CONFIG_B64`、`UNIAPI_API_KEY`。写入前拒绝任何未登记的
+   Space Secret 名称，写入后要求名称集合精确等于 `hfs-dev.toml` 中的三个受管名称；不删除未知
+   Secret，也不输出值、长度、hash 或前缀。
+4. 只同步受管的四个 wrapper 文件；diff 固定读取 prior revision，`create_commit` 使用
    `parent_commit=<prior_space_commit_sha>` 防止外部 writer 造成 TOCTOU。取得新 commit 后，
    transaction 写入并立即 readback `SOUWEN_WRAPPER_SHA=<space_commit_sha>` Space variable；
    rollback 同样改为实际 forward/no-op rollback SHA。
-4. Factory rebuild，等待 Space repo SHA 与 runtime SHA 等于新的 wrapper commit。
-5. 使用 trusted verifier 完成 surface、target capability、双层 auth 与 candidate/source/
+5. Factory rebuild，等待 Space repo SHA 与 runtime SHA 等于新的 wrapper commit。
+6. 使用 trusted verifier 完成 surface、target capability、双层 auth 与 candidate/source/
    wrapper SHA smoke。Required checks 固定覆盖 Search、LLM Search 与 immutable Fetch；readiness
    另行证明 Browser Worker ready 且 source SHA 一致。普通 CI 不做付费 LLM Search live call，
    只有显式 HFS promotion 的 capability smoke 才执行。

--- a/tests/test_hfs_v2_registry.py
+++ b/tests/test_hfs_v2_registry.py
@@ -54,6 +54,11 @@ def test_hfs_settings_remain_owned_by_candidate_pinned_workflow() -> None:
     workflow = (REPO_ROOT / ".github/workflows/deploy-hf-space.yml").read_text(encoding="utf-8")
 
     assert "SOUWEN_CONFIG_B64: ${{ secrets.SOUWEN_CONFIG_B64 }}" in workflow
+    assert "UNIAPI_API_KEY: ${{ secrets.UNIAPI_API_KEY }}" in workflow
+    assert "api.add_space_secret(" in workflow
+    assert "Managed Space Secret names:" in workflow
+    assert "actual_names != expected_names" in workflow
+    assert "api.delete_space_secret" not in workflow
     assert 'key="SOUWEN_WRAPPER_SHA"' in workflow
     assert "SOUWEN_WRAPPER_SHA variable readback mismatch" in workflow
     assert "candidate_sha" in workflow

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -1029,6 +1029,7 @@ def test_hfs_reusable_promotion_is_candidate_pinned_and_live_verified() -> None:
         "HF_SPACE_READ_TOKEN",
         "SOUWEN_SMOKE_BEARER_TOKEN",
         "SOUWEN_CONFIG_B64",
+        "UNIAPI_API_KEY",
     ):
         assert f"      {secret_name}:" not in workflow_call
     assert "    secrets:" not in workflow_call
@@ -1074,6 +1075,7 @@ def test_hfs_reusable_promotion_is_candidate_pinned_and_live_verified() -> None:
         "HF_SPACE_READ_TOKEN",
         "SOUWEN_SMOKE_BEARER_TOKEN",
         "SOUWEN_CONFIG_B64",
+        "UNIAPI_API_KEY",
     ):
         assert f"{secret_name}: ${{{{ secrets.{secret_name} }}}}" in secret_gate
     assert "Required HFS environment secret is not configured: $name" in secret_gate
@@ -1081,6 +1083,23 @@ def test_hfs_reusable_promotion_is_candidate_pinned_and_live_verified() -> None:
     assert "name: Validate required HFS LLM Search configuration" in text
     assert "HFS promotion requires exactly one enabled LLM Search Provider" in text
     assert 'env_reference = re.compile(r"^\\$\\{[A-Z_][A-Z0-9_]*\\}$")' in text
+
+    settings_sync = text.split("- name: Sync managed HFS Space secrets", maxsplit=1)[1].split(
+        "- name: Sync changed HFS wrapper files", maxsplit=1
+    )[0]
+    assert "SOUWEN_ADMIN_PASSWORD: ${{ secrets.SOUWEN_SMOKE_BEARER_TOKEN }}" in settings_sync
+    assert "SOUWEN_CONFIG_B64: ${{ secrets.SOUWEN_CONFIG_B64 }}" in settings_sync
+    assert "UNIAPI_API_KEY: ${{ secrets.UNIAPI_API_KEY }}" in settings_sync
+    assert "api.add_space_secret(" in settings_sync
+    assert "/api/spaces/{space_id}/secrets" in settings_sync
+    assert "existing_names - expected_names" in settings_sync
+    assert "actual_names != expected_names" in settings_sync
+    assert "api.delete_space_secret" not in settings_sync
+    assert (
+        text.index("- name: Capture immutable rollback point")
+        < text.index("- name: Sync managed HFS Space secrets")
+        < text.index("- name: Sync changed HFS wrapper files")
+    )
 
     prior = text.split("- name: Capture immutable rollback point", maxsplit=1)[1].split(
         "- name: Sync changed HFS wrapper files", maxsplit=1


### PR DESCRIPTION
## Summary

- sync the three `hfs-dev.toml` workflow-owned Space Secrets from the trusted `hf` environment after the immutable rollback point is captured
- fail closed before mutation when an unregistered Space Secret name exists, then require exact managed-name readback without logging values
- require `UNIAPI_API_KEY` for HFS promotion and document the ownership/mapping contract

## Validation

- `pytest tests/test_hfs_v2_registry.py tests/test_release_candidate_workflows.py tests/test_hf_space_smoke.py -q` — 43 passed
- `python3 /Users/sky/Github/SKY-Prompt/hfs-dev/scripts/check_hfs_alignment.py /Users/sky/Github/SouWen` — 0 ERROR / 0 WARN
- `python3 -B -m unittest discover -s /Users/sky/Github/SKY-Prompt/hfs-dev/tests -p 'test_*.py'` — 38 passed
- `ruff check` and `ruff format --check` for changed tests — passed
- Markdown link check and `git diff --check` — passed
- live read-only HF schema/name check — dict response with exactly the three registered Secret names

`actionlint 1.7.7` still reports the four pre-existing `environment.deployment` schema diagnostics; the same diagnostics reproduce against `origin/main`, and this PR does not add or change those fields.
