### PR TITLE
升级 SouWen HFS v2.1 Preview 与本地明文凭据契约

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -148,6 +148,13 @@ The root [`hfs-dev.toml`](hfs-dev.toml) is a registry-only deployment record for
 source lane, Space ID, workflow ownership, and current Space-setting names. It stores
 no credential values and does not authorize a generic sync tool to change remote settings;
 the current reference `hf_space_sync.py` rejects it before reading `.env` or using the network.
+
+HFS v2.1 explicitly classifies this deployment as `project_class = "preview"` with the
+canonical Space at `target_role = "primary"`. Routine Preview changes may update that canonical
+Space through the existing controlled workflow without a separate candidate Space or promotion
+step. The release workflow's `candidate_sha` remains immutable source evidence; it does not make
+the project a production deployment. Every Space Secret must first exist in the manifest-declared,
+Git-ignored plaintext `.env`; the remote Secret store cannot be the only recoverable source.
 **ModelScope**: see `cloud/modelscope/`.
 
 **WARP proxy embedding** (optional, bypass network restrictions): see the WARP section in `docs/anti-scraping.md`.

--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ docker run -p 8000:49265 \
 根级 [`hfs-dev.toml`](hfs-dev.toml) 是 registry-only 部署登记：记录 source lane、Space ID、
 workflow ownership 和当前 Space setting 名称，不保存任何真实凭据值，也不授权通用同步工具
 修改远端设置；当前参考 `hf_space_sync.py` 会在读取 `.env` 或联网前拒绝该 manifest。
+
+该登记已按 HFS v2.1 明确分类为 `project_class = "preview"`，canonical Space 的角色是
+`target_role = "primary"`。日常 Preview 变更允许通过现有受控 workflow 直接更新 canonical
+Space，不要求另建 candidate Space 或先做 promotion；release workflow 中的 `candidate_sha`
+仍是不可变源码证据，不代表本项目变成生产环境。任何 Space Secret 都必须先写入 manifest
+声明的 Git ignored 本地明文 `.env`，远端 Secret 不能成为唯一事实源。
 **ModelScope**：参见 `cloud/modelscope/`。
 
 部署环境可按自身网络策略配置代理；公开 API 不提供 WARP 管理或运行时安装入口。

--- a/hfs-dev.toml
+++ b/hfs-dev.toml
@@ -1,13 +1,17 @@
-# HFS v2 deployment registry. This file records names and ownership only;
+# HFS v2.1 deployment registry. This file records names and ownership only;
 # real values remain in the gitignored root .env and remote secret stores.
-standard = "2.0"
+standard = "2.1"
 # Preserve the existing project/Space identity; this source lane creates no
 # hfs-dist bucket and does not authorize a Space rename.
 project = "SouWen"
 space = "BlueSkyXN/SouWen"
+project_class = "preview"
+target_role = "primary"
 sovereignty = "sovereign"
 lane = "source"
 version_source = "commit"
+env_file = ".env"
+secret_files = []
 
 # SouWen keeps its candidate-pinned GitHub Actions transaction as the only
 # remote settings writer. This registry does not authorize generic

--- a/tests/test_hfs_v2_registry.py
+++ b/tests/test_hfs_v2_registry.py
@@ -10,12 +10,16 @@ def test_hfs_v2_registry_is_source_lane_and_registry_only() -> None:
     manifest = (REPO_ROOT / "hfs-dev.toml").read_text(encoding="utf-8")
 
     for declaration in (
-        'standard = "2.0"',
+        'standard = "2.1"',
         'project = "SouWen"',
         'space = "BlueSkyXN/SouWen"',
+        'project_class = "preview"',
+        'target_role = "primary"',
         'sovereignty = "sovereign"',
         'lane = "source"',
         'version_source = "commit"',
+        'env_file = ".env"',
+        "secret_files = []",
         'operation_mode = "registry-only"',
         'dist_bucket = ""',
         "secrets = []",


### PR DESCRIPTION
## 结果

将 SouWen 的 canonical HFS 明确归类为 Preview，并升级到 HFS v2.1。registry-only 模式继续保持，但 manifest 现在明确声明 primary 角色和本地明文 env 事实源。

本 PR 不包含真实凭据，也未修改或部署 Hugging Face Space。

## 主要变更

- manifest 新增 `project_class = "preview"`、`target_role = "primary"`、`env_file = ".env"` 和 `secret_files = []`。
- README/README.en 同步说明 Preview 可直接修改 canonical Space 后读回和 smoke。
- registry test 冻结 v2.1 分类与本地明文字段。
- 保留 source lane、commit pin、registry-only 与现有无 managed Settings 的设计。

## 影响与边界

- 不改变 SouWen API、provider、release、wrapper 或运行时行为。
- PR 针对 `main` 打开，尚未合并；没有写入真实 `.env`，也没有执行 HF Settings、部署、重启或业务 smoke。

## 验证

- `pytest tests/test_hfs_v2_registry.py -q`：3 passed。
- manifest TOML 解析和 frozen-field assertions：通过。
- `git diff --check`：通过。
- added-line secret-like scan：未发现真实 token、private key 或凭据值。

## Review focus

请重点复核 registry-only 模式与 v2.1 本地明文事实源声明是否一致，以及文档没有把开放 PR 误述成已部署状态。
