### PR TITLE
fix(hfs): align deployment evidence reports

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -761,11 +761,13 @@ jobs:
           if surface_report.get('overall') != 'PASS':
               raise SystemExit('deployment surface report did not pass')
           required_m1_checks = {
-              'basic/health',
-              'basic/readiness',
-              'target-m1/openalex-search',
-              'target-m1/builtin-fetch',
-              'target-m1/browser-fetch',
+              'healthz',
+              'readyz',
+              'whoami',
+              'anonymous_admin_rejected',
+              'search_live',
+              'llm_search_live',
+              'fetch_live',
           }
           observed_checks = {
               str(item.get('name')): str(item.get('outcome'))
@@ -782,13 +784,21 @@ jobs:
                   'deployment evidence is missing successful target M1 checks: '
                   f'{failed_m1_checks}'
               )
-          for report_name, report in (
-              ('surface', surface_report),
-              ('capability', capability_report),
+          for report_name, expected_mode, report in (
+              ('surface', 'surface', surface_report),
+              ('capability', 'capability', capability_report),
           ):
+              if (
+                  report.get('schema_version') != 1
+                  or report.get('script') != 'hf_space_smoke'
+                  or report.get('mode') != expected_mode
+              ):
+                  raise SystemExit(f'{report_name} report schema or mode mismatch')
               environment = report.get('environment', {})
               if environment.get('require_target_runtime') is not True:
                   raise SystemExit(f'{report_name} report did not require target runtime')
+              if environment.get('expected_version') != os.environ['VERSION']:
+                  raise SystemExit(f'{report_name} report version mismatch')
               if environment.get('expected_source_sha') != os.environ['CANDIDATE_SHA']:
                   raise SystemExit(f'{report_name} report candidate SHA mismatch')
               if environment.get('expected_wrapper_sha') != os.environ['HFS_SPACE_COMMIT_SHA']:

--- a/scripts/hf_space_smoke.py
+++ b/scripts/hf_space_smoke.py
@@ -366,6 +366,12 @@ def _write_reports(args: argparse.Namespace, mode: str, checks: list[Check]) -> 
         "mode": mode,
         "overall": overall,
         "base_url": args.base_url.rstrip("/"),
+        "environment": {
+            "expected_version": args.expected_version,
+            "expected_source_sha": args.expected_source_sha,
+            "expected_wrapper_sha": args.expected_wrapper_sha,
+            "require_target_runtime": args.require_target_runtime,
+        },
         "checks": [asdict(item) for item in checks],
     }
     lines = [

--- a/tests/test_hf_space_smoke.py
+++ b/tests/test_hf_space_smoke.py
@@ -81,8 +81,54 @@ def test_offline_mode_writes_bounded_reports(tmp_path) -> None:
     )
     payload = json.loads(json_path.read_text(encoding="utf-8"))
     assert payload["overall"] == "PASS"
+    assert payload["environment"] == {
+        "expected_version": None,
+        "expected_source_sha": None,
+        "expected_wrapper_sha": None,
+        "require_target_runtime": False,
+    }
     assert payload["checks"][0]["outcome"] == "SKIP"
     assert "HFS target smoke" in markdown_path.read_text(encoding="utf-8")
+
+
+def test_report_records_bounded_provenance_without_auth_tokens(tmp_path) -> None:
+    json_path = tmp_path / "report.json"
+    args = smoke.parse_args(
+        [
+            "--mode",
+            "capability",
+            "--json-report",
+            str(json_path),
+            "--expected-version",
+            "2.0.0rc4",
+            "--expected-source-sha",
+            "a" * 40,
+            "--expected-wrapper-sha",
+            "b" * 40,
+            "--require-target-runtime",
+            "--bearer-token",
+            "application-secret-canary",
+            "--hf-space-token",
+            "edge-secret-canary",
+        ]
+    )
+
+    smoke._write_reports(
+        args,
+        "capability",
+        [smoke.Check("healthz", "PASS", "fixture")],
+    )
+
+    report_text = json_path.read_text(encoding="utf-8")
+    payload = json.loads(report_text)
+    assert payload["environment"] == {
+        "expected_version": "2.0.0rc4",
+        "expected_source_sha": "a" * 40,
+        "expected_wrapper_sha": "b" * 40,
+        "require_target_runtime": True,
+    }
+    assert "application-secret-canary" not in report_text
+    assert "edge-secret-canary" not in report_text
 
 
 def test_target_openapi_path_set_is_exact() -> None:

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -414,22 +414,37 @@ def test_deployment_manifest_builder_emits_bounded_non_release_contract(
     hfs_live = evidence_root / "hfs"
     hfs_live.mkdir()
     report_environment = {
+        "expected_version": "2.0.0rc4",
         "expected_source_sha": candidate,
         "expected_wrapper_sha": promoted,
         "require_target_runtime": True,
     }
     (hfs_live / "hf-space-cd-surface-report.json").write_text(
-        json.dumps({"overall": "PASS", "environment": report_environment, "checks": []}),
+        json.dumps(
+            {
+                "schema_version": 1,
+                "script": "hf_space_smoke",
+                "mode": "surface",
+                "overall": "PASS",
+                "environment": report_environment,
+                "checks": [],
+            }
+        ),
         encoding="utf-8",
     )
     target_checks = [
-        "basic/health",
-        "basic/readiness",
-        "target-m1/openalex-search",
-        "target-m1/builtin-fetch",
-        "target-m1/browser-fetch",
+        "healthz",
+        "readyz",
+        "whoami",
+        "anonymous_admin_rejected",
+        "search_live",
+        "llm_search_live",
+        "fetch_live",
     ]
     capability_payload = {
+        "schema_version": 1,
+        "script": "hf_space_smoke",
+        "mode": "capability",
         "overall": "PASS",
         "environment": report_environment,
         "checks": [{"name": name, "outcome": "PASS"} for name in target_checks],


### PR DESCRIPTION
## Summary

- record bounded version/source/wrapper/target-runtime provenance in HFS smoke JSON without serializing auth tokens
- align deployment evidence validation with the current `hf_space_smoke.py` check names, including required LLM Search
- verify smoke report schema, producer, mode, version, candidate SHA, and wrapper SHA before assembling evidence

## Failure reproduced

[Deployment run 30460728735](https://github.com/BlueSkyXN/SouWen/actions/runs/30460728735) promoted and live-smoked the exact candidate successfully, then failed only in `Write deployment manifest and checksums` because the assembler still expected retired `basic/*` and `target-m1/*` names while the current report emits `healthz`, `readyz`, `search_live`, `llm_search_live`, and `fetch_live`. The current report also omitted the bounded `environment` provenance object that the assembler requires.

## Validation

- `pytest tests/test_hf_space_smoke.py tests/test_release_candidate_workflows.py tests/test_hfs_v2_registry.py -q` — 44 passed
- `ruff check` and `ruff format --check` on changed Python/tests — passed
- `actionlint .github/workflows/release-candidate.yml` — passed
- HFS v2 alignment checker — 0 ERROR / 0 WARN
- `git diff --check` — passed
