### PR TITLE
完善 SouWen HFS 在线预览、部署事务与验收文档

### DIFF
--- a/.github/workflows/deploy-hf-space.yml
+++ b/.github/workflows/deploy-hf-space.yml
@@ -313,13 +313,13 @@ jobs:
     needs: [detect-changes, delivery-contracts, docker-hfs]
     environment:
       name: hf
-      deployment: false
     runs-on: ubuntu-latest
     timeout-minutes: 20
     outputs:
       version: ${{ steps.project.outputs.version }}
       space_commit_sha: ${{ steps.sync.outputs.space_commit_sha }}
       promotion_changed: ${{ steps.sync.outputs.promotion_changed }}
+      settings_mutation_started: ${{ steps.settings_mutation.outputs.settings_mutation_started }}
       prior_space_commit_sha: ${{ steps.prior.outputs.prior_space_commit_sha }}
       prior_runtime_commit_sha: ${{ steps.prior.outputs.prior_runtime_commit_sha }}
       prior_souwen_ref: ${{ steps.prior.outputs.prior_souwen_ref }}
@@ -509,7 +509,7 @@ jobs:
           if len(matches) != 1:
               raise SystemExit(
                   "target Space Dockerfile must contain exactly one immutable SOUWEN_REF "
-                  "before automatic promotion/rollback is allowed"
+                  "before automatic promotion or operator-led recovery is allowed"
               )
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
               output.write(f"prior_space_commit_sha={prior_space_sha}\n")
@@ -521,6 +521,54 @@ jobs:
               f"runtime={runtime_sha}, stage={stage}, source={matches[0]}"
           )
           PY
+
+      - name: Preflight managed HFS Space Secret names
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_SPACE_ID: BlueSkyXN/SouWen
+        run: |
+          python -I - <<'PY'
+          import os
+
+          from huggingface_hub import HfApi
+          from huggingface_hub.utils import build_hf_headers, get_session, hf_raise_for_status
+
+          token = os.environ["HF_TOKEN"]
+          space_id = os.environ["HF_SPACE_ID"]
+          expected_names = {
+              "SOUWEN_ADMIN_PASSWORD",
+              "SOUWEN_CONFIG_B64",
+              "UNIAPI_API_KEY",
+          }
+          api = HfApi(token=token)
+
+          def read_secret_names() -> set[str]:
+              response = get_session().get(
+                  f"{api.endpoint}/api/spaces/{space_id}/secrets",
+                  headers=build_hf_headers(token=token),
+                  timeout=30.0,
+              )
+              hf_raise_for_status(response)
+              payload = response.json()
+              if not isinstance(payload, dict) or not all(
+                  isinstance(name, str) for name in payload
+              ):
+                  raise SystemExit("Space Secret name readback returned an unexpected schema")
+              return set(payload)
+
+          existing_names = read_secret_names()
+          unexpected_names = existing_names - expected_names
+          if unexpected_names:
+              raise SystemExit(
+                  "refusing to modify Space settings with unregistered Secret names: "
+                  + ", ".join(sorted(unexpected_names))
+              )
+          print("Managed Space Secret name preflight passed")
+          PY
+
+      - name: Mark settings mutation phase
+        id: settings_mutation
+        run: echo "settings_mutation_started=true" >> "$GITHUB_OUTPUT"
 
       - name: Sync managed HFS Space secrets
         env:
@@ -559,14 +607,6 @@ jobs:
               ):
                   raise SystemExit("Space Secret name readback returned an unexpected schema")
               return set(payload)
-
-          existing_names = read_secret_names()
-          unexpected_names = existing_names - expected_names
-          if unexpected_names:
-              raise SystemExit(
-                  "refusing to modify Space settings with unregistered Secret names: "
-                  + ", ".join(sorted(unexpected_names))
-              )
 
           for key, value in managed.items():
               api.add_space_secret(
@@ -802,7 +842,6 @@ jobs:
     needs: [detect-changes, sync-hfs-wrapper, rebuild-space]
     environment:
       name: hf
-      deployment: false
     runs-on: ubuntu-latest
     timeout-minutes: 120
     strategy:
@@ -895,14 +934,15 @@ jobs:
             ${{ matrix.json }}
           if-no-files-found: warn
 
-  rollback-space:
-    name: Restore previous Space revision after failed promotion
+  contain-space:
+    name: Pause Space after failed settings-aware promotion
     needs: [sync-hfs-wrapper, rebuild-space, post-deploy-smoke]
     if: >-
       ${{
         always() &&
         inputs.deploy_hfs &&
         needs.sync-hfs-wrapper.outputs.prior_space_commit_sha != '' &&
+        needs.sync-hfs-wrapper.outputs.settings_mutation_started == 'true' &&
         (
           needs.sync-hfs-wrapper.result != 'success' ||
           needs.rebuild-space.result != 'success' ||
@@ -911,11 +951,8 @@ jobs:
       }}
     environment:
       name: hf
-      deployment: false
     runs-on: ubuntu-latest
-    timeout-minutes: 40
-    outputs:
-      rollback_space_commit_sha: ${{ steps.restore.outputs.rollback_space_commit_sha }}
+    timeout-minutes: 10
     steps:
       - uses: actions/setup-python@v7
         with:
@@ -924,218 +961,55 @@ jobs:
       - name: Install Hugging Face Hub client
         run: python -m pip install "huggingface_hub>=1.8,<2"
 
-      - name: Restore managed wrapper files and verify live source
-        id: restore
+      - name: Pause and verify Space runtime
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-          HF_SPACE_READ_TOKEN: ${{ secrets.HF_SPACE_READ_TOKEN }}
           HF_SPACE_ID: BlueSkyXN/SouWen
-          HF_SPACE_URL: https://blueskyxn-souwen.hf.space
-          PRIOR_SPACE_SHA: ${{ needs.sync-hfs-wrapper.outputs.prior_space_commit_sha }}
-          PRIOR_SOUWEN_REF: ${{ needs.sync-hfs-wrapper.outputs.prior_souwen_ref }}
-          PROMOTED_SPACE_SHA: ${{ needs.sync-hfs-wrapper.outputs.space_commit_sha }}
         run: |
           python -I - <<'PY'
-          import json
           import os
-          import re
-          import tempfile
           import time
-          from pathlib import Path
-          from urllib.request import Request, urlopen
+          from huggingface_hub import HfApi
 
-          from huggingface_hub import (
-              CommitOperationAdd,
-              CommitOperationDelete,
-              HfApi,
-              hf_hub_download,
-          )
-          from huggingface_hub.errors import EntryNotFoundError
-
-          MANAGED_FILES = ("Dockerfile", "README.md", ".dockerignore", "entrypoint.sh")
-
-          hf_token = os.environ.get("HF_TOKEN", "")
-          read_token = os.environ.get("HF_SPACE_READ_TOKEN", "")
-          if not hf_token or not read_token:
-              raise SystemExit(
-                  "HF_TOKEN and HF_SPACE_READ_TOKEN are required for verified rollback"
-              )
-          prior_sha = os.environ["PRIOR_SPACE_SHA"]
-          prior_source = os.environ["PRIOR_SOUWEN_REF"]
-          promoted_sha = os.environ.get("PROMOTED_SPACE_SHA", "")
-          if re.fullmatch(r"[0-9a-f]{40}", prior_sha) is None:
-              raise SystemExit("rollback point is not an immutable Space commit")
-          if re.fullmatch(r"[0-9a-f]{40}", prior_source) is None:
-              raise SystemExit("rollback point does not contain an immutable SouWen source SHA")
-
-          api = HfApi(token=hf_token)
+          token = os.environ.get("HF_TOKEN", "")
+          if not token:
+              raise SystemExit("HF_TOKEN is required to contain a failed promotion")
+          api = HfApi(token=token)
           space_id = os.environ["HF_SPACE_ID"]
-
-          def validate_rollback_probe(payload, endpoint, expected_source, expected_wrapper):
-              if payload.get("source_sha") != expected_source:
-                  raise SystemExit(
-                      f"rollback {endpoint} source mismatch: "
-                      f"expected={expected_source}, actual={payload.get('source_sha')}"
-                  )
-              if "wrapper_sha" in payload and payload["wrapper_sha"] != expected_wrapper:
-                  raise SystemExit(
-                      f"rollback {endpoint} wrapper mismatch: "
-                      f"expected={expected_wrapper}, actual={payload['wrapper_sha']}"
-                  )
-
-          current_sha = str(api.repo_info(repo_id=space_id, repo_type="space").sha)
-          allowed_heads = {prior_sha}
-          if re.fullmatch(r"[0-9a-f]{40}", promoted_sha):
-              allowed_heads.add(promoted_sha)
-          if current_sha not in allowed_heads:
-              raise SystemExit(
-                  "refusing to overwrite an unexpected Space writer during rollback: "
-                  f"current={current_sha}, expected one of {sorted(allowed_heads)}"
-              )
-          operations = []
-          with tempfile.TemporaryDirectory() as tmpdir:
-              tmp = Path(tmpdir)
-              for filename in MANAGED_FILES:
-                  try:
-                      prior_path = hf_hub_download(
-                          repo_id=space_id,
-                          repo_type="space",
-                          filename=filename,
-                          revision=prior_sha,
-                          token=hf_token,
-                          local_dir=tmp / "prior",
-                          force_download=True,
-                      )
-                      prior_bytes = Path(prior_path).read_bytes()
-                  except EntryNotFoundError:
-                      prior_bytes = None
-                  try:
-                      current_path = hf_hub_download(
-                          repo_id=space_id,
-                          repo_type="space",
-                          filename=filename,
-                          revision=current_sha,
-                          token=hf_token,
-                          local_dir=tmp / "current",
-                          force_download=True,
-                      )
-                      current_bytes = Path(current_path).read_bytes()
-                  except EntryNotFoundError:
-                      current_bytes = None
-
-                  if prior_bytes == current_bytes:
-                      continue
-                  if prior_bytes is None:
-                      operations.append(CommitOperationDelete(path_in_repo=filename))
-                  else:
-                      operations.append(
-                          CommitOperationAdd(
-                              path_in_repo=filename,
-                              path_or_fileobj=prior_bytes,
-                          )
-                      )
-
-          if not operations:
-              if current_sha != prior_sha:
-                  raise SystemExit("rollback found no managed wrapper difference to restore")
-              rollback_sha = prior_sha
-              print(
-                  "Space head still matches the rollback point; rebuilding and validating "
-                  "the prior runtime without creating a no-op commit"
-              )
-          else:
-              rollback = api.create_commit(
-                  repo_id=space_id,
-                  repo_type="space",
-                  operations=operations,
-                  commit_message=f"Rollback failed SouWen promotion to {prior_source[:12]}",
-                  parent_commit=current_sha,
-              )
-              rollback_sha = str(rollback.oid)
-          variables = api.add_space_variable(
-              repo_id=space_id,
-              key="SOUWEN_WRAPPER_SHA",
-              value=rollback_sha,
-              description="Managed by the SouWen deployment transaction",
-          )
-          wrapper_variable = variables.get("SOUWEN_WRAPPER_SHA")
-          if getattr(wrapper_variable, "value", None) != rollback_sha:
-              raise SystemExit("rollback SOUWEN_WRAPPER_SHA variable readback mismatch")
-          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
-              output.write(f"rollback_space_commit_sha={rollback_sha}\n")
-
-          restored_dockerfile = Path(
-              hf_hub_download(
-                  repo_id=space_id,
-                  repo_type="space",
-                  filename="Dockerfile",
-                  revision=rollback_sha,
-                  token=hf_token,
-                  force_download=True,
-              )
-          ).read_text(encoding="utf-8")
-          if restored_dockerfile.splitlines().count(
-              f"ARG SOUWEN_REF={prior_source}"
-          ) != 1:
-              raise SystemExit("rollback commit does not restore the prior SouWen source pin")
-
-          api.restart_space(repo_id=space_id, factory_reboot=True)
-          deadline = time.monotonic() + 900
+          api.pause_space(repo_id=space_id)
+          deadline = time.monotonic() + 300
           last_stage = "unknown"
-          last_runtime_sha = "unknown"
           while time.monotonic() < deadline:
               runtime = api.get_space_runtime(repo_id=space_id)
               last_stage = str(getattr(runtime.stage, "value", runtime.stage))
-              last_runtime_sha = str(runtime.raw.get("sha") or "")
-              repo_sha = str(api.repo_info(repo_id=space_id, repo_type="space").sha)
-              print(
-                  f"rollback stage={last_stage}, repo_sha={repo_sha}, "
-                  f"runtime_sha={last_runtime_sha}, expected={rollback_sha}"
-              )
-              if (
-                  last_stage.upper().endswith("RUNNING")
-                  and repo_sha == rollback_sha
-                  and last_runtime_sha == rollback_sha
-              ):
+              print(f"containment stage={last_stage}")
+              if "PAUSED" in last_stage.upper():
+                  print(
+                      f"Space {space_id} is paused after a failed promotion; "
+                      "write-only Space Secret values require manual recovery"
+                  )
                   break
-              time.sleep(20)
+              time.sleep(10)
           else:
               raise SystemExit(
-                  "rollback runtime did not take over the forward rollback commit: "
-                  f"stage={last_stage}, runtime_sha={last_runtime_sha}, expected={rollback_sha}"
+                  f"Space containment could not be verified; last stage={last_stage}"
               )
-
-          for endpoint in ("/healthz", "/readyz"):
-              request = Request(
-                  f"{os.environ['HF_SPACE_URL']}{endpoint}",
-                  headers={
-                      "Accept": "application/json",
-                      "Authorization": f"Bearer {read_token}",
-                  },
-              )
-              with urlopen(request, timeout=30) as response:  # noqa: S310 - fixed Space URL
-                  payload = json.loads(response.read().decode("utf-8"))
-              validate_rollback_probe(payload, endpoint, prior_source, rollback_sha)
-          print(
-              f"rollback verified: wrapper/runtime={rollback_sha}, source={prior_source}"
-          )
           PY
 
   pause-space:
-    name: Pause Space when automatic rollback cannot be proven
-    needs: rollback-space
+    name: Retry containment when the first pause cannot be proven
+    needs: contain-space
     if: >-
       ${{
         always() &&
         inputs.deploy_hfs &&
         (
-          needs.rollback-space.result == 'failure' ||
-          needs.rollback-space.result == 'cancelled'
+          needs.contain-space.result == 'failure' ||
+          needs.contain-space.result == 'cancelled'
         )
       }}
     environment:
       name: hf
-      deployment: false
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -1170,7 +1044,7 @@ jobs:
               last_stage = str(getattr(runtime.stage, "value", runtime.stage))
               print(f"pause stage={last_stage}")
               if "PAUSED" in last_stage.upper():
-                  print(f"Space {space_id} is paused after rollback failure")
+                  print(f"Space {space_id} is paused after containment retry")
                   break
               time.sleep(10)
           else:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,40 @@
 
 ## 导航
 
-- [Souwen v2rc4 source candidate](#v200rc4--release-candidate2026-07-29-source-candidate)
+- [Unreleased main](#unreleased-main--post-rc4-maintenance)
+- [Souwen v2rc4 release candidate](#v200rc4--release-candidate2026-07-29)
 - [Souwen v2rc3 release candidate](#v200rc3--release-candidate2026-07-28)
 - [Souwen v2rc2 release candidate](#v200rc2--release-candidate2026-07-27)
 - [v1.x history](#v112--ai-workflow-安全加固与功能深化2026-05-04)
 - [v0.x history](#v090--v1-过渡版2026-04-22)
 
-> v2 段落记录当前 source candidate、已发布 RC 的公开变更和验证边界；v1/v0 段落保留历史审计脉络。
+> v2 段落记录当前 main、已发布 RC 的公开变更和验证边界；v1/v0 段落保留历史审计脉络。
 
-## v2.0.0rc4 — Release Candidate（2026-07-29 source candidate）
+## Unreleased main — post-RC4 maintenance
+
+- `v2.0.0rc4` tag 与 GitHub prerelease 保持 immutable；main 在 tag 之后的修改不会覆盖或移动
+  既有 tag。HFS 可以通过 `evidence_profile=deployment, publish=false` 部署 exact current main，
+  但 deployment evidence 不是 RC4 Release assets。
+- Panel 按 Calm Precision 0.4 补齐稳定边缘、light/dark、窄屏、键盘焦点与明确状态层；HFS/GitHub
+  文档新增全部 workspace 的直达 preview、角色和逐项验收。Search 表单改为单领域选择，避免在
+  未显式 Provider 时发送 Server contract 必然拒绝的多 domain 默认请求。
+- HFS v2.1 draft registry（正式公开基线仍为 v2.0）显式声明 `preview` / `primary` / `source`、
+  commit version source、根 `.env` env 事实源，以及 `SOUWEN_CONFIG_B64` 对应的 gitignored 原始
+  YAML 事实源；settings ownership 精确收敛到三个 workflow-managed Space Secrets 和一个
+  provenance Variable。Secret 值 write-only，失败后不再用“旧 wrapper + 新/部分 settings”
+  自动恢复，而是 fail closed pause，等待使用获批 Secret source 人工恢复。
+- HFS surface smoke 增加 authenticated admin config/ping/doctor 正向检查，并对 config 中未脱敏的
+  credential-shaped string fail closed。
+- 修正 Docker 文档：应用配置只读挂载到 `/app/souwen.yaml`，`/app/data` 专用于 WARP/runtime
+  persistence。
+
+## v2.0.0rc4 — Release Candidate（2026-07-29）
 
 ### Release status
 
-- 当前仓库源码候选为 **Souwen v2rc4**：Python/runtime/OpenAPI/SDK 为 `2.0.0rc4`，Panel
-  为 `2.0.0-rc4`。本节不预先声明 `v2.0.0rc4` tag、GitHub prerelease 或 HFS promotion
-  已完成；发布状态以 exact-main release workflow、GitHub Release 和 HFS 实时读回为准。
+- **Souwen v2rc4** 的 Python/runtime/OpenAPI/SDK 为 `2.0.0rc4`，Panel 为
+  `2.0.0-rc4`。Annotated tag `v2.0.0rc4` 与 GitHub prerelease 已发布，精确指向
+  source `51f092841696b1e6f898e7c6bea40e535f639f5c`，Release 包含 12 项正式 asset。
 - RC4 保持 API major 2 与 RC3 的 target-only Search、LLM Search、Fetch 和 Provider Catalog
   契约。RC3→RC4 OpenAPI semantic diff 只有 release version 变化，不引入 API shape 变更。
 - Panel 收敛为更明确的搜索引擎 Console 视觉，保留既有导航、generated SDK、认证、状态管理
@@ -25,8 +44,12 @@
   `@vitejs/plugin-react` `5.2.0`，继续使用 npm、Vitest 和 single-file embedded artifact。
 - Ruff 升级到 `0.16.0`，同时显式固定既有 `E4`/`E7`/`E9`/`F` lint policy；RC4 不把
   Ruff 0.16 新默认规则引发的全仓批量改写混入 release diff。
-- RC4 仍不是 `2.0.0` GA，不发布到 PyPI；正式 tag、12 项资产和 HFS promotion 只能由
-  repository-owner 在 exact-main candidate 上通过 central release workflow 创建。
+- 正式 release workflow
+  [`30444286311`](https://github.com/BlueSkyXN/SouWen/actions/runs/30444286311) 在同一 source
+  上完成四个平台 Server bundle、wheel/sdist、OpenAPI、SBOM、checksums、attestation、HFS
+  promotion 及 surface/capability smoke。RC4 仍不是 `2.0.0` GA，也未发布到 PyPI。
+- HFS 是可变运行环境，后续 deployment profile 可以运行 tag 之后的 main 修复；当前 runtime
+  必须单独回读，不能由本 changelog 或相同的 `2.0.0rc4` version string 替代。
 
 ## v2.0.0rc3 — Release Candidate（2026-07-28）
 

--- a/README.en.md
+++ b/README.en.md
@@ -8,12 +8,11 @@
 [![License](https://img.shields.io/badge/license-GPLv3-blue)](LICENSE)
 [![Version](https://img.shields.io/badge/version-2.0.0rc4-orange)](CHANGELOG.md)
 
-> The current candidate is **Souwen v2rc4** (Python/runtime `2.0.0rc4`). The
-> `v2.0.0rc4` tag, GitHub prerelease, and HFS promotion may be created only after
-> all exact-candidate release gates pass. The published
-> [`v2.0.0rc3`](https://github.com/BlueSkyXN/SouWen/releases/tag/v2.0.0rc3) remains
-> the previous immutable baseline; use GitHub Releases and live HFS readback for current status.
-> This is not the `2.0.0` GA and is not published on PyPI.
+> The published **[Souwen v2rc4](https://github.com/BlueSkyXN/SouWen/releases/tag/v2.0.0rc4)**
+> (Python/runtime `2.0.0rc4`) is the immutable Release baseline. Its tag points exactly to
+> `51f092841696b1e6f898e7c6bea40e535f639f5c` and carries 12 assets. `main` may contain
+> post-tag fixes and HFS may deploy exact current main; that deployment neither moves the RC4
+> tag nor updates its Release assets. This is not the `2.0.0` GA and is not published on PyPI.
 
 **Author**: [@BlueSkyXN](https://github.com/BlueSkyXN) · **Repository**: [github.com/BlueSkyXN/SouWen](https://github.com/BlueSkyXN/SouWen) · **License**: [GPLv3](LICENSE)
 
@@ -24,6 +23,7 @@
 ## 📖 Table of Contents
 
 - [Introduction](#-introduction)
+- [Live Preview](#-live-preview)
 - [Installation](#-installation)
 - [Quick Start](#-quick-start)
 - [Configuration](#️-configuration)
@@ -50,6 +50,17 @@ is their safe runtime projection.
 - **Frozen OpenAPI and generated SDKs**: the Python root exposes generated sync/async SDK clients; Panel uses the generated TypeScript SDK
 - **Canonical DTOs** for Search, LLM Search, Fetch, Provider Catalog, and probes
 - **Read-only admin boundary**: config, doctor, and ping only
+
+## 🌐 Live Preview
+
+- Calm Precision Panel: <https://blueskyxn-souwen.hf.space/panel#/>
+- Swagger: <https://blueskyxn-souwen.hf.space/docs>
+- Complete routes, roles, and acceptance steps: [HFS live preview guide](docs/live-preview.md)
+
+The Space repository remains private. The current App domain exposes the Panel/docs/probe
+surface for preview, while Search, LLM Search, Fetch, Providers, and Admin APIs still require a
+SouWen application credential. HFS is a mutable current-main deployment and must not be treated
+as a tag-exact GitHub Release based on the version string alone.
 
 ## 📦 Installation
 
@@ -139,15 +150,21 @@ docker build -t souwen .
 docker run -p 8000:49265 \
   -e SOUWEN_ADMIN_PASSWORD=your-admin-password \
   -e SOUWEN_USER_PASSWORD=your-user-password \
-  -v ~/.config/souwen:/app/data \
+  -v "$PWD/souwen.yaml:/app/souwen.yaml:ro" \
+  -v souwen-data:/app/data \
   souwen
 ```
+
+`/app/souwen.yaml` is the application config; `/app/data` is only for WARP/runtime persistence.
 
 **HuggingFace Spaces**: see `cloud/hfs/` and [docs/hf-space-cd.md](docs/hf-space-cd.md).
 The root [`hfs-dev.toml`](hfs-dev.toml) is a registry-only deployment record for the
 source lane, Space ID, workflow ownership, and current Space-setting names. It stores
 no credential values and does not authorize a generic sync tool to change remote settings;
 the current reference `hf_space_sync.py` rejects it before reading `.env` or using the network.
+It adopts the current HFS v2.1 draft schema (the published baseline remains v2.0) and registers
+the gitignored, mode-`0600` `local/credentials/souwen-hfs.yaml` as the raw YAML fact source from
+which `SOUWEN_CONFIG_B64` is derived.
 **ModelScope**: see `cloud/modelscope/`.
 
 **WARP proxy embedding** (optional, bypass network restrictions): see the WARP section in `docs/anti-scraping.md`.
@@ -164,6 +181,7 @@ the current reference `hf_space_sync.py` rejects it before reading `.env` or usi
 - [docs/configuration.md](docs/configuration.md) — Configuration hierarchy / WARP / HTTP backend
 - [docs/api-reference.md](docs/api-reference.md) — REST API reference
 - [docs/hf-space-cd.md](docs/hf-space-cd.md) — Hugging Face Space CD / local gates / post-deploy validation
+- [docs/live-preview.md](docs/live-preview.md) — HFS Panel/Swagger, role matrix, and feature acceptance
 - [docs/deployment.md](docs/deployment.md) — Deployment
 - [docs/anti-scraping.md](docs/anti-scraping.md) — TLS fingerprinting / WARP / rate limiting
 - [docs/appearance.md](docs/appearance.md) — Calm Precision Panel

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 [![License](https://img.shields.io/badge/license-GPLv3-blue)](LICENSE)
 [![Version](https://img.shields.io/badge/version-2.0.0rc4-orange)](CHANGELOG.md)
 
-> 当前候选版本为 **Souwen v2rc4**（Python/runtime `2.0.0rc4`）。`v2.0.0rc4` tag、
-> GitHub prerelease 与 HFS promotion 只有在 exact-candidate release gates 全部通过后才能创建；
-> 已发布的 [`v2.0.0rc3`](https://github.com/BlueSkyXN/SouWen/releases/tag/v2.0.0rc3)
-> 保留为上一 immutable baseline，当前发布状态以 GitHub Releases 和 HFS 实时读回为准。
-> 这不是 `2.0.0` GA，也尚未发布到 PyPI。
+> 已发布的 **[Souwen v2rc4](https://github.com/BlueSkyXN/SouWen/releases/tag/v2.0.0rc4)**
+> （Python/runtime `2.0.0rc4`）是 immutable Release baseline，tag 精确指向
+> `51f092841696b1e6f898e7c6bea40e535f639f5c` 并包含 12 项资产。`main` 可以包含 tag 后修复，
+> HFS 也可以部署 exact current main；这种 deployment 不会移动 RC4 tag，也不代表 Release
+> 资产已更新。这不是 `2.0.0` GA，也未发布到 PyPI。
 
 **作者**: [@BlueSkyXN](https://github.com/BlueSkyXN) · **项目地址**: [github.com/BlueSkyXN/SouWen](https://github.com/BlueSkyXN/SouWen) · **协议**: [GPLv3](LICENSE)
 
@@ -23,6 +23,7 @@
 ## 📖 目录
 
 - [简介](#-简介)
+- [在线预览](#-在线预览)
 - [安装](#-安装)
 - [快速开始](#-快速开始)
 - [配置](#️-配置)
@@ -50,6 +51,16 @@ SouWen（搜文）为 AI Agent、Python 集成和服务端应用提供统一的 
 - **Frozen OpenAPI + generated SDK**：Python root 只暴露 generated sync/async SDK；Panel 使用同一 OpenAPI 生成的 TypeScript SDK
 - **统一 canonical DTO**：Search、LLM Search、Fetch、Provider Catalog 和 probes 使用明确的 Pydantic v2 contract
 - **安全边界**：target Data API 使用 user credential；Admin 仅提供 read-only config、doctor 与 ping
+
+## 🌐 在线预览
+
+- Calm Precision Panel：<https://blueskyxn-souwen.hf.space/panel#/>
+- Swagger：<https://blueskyxn-souwen.hf.space/docs>
+- 完整 route、角色与逐项验收：[HFS 在线预览与功能验收](docs/live-preview.md)
+
+Space 仓库保持 private；当前 App domain 的 Panel/docs/probes surface 可直接预览，Search、
+LLM Search、Fetch、Providers 和 Admin API 仍要求 SouWen application credential。HFS 是
+可变 current-main deployment，不能仅凭版本号把它当成 tag-exact GitHub Release。
 
 ## 📦 安装
 
@@ -139,14 +150,19 @@ docker build -t souwen .
 docker run -p 8000:49265 \
   -e SOUWEN_ADMIN_PASSWORD=your-admin-password \
   -e SOUWEN_USER_PASSWORD=your-user-password \
-  -v ~/.config/souwen:/app/data \
+  -v "$PWD/souwen.yaml:/app/souwen.yaml:ro" \
+  -v souwen-data:/app/data \
   souwen
 ```
+
+`/app/souwen.yaml` 是应用配置；`/app/data` 只用于 WARP/runtime persistence。
 
 **HuggingFace Spaces**：参见 `cloud/hfs/` 与 [docs/hf-space-cd.md](docs/hf-space-cd.md)。
 根级 [`hfs-dev.toml`](hfs-dev.toml) 是 registry-only 部署登记：记录 source lane、Space ID、
 workflow ownership 和当前 Space setting 名称，不保存任何真实凭据值，也不授权通用同步工具
-修改远端设置；当前参考 `hf_space_sync.py` 会在读取 `.env` 或联网前拒绝该 manifest。
+修改远端设置；当前参考 `hf_space_sync.py` 会在读取 `.env` 或联网前拒绝该 manifest。它采用当前
+HFS v2.1 draft schema（正式公开基线仍为 v2.0），并登记 gitignored、`0600` 的
+`local/credentials/souwen-hfs.yaml` 作为 `SOUWEN_CONFIG_B64` 的原始 YAML 事实源。
 **ModelScope**：参见 `cloud/modelscope/`。
 
 部署环境可按自身网络策略配置代理；公开 API 不提供 WARP 管理或运行时安装入口。
@@ -163,6 +179,7 @@ workflow ownership 和当前 Space setting 名称，不保存任何真实凭据�
 - [docs/configuration.md](docs/configuration.md) — 配置层级 / WARP / HTTP backend
 - [docs/api-reference.md](docs/api-reference.md) — REST API 参考
 - [docs/hf-space-cd.md](docs/hf-space-cd.md) — Hugging Face Space CD / 本地预检 / 部署后验收
+- [docs/live-preview.md](docs/live-preview.md) — HFS 在线 Panel/Swagger、角色矩阵与功能验收
 - [docs/deployment.md](docs/deployment.md) — 部署
 - [docs/anti-scraping.md](docs/anti-scraping.md) — TLS 指纹 / WARP / 限流
 - [docs/appearance.md](docs/appearance.md) — Calm Precision 管理面板

--- a/cloud/hfs/README.md
+++ b/cloud/hfs/README.md
@@ -12,6 +12,27 @@ pinned: false
 
 面向 AI Agent 的 target-only Search、LLM Search 与 Fetch API 服务。
 
+## 在线预览
+
+Space 仓库保持 `private=true`。当前 App domain 允许匿名读取 Panel shell、Swagger、OpenAPI
+和 probes；Data/Admin API 仍要求 SouWen application credential，且 production 不开启
+`SOUWEN_ADMIN_OPEN`。根 App 当前跳转到 Swagger，产品界面请使用 Panel 直达链接。
+
+| Workspace | 直达链接 | 最低角色 |
+|---|---|---|
+| Login | <https://blueskyxn-souwen.hf.space/panel#/login> | 无 |
+| Search | <https://blueskyxn-souwen.hf.space/panel#/search> | user |
+| LLM Search | <https://blueskyxn-souwen.hf.space/panel#/llm-search> | user |
+| Fetch | <https://blueskyxn-souwen.hf.space/panel#/fetch> | user |
+| Providers | <https://blueskyxn-souwen.hf.space/panel#/providers> | user |
+| Runtime | <https://blueskyxn-souwen.hf.space/panel#/runtime> | admin |
+| Settings | <https://blueskyxn-souwen.hf.space/panel#/settings> | admin |
+| Swagger | <https://blueskyxn-souwen.hf.space/docs> | 无 |
+
+Panel 登录框接收 SouWen application token，不接收 HF write token。不要把 token 放进 URL、
+Issue、截图或日志。完整逐项验收见
+[HFS 在线预览指南](https://github.com/BlueSkyXN/SouWen/blob/main/docs/live-preview.md)。
+
 ## RC4 进程拓扑
 
 HFS wrapper 只向外暴露 `49265`。`deploy/process/supervisor.py` 先在
@@ -28,38 +49,37 @@ Worker 异常时 API health 可继续响应，但 `/readyz` 必须 fail closed�
 | GET | `/docs` | OpenAPI / Swagger UI 文档 |
 | GET | `/panel` | 管理面板 HTML；浏览器访问入口为 `/panel#/` |
 | GET | `/openapi.json` | OpenAPI schema |
+| GET | `/api/v1/whoami` | 当前 application role 与安全 feature projection |
 | POST | `/api/v1/search` | RC4 canonical Search |
 | POST | `/api/v1/llm-search` | RC4 canonical LLM Search；正式 promotion 必须配置并 live 验证 |
 | POST | `/api/v1/fetch` | RC4 canonical Fetch + private Browser Worker fallback |
 | GET | `/api/v1/providers` | RC4 Provider availability catalog |
 | GET | `/api/v1/admin/config` | 查看配置（需认证） |
 | GET | `/api/v1/admin/doctor` | 数据源健康检查（需认证） |
+| GET | `/api/v1/admin/ping` | Admin 认证存活检查（需认证） |
 
-## 配置
+## 当前 HFS settings ownership
 
-通过 HuggingFace Spaces 的 **Secrets** 注入环境变量：
+Candidate-pinned GitHub Actions 是唯一 settings writer。Space 当前只登记名称，不在仓库、
+Space card、日志或 evidence 中保存真实值：
 
-| 变量 | 说明 |
-|------|------|
-| `SOUWEN_CONFIG_B64` | Base64 编码的 souwen.yaml 完整配置；同时配置为 GitHub `hf` environment secret 供 promotion fail-fast 校验 |
-| `SOUWEN_USER_PASSWORD` | 用户密码，保护 target Data API（Search/LLM Search/Fetch/Providers） |
-| `SOUWEN_ADMIN_PASSWORD` | 管理密码，保护 read-only admin endpoints |
-| `SOUWEN_GUEST_ENABLED` | 设为 `true` 时允许无 Token 访问搜索端点 |
-| `SOUWEN_ADMIN_OPEN` | 不要在 Space 中配置；private Space 仍必须使用 `SOUWEN_ADMIN_PASSWORD` 保护管理端点 |
-| `SOUWEN_TRUSTED_PROXIES` | 受信反向代理 IP/CIDR 列表，逗号分隔（如 `10.0.0.0/8,127.0.0.1`） |
-| `SOUWEN_EXPOSE_DOCS` | 是否暴露 `/docs`、`/redoc`、`/openapi.json`，生产建议 `false` |
-| `SOUWEN_MAX_CONCURRENCY` | 聚合搜索并发上限，默认 `10`（v0.6.0） |
-| `SOUWEN_OPENALEX_API_KEY` | OpenAlex Freemium API Key（可选；额度/预付余额以账户为准） |
-| `SOUWEN_OPENALEX_EMAIL` | 已弃用兼容字段（当前不发送给 OpenAlex） |
-| `SOUWEN_SEMANTIC_SCHOLAR_API_KEY` | Semantic Scholar API Key |
-| `SOUWEN_CORE_API_KEY` | CORE API Key |
-| `SOUWEN_TAVILY_API_KEY` | Tavily AI 搜索 Key |
-| `SOUWEN_SERPER_API_KEY` | Serper (Google SERP) Key |
-| `SOUWEN_BRAVE_API_KEY` | Brave Search API Key |
-| `WARP_ENABLED` | 设为 `1` 启用内嵌 Cloudflare WARP 代理（突破 IP 限制，常用于 DBLP / Semantic Scholar） |
-| ... | 其他 SOUWEN_* 环境变量均可直接设置 |
+| 类型 | 名称 | 所有权 / 用途 |
+|---|---|---|
+| Secret | `SOUWEN_ADMIN_PASSWORD` | read-only Admin application auth |
+| Secret | `SOUWEN_CONFIG_B64` | 完整 runtime YAML；包含 Data API 访问策略与 Provider 配置 |
+| Secret | `UNIAPI_API_KEY` | 已配置 LLM Search Provider 的环境引用 |
+| Variable | `SOUWEN_WRAPPER_SHA` | 当前 Space wrapper provenance；写入后立即 readback |
 
-> 大部分爬虫引擎（DuckDuckGo、Yahoo、Brave Scraper、Google Scraper 等）无需 API Key 即可使用。
+`SOUWEN_USER_PASSWORD` 不是当前独立 Space Secret 名称；Data API credential 由
+`SOUWEN_CONFIG_B64` 对应的 runtime config 管理。`HF_TOKEN`、`HF_SPACE_READ_TOKEN` 和
+`SOUWEN_SMOKE_BEARER_TOKEN` 属于 GitHub `hf` environment，不是 Space settings。
+
+SouWen 采用当前 HFS v2.1 draft 的 `preview` / `primary` / `source` 分类（正式公开基线仍为
+v2.0）：没有 SouWen Bucket、`hfs-dist` object、Volume、seed 或 mounted config。
+`hfs-dev.toml` 声明根 `.env` 为 mode `0600` 的 env 事实源，并登记同为 gitignored、`0600` 的
+`local/credentials/souwen-hfs.yaml` 作为 `SOUWEN_CONFIG_B64` 的原始 YAML 事实源；Base64 不是
+唯一事实源。Registry 保持 registry-only；通用 `hf_space_sync.py` 不得 push、pull、prune 或改写
+这些 workflow-owned settings。
 
 ## 部署与验收
 
@@ -82,8 +102,15 @@ Search、LLM Search 与 immutable Fetch；禁止回退到 floating `main`。
 - 管理面板：<https://blueskyxn-souwen.hf.space/panel#/>
 - API 文档：<https://blueskyxn-souwen.hf.space/docs>
 
-详细边界见 `docs/hf-space-cd.md`。正式 promotion 的三项 capability live smoke 都是 required；
-任一失败会触发 rollback/pause 流程，不能作为成功发布证据。
+详细边界见
+[HFS CD 与验收](https://github.com/BlueSkyXN/SouWen/blob/main/docs/hf-space-cd.md)。正式
+promotion 的三项 capability live smoke 和 authenticated admin config/ping/doctor 都是 required。
+Secret 值在 Space 端 write-only，因此 settings sync 开始后的任一失败都会 fail closed pause，
+等待人工从获批 Secret source 恢复；不会运行“旧 wrapper + 新/部分 settings”。
+
+`v2.0.0rc4` tag/GitHub prerelease 是 immutable Release baseline。HFS 可以部署 tag 之后的 exact
+current main，并继续报告 package version `2.0.0rc4`；应通过 health/readiness source SHA、Space
+repo/runtime/wrapper SHA 和 exact-source deployment evidence 判断当前部署，不能只看版本号。
 
 ## 源码
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,7 @@ Public docs 不要求读者理解历史路径；需要保留背景材料时，�
 |---|---|
 | [deployment.md](./deployment.md) | Docker、本地服务、部署后回读和运行时保护 |
 | [hf-space-cd.md](./hf-space-cd.md) | Hugging Face Space CD、本地门禁和部署后验收 |
+| [live-preview.md](./live-preview.md) | HFS 在线 Panel/Swagger 入口、角色矩阵与逐项功能验收 |
 | [appearance.md](./appearance.md) | Calm Precision 单一管理面板、权限与构建方式 |
 
 ## Internal docs

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,6 +1,16 @@
 # API 接口参考
 
-SouWen v2 是 target-only API。frozen OpenAPI 公开路径仅为：
+SouWen v2 是 target-only API。canonical contract 有三种查看方式：
+
+- 仓库内 frozen artifact：
+  [`contracts/openapi/souwen-openapi-2.0.0rc4.json`](../contracts/openapi/souwen-openapi-2.0.0rc4.json)
+- 当前 HFS Swagger：<https://blueskyxn-souwen.hf.space/docs>
+- 当前 HFS OpenAPI JSON：<https://blueskyxn-souwen.hf.space/openapi.json>
+
+Frozen artifact 对应 immutable source/version；live URLs 对应当前可变部署。两者版本号相同不代表
+source SHA 相同，部署 provenance 应另从 `/healthz`、HF runtime 和 workflow evidence 回读。
+
+## Canonical paths
 
 | Method | Path | Auth |
 |---|---|---|
@@ -11,14 +21,113 @@ SouWen v2 是 target-only API。frozen OpenAPI 公开路径仅为：
 | GET | `/healthz`、`/readyz` | none |
 | GET | `/health`、`/readiness` | none; 2.x aliases |
 
-客户端可用 `Authorization: Bearer` 或优先的 `X-SouWen-Token`，并应发送
-`X-SouWen-API-Major: 2`。响应含 `X-Request-ID`、`X-SouWen-API-Major` 和固定的
-`X-SouWen-Rollout-Mode: target`。
+客户端可用 `Authorization: Bearer`，或在上游占用 `Authorization` 时使用优先级更高的
+`X-SouWen-Token`。业务请求应发送 `X-SouWen-API-Major: 2`。响应含 `X-Request-ID`、
+`X-SouWen-API-Major` 和固定的 `X-SouWen-Rollout-Mode: target`。
+
+以下示例假设 token 已通过安全方式放入 `SOUWEN_TOKEN`，不要把真实值写入文档、命令历史、
+Issue 或截图：
+
+```bash
+BASE_URL=https://blueskyxn-souwen.hf.space
+AUTH_HEADER="X-SouWen-Token: $SOUWEN_TOKEN"
+```
+
+## Providers
+
+先读取 catalog，再为 Search、LLM Search 和 Fetch 选择 `availability=available` 且声明对应
+capability 的 Provider。不要在客户端维护平行 Provider 清单。
+
+```bash
+curl --fail-with-body "$BASE_URL/api/v1/providers" \
+  -H "$AUTH_HEADER" \
+  -H "X-SouWen-API-Major: 2"
+```
 
 `GET /api/v1/providers` 是 `ProviderManifest` catalog、`ManifestRegistry` 和
-`ProviderManager` 的安全投影。Admin 仅保留 read-only `GET /api/v1/admin/config`、
-`GET /api/v1/admin/doctor`、`GET /api/v1/admin/ping`，仍受 admin auth 保护。
+`ProviderManager` 的安全投影。返回可用性和缺失配置，不返回凭据。
 
-已退休且不存在 replacement alias 的 public surface 包括 `/sources`、旧 `/search/*`、
-legacy `/fetch`、citation/detail/archive-save、recursive crawl、browser-fetch product entry 与旧
-enriched-search。请使用 generated Python/TypeScript SDK，而非手写旧请求形状。
+## Search
+
+```bash
+curl --fail-with-body "$BASE_URL/api/v1/search" \
+  -H "$AUTH_HEADER" \
+  -H "X-SouWen-API-Major: 2" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "retrieval augmented generation",
+    "domains": ["paper"],
+    "providers": [{"id": "openalex", "kind": "search"}],
+    "page": {"limit": 3}
+  }'
+```
+
+响应是 `SearchPage`：`items` 为 canonical results，`page` 提供 limit/cursor，`meta` 和
+`context` 提供本次执行与请求信息。调用方应保留每条结果的 provenance。
+
+## LLM Search
+
+先从 Providers 读取当前 available 的 `llm_search` Provider ID，再替换示例占位符：
+
+```bash
+curl --fail-with-body "$BASE_URL/api/v1/llm-search" \
+  -H "$AUTH_HEADER" \
+  -H "X-SouWen-API-Major: 2" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "What is retrieval augmented generation?",
+    "providers": [{"id": "<available-llm-provider>", "kind": "llm_search"}],
+    "strategy": "single",
+    "max_results_per_provider": 3
+  }'
+```
+
+响应是 `LLMSearchResult`，包含 `answer`、`evidence`、`items` 和始终存在的 `usage` 对象。
+`usage` 只反映 Provider 回报，未知值为 `null`，不能推导平台账单。
+
+## Fetch
+
+```bash
+curl --fail-with-body "$BASE_URL/api/v1/fetch" \
+  -H "$AUTH_HEADER" \
+  -H "X-SouWen-API-Major: 2" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "targets": ["https://example.com/"],
+    "providers": [{"id": "builtin-fetch", "kind": "fetch"}],
+    "strategy": "fallback",
+    "policy": {"respect_robots": true}
+  }'
+```
+
+Fetch 一次接受 1–20 个 `http/https` target。`respect_robots` 只能保持为 `true`；客户端选项
+不能关闭服务端 SSRF、redirect、DNS、robots 或 response-size 保护。每个 `FetchResult` 独立报告
+`success`、`failed` 或 `blocked`，以及自己的 provenance 或安全错误。
+
+## Admin 与 probes
+
+Admin 仅保留 read-only：
+
+| Method | Path | 说明 |
+|---|---|---|
+| GET | `/api/v1/admin/config` | 脱敏配置视图 |
+| GET | `/api/v1/admin/doctor` | Provider 静态 eligibility 与 availability |
+| GET | `/api/v1/admin/ping` | 认证后的轻量存活检查 |
+| GET | `/api/v1/whoami` | 当前角色与 feature projection |
+
+Admin endpoints 必须使用 admin credential。没有密码的 admin access 只在服务端显式设置
+`SOUWEN_ADMIN_OPEN=1` 时存在，HFS production 不允许开启。
+
+`/healthz` 与 `/readyz` 不代表业务匿名开放。`/readyz` 还要求 Browser Worker、目标配置和
+required components ready；部署验收应同时检查 HTTP 200、`rollout_mode=target`、source/wrapper
+SHA 与 component 状态。
+
+## 错误与退休接口
+
+验证错误使用 canonical error envelope；调用方应记录 `X-Request-ID`，不要依赖上游原始异常文本。
+`401/403` 表示 application auth 不满足，`429` 携带 rate-limit headers，`503` readiness 失败时
+不得被当作健康部署。
+
+已退休且不存在 replacement alias 的 public surface 包括 `/sources`、旧 `/search/*`、legacy
+`/fetch`、citation/detail/archive-save、recursive crawl、browser-fetch product entry 与旧
+enriched-search。优先使用 generated Python/TypeScript SDK，而不是手写旧请求形状。

--- a/docs/appearance.md
+++ b/docs/appearance.md
@@ -7,13 +7,33 @@ SouWen 管理面板位于 `panel/`，是一个固定的 React/Vite 管理界面�
 
 面板只提供以下顶层工作区：
 
-1. **Search**：规范化多领域检索。
-2. **LLM Search**：选择 provider 与策略的带证据综合检索。
+1. **Search**：从 13 个领域中选择一个，使用 Server 默认 Provider 完成规范化检索；多 Provider
+   fanout 由显式 SDK/API 请求承担。
+2. **LLM Search**：选择一个当前部署 configured provider，使用固定 `single` 策略完成带证据综合检索。
 3. **Fetch**：受服务端 SSRF、robots 和 provider 策略保护的内容获取。
 4. **Providers**：只读 provider 可用性、能力与缺失配置字段。
 5. **Runtime / Settings**：仅 admin 可见的只读运行诊断和安全姿态摘要。
 
 没有 Paper、Patent、Books、Video、Wayback、Bilibili、Proxy 或 WARP 的独立产品入口。
+
+## 在线预览
+
+当前 HFS Panel 入口为 <https://blueskyxn-souwen.hf.space/panel#/>。五个顶层工作区对应
+六个直达 route：
+
+| Workspace | Route | 角色 |
+|---|---|---|
+| Login | `/panel#/login` | 无 |
+| Search | `/panel#/search` | user / admin |
+| LLM Search | `/panel#/llm-search` | user / admin |
+| Fetch | `/panel#/fetch` | user / admin |
+| Providers | `/panel#/providers` | user / admin |
+| Runtime | `/panel#/runtime` | admin |
+| Settings | `/panel#/settings` | admin |
+
+Space 仓库保持 private，但当前 App domain 的 Panel/docs/probes surface 可匿名打开；业务与管理
+API 仍要求 SouWen application credential。完整登录、逐页操作、light/dark、窄屏、键盘和
+release/deployment 证据边界见 [HFS 在线预览与功能验收](./live-preview.md)。
 
 ## 数据与权限边界
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -33,7 +33,7 @@ gh workflow run release-candidate.yml \
   target-native smoke、同 candidate inventory 和一致的 OpenAPI checksum。
 - `deployment` 必须同时使用 `deploy_hfs=true, publish=false`。它跳过外层 `server-bundles`
   release job，但保留全部非 binary gate、HFS reusable workflow 的 target Server local preflight、
-  live promotion、rollback 和 readback，产出不可发布的
+  live promotion、fail-closed containment 和 readback，产出不可发布的
   `deployment-evidence-*` artifact。Assembler 还会解析 surface/capability JSON，要求 target
   runtime、Browser Worker readiness、Search、LLM Search 与 immutable Fetch 全部为 `PASS`；
   报告文件仅存在不构成通过。
@@ -111,9 +111,14 @@ docker build -t souwen .
 docker run -p 8000:49265 \
   -e SOUWEN_ADMIN_PASSWORD \
   -e SOUWEN_USER_PASSWORD \
-  -v ~/.config/souwen:/app/data \
+  -v "$PWD/souwen.yaml:/app/souwen.yaml:ro" \
+  -v souwen-data:/app/data \
   souwen
 ```
+
+`/app/souwen.yaml` 是容器工作目录下的应用配置真源；`/app/data` 只承载 WARP/runtime
+persistence。把宿主机配置目录只挂到 `/app/data` 不会让 config loader 读取该文件。只使用
+环境变量时可以省略 `souwen.yaml` mount，但仍可保留独立 data volume。
 
 启动后检查：
 
@@ -188,8 +193,8 @@ contract 继续由 Vitest 覆盖。Server runtime 通过明确 leaf extras 安�
 或 edition package matrix。
 
 PR 与直接运行 `HF Space CD` 只执行 local preflight。远端 promotion 只能由 central RC
-workflow 显式传 `deploy_hfs=true`，并按 [hf-space-cd.md](./hf-space-cd.md) 完成 private edge、
-应用 admin、repo/runtime/source SHA 与 rollback 事务验收。
+workflow 显式传 `deploy_hfs=true`，并按 [hf-space-cd.md](./hf-space-cd.md) 完成 edge compatibility、
+application admin、repo/runtime/source SHA 与 settings-aware containment 验收。
 
 ## 运行时保护
 

--- a/docs/hf-space-cd.md
+++ b/docs/hf-space-cd.md
@@ -1,6 +1,6 @@
 # Hugging Face Space CD 与验收
 
-本文说明 SouWen 的 Hugging Face Space 本地预检、受控 promotion、双层认证、provenance
+本文说明 SouWen 的 Hugging Face Space 本地预检、受控 promotion、访问鉴权、provenance
 与失败恢复边界。RC promotion 还必须满足
 [Souwen v2rc4 发布候选门禁](./internal/rc-readiness-gates.md)。未经明确批准，不得同步 Space
 仓库、factory rebuild、修改 secrets 或触发远端 smoke。
@@ -12,15 +12,18 @@
 - OpenAPI 文档：<https://blueskyxn-souwen.hf.space/docs>
 - Space 仓库：<https://huggingface.co/spaces/BlueSkyXN/SouWen>
 
-目标 Space 必须在 promotion 前已是 `private=true`。仓库可见性与应用鉴权是两个独立结论：
-private Space 的 edge 访问仍需 Hugging Face token；进入应用后，SouWen admin API 还必须由
-独立的 admin password 保护。最小 bootstrap 可以暂时把已确认的目标 Space write token 同时写入
-`HF_TOKEN` 与 `HF_SPACE_READ_TOKEN` 两个 GitHub secret 名称来打通链路；这只是过渡配置，不改变
-两个通道的职责，后续可无代码改动替换为独立 READ token。不能用“Space 是 private”推导“匿名
-请求不可能获得 admin”。
+目标 Space 必须在 promotion 前已是 `private=true`。这只证明 Space 仓库及其控制面可见性，
+不能推导 App domain 的每条 HTTP surface 都被 Hugging Face edge 拒绝。当前部署允许匿名读取
+Panel shell、Swagger、OpenAPI 和 probes；Data/Admin API 仍必须由独立的 SouWen application
+credential 保护。部署后必须分别实测 surface、Data API 和 Admin API，不能用“Space 是 private”
+替代负向鉴权证据。
+
+`HF_TOKEN` 只用于 Space repo/settings/runtime 管理。`HF_SPACE_READ_TOKEN` 让 smoke 与可能启用
+edge gate 的环境兼容；当前 App surface 即使不要求该 token，smoke 仍必须证明 edge-only 或完全匿名
+请求都不能获得 admin。不要为了公开预览而开启 `SOUWEN_ADMIN_OPEN` 或匿名 Data API。
 
 `/panel#/` 中的 `#` 是前端 hash router 片段，不会发送到服务端；服务端实际校验 `/panel`。
-这些固定 URL 在 private Space 下不代表匿名公开可访问，调用方必须遵守 Hugging Face 的访问策略。
+这些固定 URL 的可用性是运行时事实；平台策略变化后应重新读回 HTTP 状态。
 
 ## GitHub Actions 分层
 
@@ -64,15 +67,31 @@ HFS Docker build 必须传 `SOUWEN_REF=<40位 candidate SHA>`。Dockerfile 的�
 镜像无条件安装原生 Playwright Chromium；不提供额外 browser-fetch 产品入口。Supervisor 必须先验证
 Worker readiness，再启动 API。
 
-## Private Space 双层认证
+### 本地明文事实源
 
-Hugging Face 官方 private Space HTTP 入口占用标准 `Authorization: Bearer <HF token>`。
-因此 promotion smoke 使用两个不同 secrets，禁止复用高权限凭据：
+SouWen 当前采用 HFS v2.1 draft registry；正式公开基线仍为 v2.0。Tracked
+`hfs-dev.toml` 只登记名称与路径，不保存真实值。本地事实源分为：
+
+| 路径 | 权限 | 责任 |
+|---|---:|---|
+| `.env` | `0600` | env 值、控制凭据和三个受管 Space Secret 的本地值；不得提交 |
+| `local/credentials/souwen-hfs.yaml` | `0600` | `SOUWEN_CONFIG_B64` 对应的可直接阅读原始 YAML；不得提交 |
+
+`local/credentials/` 必须为 `0700`，两个文件都必须是普通文件且非 symlink。修改 HFS runtime
+配置时先修改原始 YAML，再临时生成 Base64 并更新获批的本地/GitHub Secret source；不得把
+Base64、Space Secret、远端 URL 或 CLI 登录状态当作唯一事实源。Registry-only sentinel 继续在
+读取这些本地值和联网前拒绝通用 `hf_space_sync.py diff/push/pull`。
+
+## Edge compatibility 与 application auth
+
+当 Hugging Face edge 需要 token 时，它占用标准 `Authorization: Bearer <HF token>`。SouWen
+application token 必须走独立的 `X-SouWen-Token`；即使当前 preview surface 匿名可读，也保留
+两个职责不同的 workflow secrets，禁止让 write credential 充当应用密码：
 
 | Secret | 用途 | 请求通道 |
 |---|---|---|
 | `HF_TOKEN` | 写 Space repo、restart/pause runtime | 仅 HFS 管理 API；需要 write 权限 |
-| `HF_SPACE_READ_TOKEN` | 通过 private Space edge | `Authorization: Bearer ...`；目标权限只需 READ，最小 bootstrap 可暂时复用已确认 write token |
+| `HF_SPACE_READ_TOKEN` | 兼容可能启用的 private edge | `Authorization: Bearer ...`；目标权限只需 READ |
 | `SOUWEN_SMOKE_BEARER_TOKEN` | SouWen 应用 admin password | `X-SouWen-Token: ...` |
 | `SOUWEN_CONFIG_B64` | 与 Space 同源的 RC4 配置；promotion 前验证 exact 一个 LLM Search Provider 与 gateway 结构 | 仅 workflow 内存预检；`${VAR}` 是否解析由 post-deploy live smoke 证明 |
 | `UNIAPI_API_KEY` | RC4 UniAPI gateway credential | workflow 将其写入同名 Space Secret；只回读 Secret 名称，不读取或记录值 |
@@ -85,9 +104,9 @@ SouWen 仍以标准 `Authorization: Bearer <password>` 作为普通部署的首�
 Post-deploy harness 从 central workflow 的受信 `verifier_sha` checkout 运行，不执行 candidate
 checkout 中的 secret-bearing 脚本。验收同时证明：
 
-1. `HF_SPACE_READ_TOKEN` 能通过 private edge。
+1. 携带 `HF_SPACE_READ_TOKEN` 时 surface 可按当前 edge 策略访问。
 2. 携带独立 SouWen token 时 `/api/v1/whoami` 为 `role=admin && admin_open=false`。
-3. 只通过 HF edge、不提供 SouWen token 时，不得获得 admin。
+3. 只通过 HF edge 或完全匿名、不提供 SouWen token 时，不得获得 admin 或访问 Data/Admin API。
 
 ## Provenance 三段模型
 
@@ -114,35 +133,34 @@ SHA。
 2. 记录 `prior_space_commit_sha`、`prior_runtime_commit_sha`、`prior_souwen_ref`。旧部署没有
    immutable source pin 时，在写入前停止，不能回退到 floating `main`；同时记录
    `prior_runtime_stage` 供 manifest 和恢复审计。
-3. rollback point 稳定后，workflow 将 `SOUWEN_SMOKE_BEARER_TOKEN` 映射为 Space
-   `SOUWEN_ADMIN_PASSWORD`，并同步 `SOUWEN_CONFIG_B64`、`UNIAPI_API_KEY`。写入前拒绝任何未登记的
-   Space Secret 名称，写入后要求名称集合精确等于 `hfs-dev.toml` 中的三个受管名称；不删除未知
-   Secret，也不输出值、长度、hash 或前缀。
+3. rollback point 稳定后，workflow 先在独立 preflight 中只读 Secret 名称并拒绝任何未登记名称；
+   preflight 失败时没有 settings mutation，也不得暂停原健康 Space。preflight 完成后、第一次写入前，
+   workflow 写出 `settings_mutation_started=true` 事务标记，再将 `SOUWEN_SMOKE_BEARER_TOKEN` 映射为
+   Space `SOUWEN_ADMIN_PASSWORD`，并同步 `SOUWEN_CONFIG_B64`、`UNIAPI_API_KEY`。写入后名称集合必须
+   精确等于 `hfs-dev.toml` 中的三个受管名称；不删除未知 Secret，也不输出值、长度、hash 或前缀。
 4. 只同步受管的四个 wrapper 文件；diff 固定读取 prior revision，`create_commit` 使用
    `parent_commit=<prior_space_commit_sha>` 防止外部 writer 造成 TOCTOU。取得新 commit 后，
-   transaction 写入并立即 readback `SOUWEN_WRAPPER_SHA=<space_commit_sha>` Space variable；
-   rollback 同样改为实际 forward/no-op rollback SHA。
+   transaction 写入并立即 readback `SOUWEN_WRAPPER_SHA=<space_commit_sha>` Space variable。
 5. Factory rebuild，等待 Space repo SHA 与 runtime SHA 等于新的 wrapper commit。
-6. 使用 trusted verifier 完成 surface、target capability、双层 auth 与 candidate/source/
+6. 使用 trusted verifier 完成 surface、target capability、edge/application auth 与 candidate/source/
    wrapper SHA smoke。Required checks 固定覆盖 Search、LLM Search 与 immutable Fetch；readiness
    另行证明 Browser Worker ready 且 source SHA 一致。普通 CI 不做付费 LLM Search live call，
    只有显式 HFS promotion 的 capability smoke 才执行。
 
-若 sync 已取得 rollback point，而 sync/rebuild/post-smoke 任一阶段失败：
+Space Secret 是 write-only：workflow 能读回名称，不能捕获旧值。因此
+`settings_mutation_started=true` 一旦完成，
+任何 sync/rebuild/post-smoke 失败都不能安全地自动恢复成“旧 wrapper + 旧 settings”。失败路径必须：
 
-- wrapper 已改变时，workflow 以 forward commit 恢复 prior revision 的四个受管文件，并再次
-  factory rebuild；
-- 若失败发生在 wrapper 真正改变前、当前 head 仍等于 prior SHA，则不创建 no-op commit，直接
-  factory rebuild 并验证 prior repo/runtime/source 三段状态；验证失败才进入 pause；
-- 创建 forward rollback 时，恢复后的 repo/runtime SHA 等于新的 rollback commit；no-op 恢复
-  则仍等于 prior SHA。两条路径的 health/readiness `source_sha` 都必须等于
-  `prior_souwen_ref`，且都不会 force-rewrite 历史；
-- 如果发现未知外部 writer，或恢复/rebuild/readback 失败，workflow 调用 `pause_space` 并验证
-  `PAUSED`；
-- 原 promotion 仍保持失败，rollback 成功不能把失败验收伪装为 PASS。
+- 调用 `pause_space` 并验证 `PAUSED`，避免旧代码与新/部分 settings 组合继续对外运行；
+- 保留 prior repo/runtime/source snapshot 和失败 run，供人工恢复使用；
+- 从获批的安全 Secret source 恢复相互匹配的 settings，再选择 prior 或 corrected wrapper，factory
+  rebuild 后重新执行完整 surface/capability/provenance smoke；
+- 保持原 promotion 为失败，暂停成功不能把失败验收伪装为 PASS。
 
-GitHub Actions 的 cancel、runner 丢失或平台故障不能保证 rollback job 一定启动，因此失败通知
-仍是人工 hard stop：先只读核对 Space repo/runtime/source 三段状态，再决定恢复或保持 paused。
+这是一条 fail-closed containment 路径，不是自动 rollback。只调整 Secret 与 wrapper 的写入顺序
+无法解决 write-only prior values 缺失。GitHub Actions cancel、runner 丢失或平台故障也不能保证
+containment job 一定启动，因此失败通知仍是人工 hard stop：先只读核对 Space repo/runtime/source
+与 settings names，再决定恢复，未完成恢复前保持 paused。
 
 ## 必测入口
 
@@ -153,7 +171,7 @@ GitHub Actions 的 cancel、runner 丢失或平台故障不能保证 rollback jo
 | API schema | `/openapi.json` | title/version 与暴露策略正确 |
 | API 文档 | `/docs` | Swagger UI 可按策略访问 |
 | 管理面板 | `/panel` | 单文件前端 HTML 可返回 |
-| 鉴权 | `/api/v1/whoami` | 双层 token 获得 admin；缺应用 token 不得为 admin |
+| 鉴权 | `/api/v1/whoami` | 应用 token 获得 admin；edge-only/匿名请求不得为 admin |
 | 控制面 | `/api/v1/admin/config`、`/api/v1/admin/ping` | 只读、脱敏且受 admin auth 保护 |
 | Doctor | `/api/v1/admin/doctor` | 静态状态可读取 |
 
@@ -168,6 +186,7 @@ Search Provider、已配置的 LLM Search Provider 与 immutable Fetch 目标。
   的机器不能把该层标为已验证。
 - PR preflight 失败：修代码、测试或 wrapper，不直接触发远端 promotion。
 - Promotion 前 rollback-point 检查失败：先人工建立可信 immutable baseline，不允许跳过检查。
-- Auth smoke 失败：分别核对 private edge READ token 与 SouWen admin password，不把两个 token
-  合并，也不临时开启 `SOUWEN_ADMIN_OPEN`。
-- 自动 rollback/pause 失败：保持发布 No-Go，按 run 中记录的 prior SHA 做人工恢复并完整回读。
+- Auth smoke 失败：分别核对可选 edge READ token 与 SouWen admin password，不把两个 token合并，
+  也不临时开启 `SOUWEN_ADMIN_OPEN`。
+- 自动 containment/pause 失败：保持发布 No-Go，按 run 中记录的 prior SHA 和获批 Secret source
+  做人工恢复并完整回读。

--- a/docs/internal/adr/0003-browser-fetch-worker.md
+++ b/docs/internal/adr/0003-browser-fetch-worker.md
@@ -226,8 +226,9 @@ functional scripts and GitHub Actions, consistent with repository test policy.
   API port 49265. The Worker remains exact loopback 49266 and the local Docker gate verifies that no
   host mapping exists.
 - Health/readiness now distinguish candidate source, Space wrapper, config revision, rollout mode and
-  Worker source. The HFS transaction manages `SOUWEN_WRAPPER_SHA` with immediate readback and restores
-  it to the actual rollback commit on failure.
+  Worker source. The HFS transaction manages `SOUWEN_WRAPPER_SHA` with immediate readback. Because
+  Space Secret values are write-only, a failed settings-aware promotion pauses the Space for
+  operator-led recovery instead of restoring an old wrapper with new or partial settings.
 - Deployment evidence assembly parses required target M1 receipts rather than trusting artifact
   presence. Live VAL-BFW-007 is not claimed until the merged exact candidate completes the protected
   `deployment` profile and HFS readback; VAL-BFW-008 remains Phase 8 release work.

--- a/docs/internal/development-branching.md
+++ b/docs/internal/development-branching.md
@@ -130,12 +130,12 @@ it from the current `main` workflow revision with an exact 40-character
 3. Accept **RC-ready** only when all 15 always-required gates pass on the exact
    candidate and the evidence bundle inventory/checksums agree.
 4. Merge the approved candidate. Before any HFS write, require
-   `candidate_sha == origin/main`, protected `hf`/`release` environments, private
-   Space dual-layer auth, and an immutable rollback point.
+   `candidate_sha == origin/main`, protected `hf`/`release` environments, a private
+   Space repository, application-auth evidence, and an immutable recovery point.
 5. For a lightweight runtime-only acceptance, use `evidence_profile=deployment`,
    `deploy_hfs=true`, and `publish=false`. This skips the `server-bundles` release
    job but retains non-binary gates, the single HFS-local PyInstaller smoke,
-   promotion, rollback and live readback. Its `deployment-evidence-*` artifact is
+   promotion, fail-closed containment and live readback. Its `deployment-evidence-*` artifact is
    not RC-ready or publish-ready evidence.
 6. An approved `evidence_profile=release`, `deploy_hfs=true`, `publish=false` run
    establishes publish-ready live evidence. `publish=true` additionally creates

--- a/docs/internal/rc-readiness-gates.md
+++ b/docs/internal/rc-readiness-gates.md
@@ -5,10 +5,9 @@ candidate SHA、run URL、checksum、测试计数和部署回读等运行结果�
 而应由发布流水线写入候选专属的 `release-manifest.json` 或
 `deployment-manifest.json` artifact。
 
-> **Phase 8 完成前的执行边界**：RC4 的 `deployment` profile 可用于 P4-07/M1 HFS 验收；
-> `release` profile 已切换为 ADR 0005 的精确四个 PyInstaller Server bundle 与 immutable OpenAPI
-> 契约。旧 24-binary CLI/Nuitka workflow 不参与 central release。旧发布面与 compatibility residue
-> audit 完成前，`release-candidate.yml` 仍必须拒绝 `publish=true`。
+> **RC4 publication boundary**：`v2.0.0rc4` 已作为 immutable tag/prerelease 发布。本文保留其
+> gate contract 供审计；tag 后的 main 只能使用 `deployment, publish=false` 做 HFS 验收，不能覆盖
+> 或移动现有 tag。下一次 publication 必须采用新版本并更新对应 release contract。
 
 ## 判定原则
 
@@ -35,9 +34,9 @@ candidate SHA、run URL、checksum、测试计数和部署回读等运行结果�
 - **RC-ready**：除 HFS promotion 外的 15 个 gate 全部 `PASS`；HFS 为
   `required=false, status=NOT_RUN`。Central workflow 使用 `evidence_profile=release`、
   `publish=false, deploy_hfs=false`，只生成 evidence bundle，不创建 tag/Release、不写 Space。
-- **Publish-ready target**：RC-ready 加上 HFS promotion `PASS`；private edge、SouWen admin、
-  wrapper/runtime/source provenance 和 rollback point 均有证据。只有该状态才允许
-  `evidence_profile=release, publish=true`；Phase 8 residue audit 完成前该状态不可达。
+- **Publish-ready target**：RC-ready 加上 HFS promotion `PASS`；private Space repository、
+  SouWen application auth、wrapper/runtime/source provenance 和 recovery point 均有证据。
+  对已存在的 RC4 tag，该状态只保留为历史 release evidence，不能再次 publish。
 
 `release-candidate.yml` 必须从当前 `origin/main` 的 control-plane workflow 运行；任何
 candidate code 执行前先做 immutable SHA、lineage 与 version static check。无 deploy/publish 的
@@ -217,9 +216,10 @@ RC-ready run 可以验证从 current main 派生的 candidate；任何 secret-be
 ### 15. HFS promotion
 
 - 只有用户明确批准后才能执行远端 promotion；批准前只允许本地/PR gate 和只读检查。
-- Promotion 前要求目标 Space 已为 private，并分离三个 secret：`HF_TOKEN` 写管理面、
-  `HF_SPACE_READ_TOKEN` 通过 private edge、`SOUWEN_SMOKE_BEARER_TOKEN` 作为 SouWen admin
-  password。远端必须 `admin_open=false`；只通过 edge、不提供应用 token 时不得获得 admin。
+- Promotion 前要求目标 Space repository 已为 private，并分离三个 secret：`HF_TOKEN` 写管理面、
+  `HF_SPACE_READ_TOKEN` 兼容可能启用的 edge gate、`SOUWEN_SMOKE_BEARER_TOKEN` 作为 SouWen
+  admin password。远端必须 `admin_open=false`；edge-only 或匿名请求不得获得 admin 或访问
+  Data/Admin API。Panel/docs/probes 是否匿名可读必须按当次 runtime 实测，不能由 repo privacy 推导。
 - Promotion 前记录可信 rollback point：旧 Space repo SHA 等于旧 runtime SHA，旧 Dockerfile
   唯一 pin 40 位 `prior_souwen_ref`，并记录 `prior_runtime_stage`；只接受 `RUNNING` / `SLEEPING`
   稳定状态，不通过 preflight restart 改变 prior runtime。不存在 immutable rollback point 时必须
@@ -228,11 +228,16 @@ RC-ready run 可以验证从 current main 派生的 candidate；任何 secret-be
   `runtime.raw.sha`（必须等于 wrapper commit）、health/readiness `source_sha`（必须等于
   `candidate_sha`）。Wrapper SHA 通常不等于 SouWen source SHA。
 - Surface/capability smoke 必须从 trusted `verifier_sha` 执行，不能把 app admin token 暴露给
-  candidate checkout。失败时以 forward commit 恢复 prior wrapper 内容并验证旧 source；恢复
-  或 readback 无法证明时 pause Space，原 promotion 仍为 FAIL。
+  candidate checkout。它还必须正向检查 authenticated admin config/ping/doctor，并验证 config
+  的 credential-shaped string 已脱敏。
+- Space Secret 值 write-only；Secret name/schema preflight 必须在 mutation marker 前完成，失败时
+  不得 pause 原健康 Space。`settings_mutation_started=true` 必须在第一次写调用前由已完成 step 写出；
+  此后的任一 sync/rebuild/post-smoke 失败必须 pause Space 并验证 `PAUSED`，再从获批 Secret source
+  人工恢复匹配的 settings/wrapper，原 promotion 仍为 FAIL。
 
-**Evidence**：批准记录引用、prior/promoted/rollback Space SHA、source SHA、factory rebuild run、
-surface/capability report、双层 auth/admin-open assertion。`RUNNING` 单独不构成 PASS。
+**Evidence**：批准记录引用、prior/promoted Space SHA、source SHA、factory rebuild run、
+surface/capability report、edge/application auth/admin-open assertion；失败路径另保存 containment
+结果与人工恢复证据。`RUNNING` 单独不构成 PASS。
 
 ### 16. RC assets
 

--- a/docs/live-preview.md
+++ b/docs/live-preview.md
@@ -1,0 +1,89 @@
+# HFS 在线预览与功能验收
+
+本文给出 `BlueSkyXN/SouWen` 当前 HFS 部署的浏览器入口、角色边界和逐项验收步骤。
+它描述的是可变的 current-main deployment，不替代 immutable GitHub Release、tag 或一次性
+workflow artifact。
+
+## 入口与访问模型
+
+- App：<https://blueskyxn-souwen.hf.space/>
+- Panel：<https://blueskyxn-souwen.hf.space/panel#/>
+- Swagger：<https://blueskyxn-souwen.hf.space/docs>
+- Space 仓库：<https://huggingface.co/spaces/BlueSkyXN/SouWen>
+- GitHub Release：<https://github.com/BlueSkyXN/SouWen/releases/tag/v2.0.0rc4>
+
+Hugging Face 控制面的 Space 仓库保持 `private=true`。当前 App domain 允许匿名读取 Panel
+shell、Swagger、OpenAPI 和 probes；这不代表 Data/Admin API 匿名开放。Search、LLM Search、
+Fetch、Providers 和全部 Admin endpoint 仍由 SouWen application credential 保护。
+
+部署或平台策略变化后，不应凭文档推测访问状态：以实际 HTTP 状态、`/api/v1/whoami` 和
+deployment evidence 为准。Panel 登录框只接收 SouWen application token，不接收 HF write
+token，也不会把两个 token 拼接或写入 URL。
+
+## 完整功能矩阵
+
+| 功能 | 直达地址 | 最低角色 | 验收内容 |
+|---|---|---|---|
+| Login | <https://blueskyxn-souwen.hf.space/panel#/login> | 无 | 同源 Server URL、application token、错误提示与会话选项 |
+| Search | <https://blueskyxn-souwen.hf.space/panel#/search> | user | 单领域选择、请求状态、标题、snippet 与规范化结果 |
+| LLM Search | <https://blueskyxn-souwen.hf.space/panel#/llm-search> | user | 单个 configured Provider ID、固定 `single`、综合回答与 evidence |
+| Fetch | <https://blueskyxn-souwen.hf.space/panel#/fetch> | user | 最多 20 个 URL、fallback/fanout、SSRF/robots 保护结果 |
+| Providers | <https://blueskyxn-souwen.hf.space/panel#/providers> | user | 104 个 Provider package 的能力、可用性和缺失配置 |
+| Runtime | <https://blueskyxn-souwen.hf.space/panel#/runtime> | admin | 脱敏、只读的 Provider/runtime 诊断 |
+| Settings | <https://blueskyxn-souwen.hf.space/panel#/settings> | admin | 访问策略、配置数量与 LLM Search 姿态摘要 |
+| Swagger | <https://blueskyxn-souwen.hf.space/docs> | 无 | 当前 runtime OpenAPI 的交互式文档 |
+| OpenAPI JSON | <https://blueskyxn-souwen.hf.space/openapi.json> | 无 | 8 条 canonical public contract paths |
+| Health | <https://blueskyxn-souwen.hf.space/healthz> | 无 | version、source SHA、wrapper SHA、target rollout |
+| Readiness | <https://blueskyxn-souwen.hf.space/readyz> | 无 | API、Provider、LLM Search 与 Browser Worker readiness |
+
+`Runtime / Settings` 是一个顶层导航组，对应两个 admin-only hash route。普通 user token
+会被送回 Search；这属于权限保护，不是路由故障。
+
+## 浏览器验收顺序
+
+1. 打开 Panel。根 App 当前跳转到 Swagger，所以产品界面应使用 `/panel#/` 直达链接。
+2. 在 Login 页保留自动填入的同源 Server URL。输入获批的 SouWen user 或 admin token；不要
+   在 URL、Issue、截图、日志或聊天中粘贴凭据。
+3. 先打开 Providers，确认至少一个 `search`、一个 `llm_search` 和一个 `fetch` Provider 为
+   available。LLM Search 页的 Provider ID 应从这里选择，不使用文档中的硬编码私有配置。
+4. 在 Search 输入研究问题并选择一个领域。未显式指定 Provider 的 Server contract 一次只接受
+   一个 domain；Panel 默认选择 `paper`，避免生成必然失败的多 domain 请求。成功状态应展示规范化结果；
+   零结果应展示明确 empty state，而不是空白页面。
+5. 在 LLM Search 输入问题和一个 available Provider ID。Target runtime 的策略固定为 `single`；
+   成功状态应同时展示回答和 evidence，Provider 错误应进入可读 error state。
+6. 在 Fetch 输入一个获准的公开 `http/https` URL。成功结果应显示 target、status、title/content；
+   内网、非 HTTP scheme 或违反 server policy 的目标必须 fail closed。
+7. 使用 admin token 打开 Runtime 和 Settings。两页都只能读取；页面不得显示 token、password、
+   cookie、credential、API key 或完整私有 endpoint。
+8. 切换 light/dark，并在窄屏下检查所有导航和表单；使用 `Tab` 验证 skip link、焦点环和按钮顺序。
+
+## HTTP 快速核对
+
+不带 application credential 的 surface 与负向鉴权检查：
+
+```bash
+BASE_URL=https://blueskyxn-souwen.hf.space
+curl --fail-with-body "$BASE_URL/healthz"
+curl --fail-with-body "$BASE_URL/readyz"
+curl --fail-with-body "$BASE_URL/openapi.json"
+curl -o /dev/null -sS -w '%{http_code}\n' "$BASE_URL/api/v1/providers"  # 期望 401
+```
+
+受保护接口的调用示例见 [api-reference.md](./api-reference.md)。不要把真实 token 写入 shell
+history；交互测试应使用受控环境变量或 Panel password input。
+
+## Release 与 deployment 边界
+
+`v2.0.0rc4` tag 和 GitHub prerelease 是 immutable release baseline。`main` 可以包含 tag 后的
+修复，HFS 也可以通过 `evidence_profile=deployment, publish=false` 部署 exact current main；
+这样的 runtime 仍报告 package version `2.0.0rc4`，但不能描述为 tag-exact Release assets。
+
+验收 current deployment 时至少同时回读：
+
+1. GitHub `origin/main` 的完整 40 位 SHA。
+2. `/healthz` 与 `/readyz` 的 `source_sha`。
+3. HF Space repo SHA、`runtime.raw.sha` 与 probes 的 `wrapper_sha`。
+4. exact-source deployment run 的 surface/capability reports 与 attestation。
+
+只有这四层一致，才能说明当前 main 已部署并可预览；它们仍不移动既有 tag，也不替代下一版本
+Release 的 publication gate。

--- a/hfs-dev.toml
+++ b/hfs-dev.toml
@@ -1,13 +1,18 @@
-# HFS v2 deployment registry. This file records names and ownership only;
-# real values remain in the gitignored root .env and remote secret stores.
-standard = "2.0"
+# HFS v2.1 draft deployment registry. This file records names and ownership
+# only; real env values remain in the gitignored root .env, while the raw
+# structured runtime configuration remains in local/credentials/.
+standard = "2.1"
 # Preserve the existing project/Space identity; this source lane creates no
 # hfs-dist bucket and does not authorize a Space rename.
 project = "SouWen"
 space = "BlueSkyXN/SouWen"
+project_class = "preview"
+target_role = "primary"
 sovereignty = "sovereign"
 lane = "source"
 version_source = "commit"
+env_file = ".env"
+secret_files = ["local/credentials/souwen-hfs.yaml"]
 
 # SouWen keeps its candidate-pinned GitHub Actions transaction as the only
 # remote settings writer. This registry does not authorize generic
@@ -20,17 +25,28 @@ operation_mode = "registry-only"
 # executable failures instead of relying only on the registry-only comment.
 dist_bucket = ""
 
-# Local control credentials must not be pushed into Space settings.
-local_only = ["GH_TOKEN", "HF_TOKEN"]
+# Local/GitHub control credentials must not be pushed under these names.
+local_only = [
+  "GH_TOKEN",
+  "HF_TOKEN",
+  "HF_SPACE_READ_TOKEN",
+  "SOUWEN_SMOKE_BEARER_TOKEN",
+]
 
 # GitHub environment secrets such as HF_SPACE_READ_TOKEN and
 # SOUWEN_SMOKE_BEARER_TOKEN are owned by the release workflow and are outside
 # the Space-setting schema recorded by this manifest.
 
-# Generic hfs-dev sync write sets are intentionally empty. Current remote names
-# are recorded below under workflow ownership so a generic sync cannot overwrite
-# or prune settings managed by the release transaction.
-secrets = []
+# The v2.1 draft records the real Space Secret names and requires their local
+# values in .env. SOUWEN_CONFIG_B64 is derived from the registered raw YAML;
+# Base64 is not the only fact source. Generic sync remains executable-disabled
+# by the empty dist_bucket sentinel; only the candidate-pinned workflow may
+# write these registered names.
+secrets = [
+  "SOUWEN_ADMIN_PASSWORD",
+  "SOUWEN_CONFIG_B64",
+  "UNIAPI_API_KEY",
+]
 variables = []
 
 # Space Secret values are write-only remotely. Only current key names are
@@ -47,7 +63,8 @@ workflow_owned_secrets = [
 # other outside the existing candidate-pinned workflow.
 
 # The release workflow transaction writes this variable and verifies it by
-# immediate readback during both promotion and rollback.
+# immediate readback during promotion; failed settings-aware promotions pause
+# for operator-led recovery because prior Space Secret values are write-only.
 workflow_owned_variables = ["SOUWEN_WRAPPER_SHA"]
 
 # SouWen has no distribution seed or mounted runtime configuration. The HFS
@@ -56,4 +73,5 @@ workflow_owned_variables = ["SOUWEN_WRAPPER_SHA"]
 deviations = [
   "generic-sync-disabled = Empty dist_bucket intentionally makes the current reference hf_space_sync validator reject diff, push, and pull before any remote operation",
   "workflow-owned-settings = Existing candidate-pinned GitHub Actions own all Space Secret and Variable writes",
+  "workflow-generated-provenance = SOUWEN_WRAPPER_SHA is generated and read back by the deployment transaction, not supplied as local configuration input",
 ]

--- a/panel/src/CalmPrecisionApp.tsx
+++ b/panel/src/CalmPrecisionApp.tsx
@@ -113,36 +113,34 @@ function SearchPage() {
   const client = useSouWenClient()
   const request = useLatestRequest<SearchPage>()
   const [query, setQuery] = useState('')
-  const [domains, setDomains] = useState<string[]>(['paper', 'web'])
+  const [domain, setDomain] = useState('paper')
   const [state, setState] = useState<DataState<{ items: Item[] }>>({ status: 'idle' })
-  const toggle = (domain: string) => setDomains((current) => current.includes(domain) ? current.filter((value) => value !== domain) : [...current, domain])
   async function submit(event: FormEvent) {
-    event.preventDefault(); if (!query.trim() || !domains.length) return; setState({ status: 'loading' })
+    event.preventDefault(); if (!query.trim()) return; setState({ status: 'loading' })
     void request.run(
-      (signal) => client.search({ query: query.trim(), domains, page: { limit: 20 } } as RequestFor<'search'>, { signal }),
+      (signal) => client.search({ query: query.trim(), domains: [domain], page: { limit: 20 } } as RequestFor<'search'>, { signal }),
       (data) => setState({ status: 'success', data: data as unknown as { items: Item[] } }),
       (error) => setState({ status: 'error', error: formatError(error) }),
     )
   }
-  return <><Header eyebrow="Search" title="搜索" description="选择领域并提交查询，结果统一规范化，只展示可追溯的公共字段。" /><section className={`${styles.panel} ${styles.formPanel}`}><form className={styles.form} onSubmit={submit}><div className={styles.field}><label className={styles.label} htmlFor="search-query">查询</label><input className={styles.input} id="search-query" name="query" type="search" value={query} onChange={(event) => setQuery(event.target.value)} required maxLength={4096} placeholder="输入研究问题、主题或作者" /></div><fieldset className={styles.field}><legend className={styles.label}>领域</legend><div className={styles.choiceList}>{DOMAINS.map((domain) => <label className={styles.choice} key={domain}><input type="checkbox" name="domains" checked={domains.includes(domain)} onChange={() => toggle(domain)} />{domain}</label>)}</div><span className={styles.hint}>至少选择一个领域。</span></fieldset><div className={styles.formFooter}><span className={styles.hint}>由 generated SouWenClient 发送请求。</span><button className={styles.button} disabled={state.status === 'loading' || !query.trim() || !domains.length} type="submit" aria-busy={state.status === 'loading'}>运行搜索</button></div></form></section><Status state={state} name="搜索结果" />{state.status === 'success' && <Results items={state.data?.items ?? []} />}</>
+  return <><Header eyebrow="Search" title="搜索" description="选择一个领域并提交查询，结果统一规范化，只展示可追溯的公共字段。" /><section className={`${styles.panel} ${styles.formPanel}`}><form className={styles.form} onSubmit={submit}><div className={styles.field}><label className={styles.label} htmlFor="search-query">查询</label><input className={styles.input} id="search-query" name="query" type="search" value={query} onChange={(event) => setQuery(event.target.value)} required maxLength={4096} placeholder="输入研究问题、主题或作者" /></div><div className={styles.field}><label className={styles.label} htmlFor="search-domain">领域</label><select className={styles.select} id="search-domain" name="domain" value={domain} onChange={(event) => setDomain(event.target.value)}>{DOMAINS.map((value) => <option key={value} value={value}>{value}</option>)}</select><span className={styles.hint}>默认 Provider 选择一次只接受一个领域。</span></div><div className={styles.formFooter}><span className={styles.hint}>由 generated SouWenClient 发送请求。</span><button className={styles.button} disabled={state.status === 'loading' || !query.trim()} type="submit" aria-busy={state.status === 'loading'}>运行搜索</button></div></form></section><Status state={state} name="搜索结果" />{state.status === 'success' && <Results items={state.data?.items ?? []} />}</>
 }
 
 function LlmSearchPage() {
   const client = useSouWenClient()
   const request = useLatestRequest<LLMSearchResult>()
   const [query, setQuery] = useState('')
-  const [providers, setProviders] = useState('')
-  const [strategy, setStrategy] = useState<'single' | 'fanout' | 'first_success'>('first_success')
+  const [provider, setProvider] = useState('')
   const [state, setState] = useState<DataState<{ answer?: string | null; evidence: Item[]; items: Item[] }>>({ status: 'idle' })
   async function submit(event: FormEvent) {
-    event.preventDefault(); const refs = providers.split(',').map((value) => value.trim()).filter(Boolean).map((id) => ({ id, kind: 'llm_search' })); if (!query.trim() || !refs.length) return; setState({ status: 'loading' })
+    event.preventDefault(); if (!query.trim() || !provider.trim()) return; setState({ status: 'loading' })
     void request.run(
-      (signal) => client.llmSearch({ query: query.trim(), providers: refs, strategy } as RequestFor<'llmSearch'>, { signal }),
+      (signal) => client.llmSearch({ query: query.trim(), providers: [{ id: provider.trim(), kind: 'llm_search' }], strategy: 'single' } as RequestFor<'llmSearch'>, { signal }),
       (data) => setState({ status: 'success', data: data as unknown as { answer?: string | null; evidence: Item[]; items: Item[] } }),
       (error) => setState({ status: 'error', error: formatError(error) }),
     )
   }
-  return <><Header eyebrow="LLM Search" title="综合搜索" description="选定 provider 和策略，由 LLM 汇总回答并附带来源证据。" /><section className={`${styles.panel} ${styles.formPanel}`}><form className={styles.form} onSubmit={submit}><div className={styles.field}><label className={styles.label} htmlFor="llm-query">问题</label><textarea className={styles.textarea} id="llm-query" name="query" value={query} onChange={(event) => setQuery(event.target.value)} required maxLength={4096} placeholder="提出一个需要依据的研究问题" /></div><div className={styles.formRow}><div className={styles.field}><label className={styles.label} htmlFor="llm-providers">Provider IDs</label><input className={styles.input} id="llm-providers" name="providers" value={providers} onChange={(event) => setProviders(event.target.value)} required placeholder="例如: research-llm" /><span className={styles.hint}>多个 provider 以逗号分隔，可在 Providers 页核对。</span></div><div className={styles.field}><label className={styles.label} htmlFor="llm-strategy">策略</label><select className={styles.select} id="llm-strategy" name="strategy" value={strategy} onChange={(event) => setStrategy(event.target.value as typeof strategy)}><option value="first_success">first_success</option><option value="fanout">fanout</option><option value="single">single</option></select></div></div><div className={styles.formFooter}><span className={styles.hint}>预算与认证边界由服务端执行。</span><button className={styles.button} disabled={state.status === 'loading' || !query.trim() || !providers.trim()} type="submit" aria-busy={state.status === 'loading'}>综合回答</button></div></form></section><Status state={state} name="LLM Search" />{state.status === 'success' && <section className={styles.responseStack} aria-live="polite">{state.data?.answer && <article className={`${styles.panel} ${styles.answer}`}><h2 className={styles.sectionTitle}>回答</h2><p className={styles.resultBody}>{state.data.answer}</p></article>}<Results items={state.data?.evidence ?? state.data?.items ?? []} /></section>}</>
+  return <><Header eyebrow="LLM Search" title="综合搜索" description="选定当前部署配置的 provider，由 LLM 汇总回答并附带来源证据。" /><section className={`${styles.panel} ${styles.formPanel}`}><form className={styles.form} onSubmit={submit}><div className={styles.field}><label className={styles.label} htmlFor="llm-query">问题</label><textarea className={styles.textarea} id="llm-query" name="query" value={query} onChange={(event) => setQuery(event.target.value)} required maxLength={4096} placeholder="提出一个需要依据的研究问题" /></div><div className={styles.field}><label className={styles.label} htmlFor="llm-provider">Provider ID</label><input className={styles.input} id="llm-provider" name="provider" value={provider} onChange={(event) => setProvider(event.target.value)} required placeholder="从 Providers 页复制 available 的 LLM Search ID" /><span className={styles.hint}>Target runtime 只接受一个已配置 provider，策略固定为 single。</span></div><div className={styles.formFooter}><span className={styles.hint}>预算与认证边界由服务端执行。</span><button className={styles.button} disabled={state.status === 'loading' || !query.trim() || !provider.trim()} type="submit" aria-busy={state.status === 'loading'}>综合回答</button></div></form></section><Status state={state} name="LLM Search" />{state.status === 'success' && <section className={styles.responseStack} aria-live="polite">{state.data?.answer && <article className={`${styles.panel} ${styles.answer}`}><h2 className={styles.sectionTitle}>回答</h2><p className={styles.resultBody}>{state.data.answer}</p></article>}<Results items={state.data?.evidence ?? state.data?.items ?? []} /></section>}</>
 }
 
 function FetchPage() {

--- a/panel/src/core/test/calmPrecisionApp.test.tsx
+++ b/panel/src/core/test/calmPrecisionApp.test.tsx
@@ -82,7 +82,8 @@ describe('Calm Precision Panel', () => {
     expect(main).toHaveFocus()
     expect(screen.getByLabelText('切换为深色模式')).toBeVisible()
     expect(screen.getByLabelText('查询')).toBeRequired()
-    expect(screen.getByLabelText('knowledge')).toBeInTheDocument()
+    expect(screen.getByRole('combobox', { name: '领域' })).toHaveValue('paper')
+    expect(screen.getByRole('option', { name: 'knowledge' })).toBeInTheDocument()
   })
 
   it('keeps the admin-only navigation group out of a user session', async () => {
@@ -140,6 +141,7 @@ describe('Calm Precision Panel', () => {
     await user.type(await screen.findByLabelText('查询'), 'test query')
     await user.click(screen.getByRole('button', { name: '运行搜索' }))
     expect(screen.getByRole('status')).toHaveTextContent('正在请求搜索结果')
+    expect(sdk.search.mock.calls[0][0]).toMatchObject({ domains: ['paper'] })
     resolveSearch?.({ items: [] })
     expect(await screen.findByText('本次请求没有可显示的结果。')).toBeInTheDocument()
 
@@ -163,9 +165,13 @@ describe('Calm Precision Panel', () => {
     render(<CalmPrecisionApp />)
 
     await user.type(await screen.findByLabelText('问题'), 'evidence query')
-    await user.type(screen.getByLabelText('Provider IDs'), 'provider-a')
+    await user.type(screen.getByLabelText('Provider ID'), 'provider-a')
     await user.click(screen.getByRole('button', { name: '综合回答' }))
 
+    expect(sdk.llmSearch.mock.calls[0][0]).toMatchObject({
+      providers: [{ id: 'provider-a', kind: 'llm_search' }],
+      strategy: 'single',
+    })
     expect(await screen.findByRole('link', { name: '规范化证据标题' })).toHaveAttribute('href', 'https://example.test/evidence')
     expect(screen.getByText('provider-a')).toBeInTheDocument()
   })
@@ -176,7 +182,11 @@ describe('Calm Precision Panel', () => {
     const user = userEvent.setup()
     render(<CalmPrecisionApp />)
 
-    await user.type(await screen.findByLabelText('URLs'), Array.from({ length: 21 }, (_, index) => `https://example.test/${index}`).join('\n'))
+    fireEvent.change(await screen.findByLabelText('URLs'), {
+      target: {
+        value: Array.from({ length: 21 }, (_, index) => `https://example.test/${index}`).join('\n'),
+      },
+    })
     await user.click(screen.getByRole('button', { name: '开始 Fetch' }))
 
     expect(await screen.findByRole('alert')).toHaveTextContent('最多支持 20 个 URL')
@@ -224,7 +234,7 @@ describe('Calm Precision Panel', () => {
     const query = await screen.findByLabelText('问题')
     const form = query.closest('form')!
     await user.type(query, 'first')
-    await user.type(screen.getByLabelText('Provider IDs'), 'provider-a')
+    await user.type(screen.getByLabelText('Provider ID'), 'provider-a')
     await user.click(screen.getByRole('button', { name: '综合回答' }))
     const firstSignal = sdk.llmSearch.mock.calls[0][1].signal as AbortSignal
     await user.clear(query)

--- a/scripts/hf_space_smoke.py
+++ b/scripts/hf_space_smoke.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 import time
 from dataclasses import asdict, dataclass, field
@@ -28,6 +29,48 @@ TARGET_PATHS = {
 }
 FETCH_PROBE_PATH = "scripts/fixtures/hf-space-fetch-probe.html"
 FETCH_PROBE_MARKER = "SOUWEN_IMMUTABLE_FETCH_PROBE_V1"
+_SECRET_KEYWORDS = {
+    "key",
+    "keys",
+    "secret",
+    "token",
+    "password",
+    "sessdata",
+    "authorization",
+    "auth",
+    "csrf",
+    "cookie",
+    "cookies",
+    "jwt",
+    "session",
+    "sid",
+    "xsrf",
+}
+_COMPACT_SECRET_FIELDS = {
+    "accesskey",
+    "accesskeys",
+    "accesstoken",
+    "apikey",
+    "apikeys",
+    "authtoken",
+    "bearertoken",
+    "clientsecret",
+    "csrftoken",
+    "credential",
+    "credentials",
+    "privatekey",
+    "refreshtoken",
+    "sessionid",
+    "signingkey",
+    "xapikey",
+    "xcsrftoken",
+    "xsessionid",
+    "xxsrftoken",
+    "xsrftoken",
+}
+_ACRONYM_BOUNDARY = re.compile(r"(.)([A-Z][a-z]+)")
+_CAMEL_BOUNDARY = re.compile(r"([a-z0-9])([A-Z])")
+_FIELD_SPLITTER = re.compile(r"[^A-Za-z0-9]+")
 
 
 @dataclass(slots=True)
@@ -65,14 +108,16 @@ class Client:
         method: str = "GET",
         payload: dict[str, Any] | None = None,
         application_auth: bool = True,
+        anonymous: bool = False,
     ) -> tuple[int, dict[str, str], bytes]:
         headers = {"Accept": "application/json", "User-Agent": "SouWen-HFS-Smoke/2"}
-        if self.edge_token:
-            headers["Authorization"] = f"Bearer {self.edge_token}"
-            if application_auth and self.app_token:
-                headers["X-SouWen-Token"] = self.app_token
-        elif application_auth and self.app_token:
-            headers["Authorization"] = f"Bearer {self.app_token}"
+        if not anonymous:
+            if self.edge_token:
+                headers["Authorization"] = f"Bearer {self.edge_token}"
+                if application_auth and self.app_token:
+                    headers["X-SouWen-Token"] = self.app_token
+            elif application_auth and self.app_token:
+                headers["Authorization"] = f"Bearer {self.app_token}"
         data = None
         if payload is not None:
             data = json.dumps(payload).encode("utf-8")
@@ -126,6 +171,34 @@ def _record(checks: list[Check], name: str, callback, *, required: bool = True) 
 def _expect(condition: bool, detail: str) -> None:
     if not condition:
         raise SmokeFailure(detail)
+
+
+def _is_secret_field(name: str) -> bool:
+    """Mirror the server redaction field classifier without importing SouWen."""
+    camel_split = _ACRONYM_BOUNDARY.sub(r"\1_\2", name)
+    camel_split = _CAMEL_BOUNDARY.sub(r"\1_\2", camel_split)
+    parts = [part.lower() for part in _FIELD_SPLITTER.split(camel_split) if part]
+    if any(part in _SECRET_KEYWORDS for part in parts):
+        return True
+    return "".join(parts) in _COMPACT_SECRET_FIELDS
+
+
+def _unredacted_secret_fields(value: Any, path: tuple[str, ...] = ()) -> list[str]:
+    """Return credential-shaped string fields that are not using the redaction sentinel."""
+    if isinstance(value, dict):
+        leaked: list[str] = []
+        for key, item in value.items():
+            child_path = (*path, str(key))
+            if _is_secret_field(str(key)) and isinstance(item, str) and item not in {"", "***"}:
+                leaked.append(".".join(child_path))
+            leaked.extend(_unredacted_secret_fields(item, child_path))
+        return leaked
+    if isinstance(value, list):
+        leaked = []
+        for index, item in enumerate(value):
+            leaked.extend(_unredacted_secret_fields(item, (*path, str(index))))
+        return leaked
+    return []
 
 
 def _probe(client: Client, path: str, args: argparse.Namespace):
@@ -186,10 +259,68 @@ def _surface_checks(client: Client, args: argparse.Namespace, checks: list[Check
 
     _record(checks, "whoami", whoami)
 
+    def admin_ping():
+        status, _headers, payload = client.json("/api/v1/admin/ping")
+        _expect(status == 200 and payload == {"status": "ok"}, f"admin ping status {status}")
+        return "authenticated admin ping verified", None
+
+    _record(checks, "admin_ping", admin_ping)
+
+    def admin_config():
+        status, _headers, payload = client.json("/api/v1/admin/config")
+        _expect(status == 200 and isinstance(payload, dict), f"admin config status {status}")
+        leaked_fields = _unredacted_secret_fields(payload)
+        _expect(not leaked_fields, "admin config contains unredacted credential-shaped fields")
+        if client.app_token:
+            serialized = json.dumps(payload, ensure_ascii=False)
+            _expect(client.app_token not in serialized, "admin config contains application token")
+        return "authenticated redacted admin config verified", None
+
+    _record(checks, "admin_config", admin_config)
+
+    def admin_doctor():
+        status, _headers, payload = client.json("/api/v1/admin/doctor")
+        providers = payload.get("providers") if isinstance(payload, dict) else None
+        _expect(status == 200 and isinstance(providers, list), f"admin doctor status {status}")
+        total = payload.get("total")
+        available = payload.get("available")
+        unavailable = payload.get("unavailable")
+        _expect(total == len(providers), "admin doctor provider total mismatch")
+        _expect(
+            isinstance(available, int)
+            and isinstance(unavailable, int)
+            and available + unavailable == total,
+            "admin doctor availability totals mismatch",
+        )
+        return f"authenticated admin doctor verified ({total} providers)", None
+
+    _record(checks, "admin_doctor", admin_doctor)
+
     if client.app_token:
 
-        def anonymous_admin():
+        def edge_only_data():
+            status, _headers, _payload = client.json("/api/v1/providers", application_auth=False)
+            _expect(status in {401, 403}, f"edge-only data API status {status}")
+            return "edge-only Data API request rejected", None
+
+        _record(checks, "edge_only_data_rejected", edge_only_data)
+
+        def edge_only_admin():
             status, _headers, _payload = client.json("/api/v1/admin/ping", application_auth=False)
+            _expect(status in {401, 403}, f"edge-only admin status {status}")
+            return "edge-only admin request rejected", None
+
+        _record(checks, "edge_only_admin_rejected", edge_only_admin)
+
+        def anonymous_data():
+            status, _headers, _payload = client.json("/api/v1/providers", anonymous=True)
+            _expect(status in {401, 403}, f"anonymous data API status {status}")
+            return "anonymous Data API request rejected", None
+
+        _record(checks, "anonymous_data_rejected", anonymous_data)
+
+        def anonymous_admin():
+            status, _headers, _payload = client.json("/api/v1/admin/ping", anonymous=True)
             _expect(status in {401, 403}, f"anonymous admin status {status}")
             return "anonymous admin rejected", None
 

--- a/tests/test_hf_space_smoke.py
+++ b/tests/test_hf_space_smoke.py
@@ -7,6 +7,7 @@ import json
 import pytest
 
 from scripts import hf_space_smoke as smoke
+from souwen.common_runtime.security import redaction as canonical_redaction
 
 
 def test_parse_args_preserves_deployment_workflow_interface() -> None:
@@ -61,6 +62,42 @@ def test_client_keeps_edge_and_application_auth_separate(monkeypatch) -> None:
     assert status == 200
     assert captured["headers"]["Authorization"] == "Bearer edge-canary"
     assert captured["headers"]["X-souwen-token"] == "app-canary"
+
+
+def test_client_can_send_a_completely_anonymous_negative_probe(monkeypatch) -> None:
+    captured = {}
+
+    class Response:
+        status = 401
+        headers = {}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self):
+            return b"{}"
+
+    def fake_urlopen(request, timeout):
+        captured["headers"] = {key.lower(): value for key, value in request.header_items()}
+        captured["timeout"] = timeout
+        return Response()
+
+    monkeypatch.setattr(smoke, "urlopen", fake_urlopen)
+    client = smoke.Client(
+        "https://example.invalid",
+        edge_token="edge-canary",
+        app_token="app-canary",
+        timeout=3,
+    )
+
+    status, _headers, _body = client.request("/api/v1/providers", anonymous=True)
+
+    assert status == 401
+    assert "authorization" not in captured["headers"]
+    assert "x-souwen-token" not in captured["headers"]
 
 
 def test_offline_mode_writes_bounded_reports(tmp_path) -> None:
@@ -183,6 +220,108 @@ def test_readiness_probe_requires_browser_worker_evidence() -> None:
 
     with pytest.raises(smoke.SmokeFailure, match="browser worker"):
         smoke._probe(Client(), "/readyz", args)
+
+
+def test_surface_checks_cover_authenticated_admin_routes_and_redaction() -> None:
+    class Client:
+        app_token = "admin-secret-canary"
+
+        def request(self, path, **_kwargs):
+            assert path == "/panel"
+            return 200, {}, b'<main id="root"></main>'
+
+        def json(self, path, **_kwargs):
+            if path in {"/healthz", "/readyz"}:
+                return 200, {"x-souwen-api-major": "2"}, {"rollout_mode": "target"}
+            if path == "/openapi.json":
+                return (
+                    200,
+                    {},
+                    {
+                        "paths": {item: {} for item in smoke.TARGET_PATHS},
+                        "x-souwen-contract-stage": "target_only",
+                    },
+                )
+            if path == "/api/v1/whoami":
+                return 200, {}, {"role": "admin", "admin_open": False}
+            if path == "/api/v1/admin/ping":
+                if _kwargs.get("application_auth") is False or _kwargs.get("anonymous") is True:
+                    return 401, {}, {"error": {"code": "unauthorized"}}
+                return 200, {}, {"status": "ok"}
+            if path == "/api/v1/admin/config":
+                return (
+                    200,
+                    {},
+                    {
+                        "admin_password": "***",
+                        "sources": {"fixture": {"api_key": "***"}},
+                    },
+                )
+            if path == "/api/v1/admin/doctor":
+                return (
+                    200,
+                    {},
+                    {
+                        "total": 1,
+                        "available": 1,
+                        "unavailable": 0,
+                        "providers": [{"provider": "fixture"}],
+                    },
+                )
+            if path == "/api/v1/providers":
+                if _kwargs.get("application_auth") is False or _kwargs.get("anonymous") is True:
+                    return 401, {}, {"error": {"code": "unauthorized"}}
+                return 200, {}, {"items": []}
+            raise AssertionError(path)
+
+    checks = []
+    smoke._surface_checks(Client(), smoke.parse_args(["--fail-admin-open"]), checks)
+
+    by_name = {check.name: check for check in checks}
+    for name in (
+        "admin_ping",
+        "admin_config",
+        "admin_doctor",
+        "edge_only_data_rejected",
+        "edge_only_admin_rejected",
+        "anonymous_data_rejected",
+        "anonymous_admin_rejected",
+    ):
+        assert by_name[name].outcome == "PASS"
+
+
+@pytest.mark.parametrize(
+    "field",
+    sorted(canonical_redaction._SECRET_KEYWORDS | canonical_redaction._COMPACT_SECRET_FIELDS),
+)
+def test_admin_config_classifier_covers_the_canonical_secret_inventory(field: str) -> None:
+    assert smoke._is_secret_field(field)
+
+
+def test_smoke_secret_field_inventory_stays_in_lockstep_with_the_server() -> None:
+    assert smoke._SECRET_KEYWORDS == canonical_redaction._SECRET_KEYWORDS
+    assert smoke._COMPACT_SECRET_FIELDS == canonical_redaction._COMPACT_SECRET_FIELDS
+
+
+@pytest.mark.parametrize(
+    "field",
+    ("api_key", "private-key", "clientSecret", "XSessionID", "refreshToken"),
+)
+def test_admin_config_classifier_matches_separator_and_camel_case_fields(field: str) -> None:
+    assert smoke._is_secret_field(field)
+
+
+def test_unredacted_admin_config_is_a_required_failure() -> None:
+    assert smoke._unredacted_secret_fields(
+        {
+            "sources": {
+                "fixture": {
+                    "api_key": "plain-text-secret",
+                    "privateKey": "plain-text-private-key",
+                }
+            }
+        }
+    ) == ["sources.fixture.api_key", "sources.fixture.privateKey"]
 
 
 def test_missing_required_llm_provider_is_reported_as_a_failed_check(monkeypatch, tmp_path) -> None:

--- a/tests/test_hfs_v2_registry.py
+++ b/tests/test_hfs_v2_registry.py
@@ -1,34 +1,42 @@
 from __future__ import annotations
 
+import re
+import tomllib
 from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
-def test_hfs_v2_registry_is_source_lane_and_registry_only() -> None:
-    manifest = (REPO_ROOT / "hfs-dev.toml").read_text(encoding="utf-8")
+def test_hfs_v2_1_registry_is_preview_source_lane_and_registry_only() -> None:
+    manifest_text = (REPO_ROOT / "hfs-dev.toml").read_text(encoding="utf-8")
+    manifest = tomllib.loads(manifest_text)
 
-    for declaration in (
-        'standard = "2.0"',
-        'project = "SouWen"',
-        'space = "BlueSkyXN/SouWen"',
-        'sovereignty = "sovereign"',
-        'lane = "source"',
-        'version_source = "commit"',
-        'operation_mode = "registry-only"',
-        'dist_bucket = ""',
-        "secrets = []",
-        "variables = []",
-    ):
-        assert declaration in manifest
-
-    assert '"SOUWEN_ADMIN_PASSWORD"' in manifest
-    assert '"SOUWEN_CONFIG_B64"' in manifest
-    assert '"UNIAPI_API_KEY"' in manifest
-    assert 'workflow_owned_variables = ["SOUWEN_WRAPPER_SHA"]' in manifest
-    assert "generic-sync-disabled" in manifest
-    assert "workflow-owned-settings" in manifest
+    assert manifest["standard"] == "2.1"
+    assert manifest["project"] == "SouWen"
+    assert manifest["space"] == "BlueSkyXN/SouWen"
+    assert manifest["project_class"] == "preview"
+    assert manifest["target_role"] == "primary"
+    assert manifest["sovereignty"] == "sovereign"
+    assert manifest["lane"] == "source"
+    assert manifest["version_source"] == "commit"
+    assert manifest["env_file"] == ".env"
+    assert manifest["secret_files"] == ["local/credentials/souwen-hfs.yaml"]
+    assert manifest["operation_mode"] == "registry-only"
+    assert manifest["dist_bucket"] == ""
+    assert manifest["variables"] == []
+    assert set(manifest["secrets"]) == {
+        "SOUWEN_ADMIN_PASSWORD",
+        "SOUWEN_CONFIG_B64",
+        "UNIAPI_API_KEY",
+    }
+    assert set(manifest["workflow_owned_secrets"]) == set(manifest["secrets"])
+    assert manifest["workflow_owned_variables"] == ["SOUWEN_WRAPPER_SHA"]
+    assert any(item.startswith("generic-sync-disabled =") for item in manifest["deviations"])
+    assert any(item.startswith("workflow-owned-settings =") for item in manifest["deviations"])
+    assert any(
+        item.startswith("workflow-generated-provenance =") for item in manifest["deviations"]
+    )
 
 
 def test_hfs_local_fact_sources_are_ignored_but_templates_remain_trackable() -> None:
@@ -52,7 +60,16 @@ def test_hfs_local_fact_sources_are_ignored_but_templates_remain_trackable() -> 
 
 def test_hfs_settings_remain_owned_by_candidate_pinned_workflow() -> None:
     workflow = (REPO_ROOT / ".github/workflows/deploy-hf-space.yml").read_text(encoding="utf-8")
+    manifest = tomllib.loads((REPO_ROOT / "hfs-dev.toml").read_text(encoding="utf-8"))
+    managed_block = workflow.split("managed = {", maxsplit=1)[1].split("}", maxsplit=1)[0]
+    managed_pairs = re.findall(
+        r'"([A-Z][A-Z0-9_]+)": os\.environ\["([A-Z][A-Z0-9_]+)"\]',
+        managed_block,
+    )
 
+    assert managed_pairs
+    assert all(key == env_name for key, env_name in managed_pairs)
+    assert {key for key, _env_name in managed_pairs} == set(manifest["secrets"])
     assert "SOUWEN_CONFIG_B64: ${{ secrets.SOUWEN_CONFIG_B64 }}" in workflow
     assert "UNIAPI_API_KEY: ${{ secrets.UNIAPI_API_KEY }}" in workflow
     assert "api.add_space_secret(" in workflow

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import ast
 import hashlib
 import json
 import re
@@ -1072,13 +1071,12 @@ def test_hfs_reusable_promotion_is_candidate_pinned_and_live_verified() -> None:
     assert "prior_runtime_stage" in text
     assert "parent_commit=prior_space_sha" in text
     assert "revision=prior_space_sha" in text
-    assert "  rollback-space:" in text
+    assert "settings_mutation_started" in text
+    assert "  contain-space:" in text
     assert "needs.post-deploy-smoke.result != 'success'" in text
-    assert "CommitOperationDelete" in text
-    assert "rollback_space_commit_sha" in text
     assert "  pause-space:" in text
     assert "api.pause_space" in text
-    assert "needs.rollback-space.result == 'cancelled'" in text
+    assert "needs.contain-space.result == 'cancelled'" in text
     assert "HF_SPACE_READ_TOKEN" in text
     assert '"X-SouWen-Token: $SOUWEN_SMOKE_BEARER_TOKEN"' in text
 
@@ -1099,19 +1097,25 @@ def test_hfs_reusable_promotion_is_candidate_pinned_and_live_verified() -> None:
     assert "HFS promotion requires exactly one enabled LLM Search Provider" in text
     assert 'env_reference = re.compile(r"^\\$\\{[A-Z_][A-Z0-9_]*\\}$")' in text
 
+    settings_preflight = text.split("- name: Preflight managed HFS Space Secret names", maxsplit=1)[
+        1
+    ].split("- name: Mark settings mutation phase", maxsplit=1)[0]
     settings_sync = text.split("- name: Sync managed HFS Space secrets", maxsplit=1)[1].split(
         "- name: Sync changed HFS wrapper files", maxsplit=1
     )[0]
+    assert "/api/spaces/{space_id}/secrets" in settings_preflight
+    assert "existing_names - expected_names" in settings_preflight
     assert "SOUWEN_ADMIN_PASSWORD: ${{ secrets.SOUWEN_SMOKE_BEARER_TOKEN }}" in settings_sync
     assert "SOUWEN_CONFIG_B64: ${{ secrets.SOUWEN_CONFIG_B64 }}" in settings_sync
     assert "UNIAPI_API_KEY: ${{ secrets.UNIAPI_API_KEY }}" in settings_sync
     assert "api.add_space_secret(" in settings_sync
     assert "/api/spaces/{space_id}/secrets" in settings_sync
-    assert "existing_names - expected_names" in settings_sync
     assert "actual_names != expected_names" in settings_sync
     assert "api.delete_space_secret" not in settings_sync
     assert (
         text.index("- name: Capture immutable rollback point")
+        < text.index("- name: Preflight managed HFS Space Secret names")
+        < text.index("- name: Mark settings mutation phase")
         < text.index("- name: Sync managed HFS Space secrets")
         < text.index("- name: Sync changed HFS wrapper files")
     )
@@ -1123,14 +1127,17 @@ def test_hfs_reusable_promotion_is_candidate_pinned_and_live_verified() -> None:
     assert '"PAUSED"' in prior
     assert "api.restart_space" not in prior
 
-    rollback = text.split("  rollback-space:", maxsplit=1)[1].split("  pause-space:", maxsplit=1)[0]
-    assert "rollback_sha = prior_sha" in rollback
-    assert "Space head still matches the rollback point" in rollback
-    assert "no distinct forward rollback commit" not in rollback
-    assert 'if "wrapper_sha" in payload and payload["wrapper_sha"] != expected_wrapper:' in rollback
+    containment = text.split("  contain-space:", maxsplit=1)[1].split("  pause-space:", maxsplit=1)[
+        0
+    ]
+    assert "api.pause_space" in containment
+    assert "write-only Space Secret values require manual recovery" in containment
+    assert "needs.sync-hfs-wrapper.outputs.settings_mutation_started == 'true'" in containment
+    assert "api.create_commit" not in containment
+    assert "api.restart_space" not in containment
 
     post_deploy = text.split("  post-deploy-smoke:", maxsplit=1)[1].split(
-        "  rollback-space:", maxsplit=1
+        "  contain-space:", maxsplit=1
     )[0]
     assert "ref: ${{ inputs.verifier_sha }}" in post_deploy
     assert "cd trusted-verifier" in post_deploy
@@ -1138,44 +1145,31 @@ def test_hfs_reusable_promotion_is_candidate_pinned_and_live_verified() -> None:
     assert "ref: ${{ inputs.candidate_sha || github.sha }}" not in post_deploy
 
 
-def test_hfs_rollback_probe_distinguishes_legacy_absent_wrapper_from_rc4_null_or_drift() -> None:
+def test_hfs_settings_preflight_finishes_before_the_containment_marker_and_first_write() -> None:
     text = _workflow("deploy-hf-space.yml")
-    rollback = _job(text, "rollback-space", "pause-space")
-    source = textwrap.dedent(
-        rollback.split("<<'PY'", maxsplit=1)[1].split("\n          PY", maxsplit=1)[0]
-    ).lstrip()
-    module = ast.parse(source)
-    function = next(
-        node
-        for node in module.body
-        if isinstance(node, ast.FunctionDef) and node.name == "validate_rollback_probe"
-    )
-    namespace: dict[str, object] = {}
-    exec(compile(ast.Module(body=[function], type_ignores=[]), "rollback-probe", "exec"), namespace)
-    validate = namespace["validate_rollback_probe"]
-    source_sha = "a" * 40
-    wrapper_sha = "b" * 40
+    sync = _job(text, "sync-hfs-wrapper", "rebuild-space")
 
-    validate({"source_sha": source_sha}, "/health", source_sha, wrapper_sha)
-    validate(
-        {"source_sha": source_sha, "wrapper_sha": wrapper_sha},
-        "/health",
-        source_sha,
-        wrapper_sha,
-    )
-    with pytest.raises(SystemExit, match="wrapper mismatch"):
-        validate(
-            {"source_sha": source_sha, "wrapper_sha": None}, "/health", source_sha, wrapper_sha
-        )
-    with pytest.raises(SystemExit, match="wrapper mismatch"):
-        validate(
-            {"source_sha": source_sha, "wrapper_sha": "c" * 40},
-            "/health",
-            source_sha,
-            wrapper_sha,
-        )
-    with pytest.raises(SystemExit, match="source mismatch"):
-        validate({"source_sha": "c" * 40}, "/health", source_sha, wrapper_sha)
+    preflight = sync.index("- name: Preflight managed HFS Space Secret names")
+    marker = sync.index("- name: Mark settings mutation phase")
+    first_write = sync.index("api.add_space_secret(")
+
+    assert preflight < marker < first_write
+    assert "id: settings_mutation" in sync[marker:first_write]
+    assert "settings_mutation_started=true" in sync[marker:first_write]
+    assert (
+        "settings_mutation_started: "
+        "${{ steps.settings_mutation.outputs.settings_mutation_started }}"
+    ) in sync
+
+
+def test_hfs_containment_requires_a_completed_settings_mutation_marker() -> None:
+    text = _workflow("deploy-hf-space.yml")
+    containment = _job(text, "contain-space", "pause-space")
+
+    assert "needs.sync-hfs-wrapper.outputs.settings_mutation_started == 'true'" in containment
+    assert "needs.sync-hfs-wrapper.result != 'success'" in containment
+    assert "needs.rebuild-space.result != 'success'" in containment
+    assert "needs.post-deploy-smoke.result != 'success'" in containment
 
 
 def test_hfs_rebuild_job_avoids_checkout_and_dependency_cache() -> None:


### PR DESCRIPTION
## 结果

本 PR 将 SouWen 的 canonical HFS Preview 收口为可操作、可验收且失败后 fail closed 的部署面：Panel 的 Search/LLM Search 请求与 Server contract 一致，完整功能有固定 deep link 与角色说明，部署事务在 settings mutation 后失败时暂停 Space 等待人工恢复，不再尝试用未知旧 Secret 值自动回滚。

本 PR 包含并扩展 #268 的 HFS registry 调整；#268 可在本 PR 合并后关闭。

## 主要变更

- 修正 Panel 请求合同：Search 固定单领域，LLM Search 固定单 configured Provider 与 `single` 策略；保留 loading/error/empty、深色模式、窄屏和键盘焦点行为。
- 新增 `docs/live-preview.md`，列出 Login、Search、LLM Search、Fetch、Providers、Runtime、Settings、Swagger、OpenAPI 和 probes 的直达入口、角色与验收顺序。
- 将 Space Secret name/schema preflight 与 mutation phase 分开；只有 `settings_mutation_started=true` 后的失败才触发 containment，写前失败不会暂停健康 Space。
- 扩展 trusted HFS smoke：authenticated admin ping/config/doctor、canonical redaction parity、edge-only 与完全匿名 Data/Admin API 负向鉴权。
- 采用当前 HFS v2.1 draft registry schema，登记 `preview` / `primary` / `source`、本地 env 与 raw YAML 事实源；正式公开 HFS 基线仍为 v2.0，generic sync 继续在读本地值和联网前 fail closed。
- 修正文档中的 RC4 Release、current-main deployment、Docker config mount、Space settings ownership 与失败恢复边界。既有 `v2.0.0rc4` tag/Release 不移动、不覆盖。

## 影响与边界

- 目标仍只有 `BlueSkyXN/SouWen` canonical Space；不创建、移动或删除任何 Space/Bucket，不影响其他项目。
- Space repository 继续保持 private；当前 App domain 的 Panel/docs/probes 可预览，Data/Admin API 仍要求 SouWen application credential。
- 本 PR 本身不部署。合并并取得 exact final-main SHA 后，另用 `deployment + publish=false + deploy_hfs=true` 执行 factory rebuild 与 live acceptance。
- Secret 值不进入 Git、PR、日志、截图或 artifact；tracked registry 只保存名称和路径。

## 验证

- `PYTHONPATH=src pytest tests/ -q --tb=short`：2744 passed，2 skipped。
- `cd panel && npm test && npm run build:local && npm run check:artifact`：7 files / 48 tests PASS，single-file artifact readback PASS。
- `ruff check src tests scripts`：PASS；`ruff format --check src tests scripts`：908 files formatted。
- `sdk-contract` 与 `server-contract` profiles：PASS。
- Markdown links：65 files / 157 local links / 0 issues。
- Generated docs、legacy wording gate、`git diff --check`：PASS。
- `actionlint -shellcheck= -pyflakes=`：workflow YAML/expression lint PASS；默认外部 integrations 在本机 actionlint v1.7.7 出现 CPU loop，交由远端 CI 复核。
- HFS v2.1 draft checker（含 local values）：0 ERROR / 0 WARN；工具测试 74/74 PASS；generic sync 预期 exit 2，发生在读取本地值和联网前。
- 两个独立只读复核均给出 GO，无剩余 P1/P2 finding。

## Review focus

1. `.github/workflows/deploy-hf-space.yml` 中 preflight、mutation marker、first write 与 containment 条件顺序。
2. `scripts/hf_space_smoke.py` 的 authenticated/edge-only/anonymous auth 矩阵与 redaction parity。
3. `hfs-dev.toml` 的 draft/public-baseline、registry-only 和 local fact-source 边界。
4. Panel Search/LLM Search 请求 shape 与文档矩阵是否一致。
