### PR TITLE
修复 HFS registry 测试的 Python 3.10 兼容性

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,15 @@ scraper = ["curl-cffi>=0.14.0"]
 # Web 服务器（FastAPI + Uvicorn）
 server = ["fastapi>=0.111", "uvicorn[standard]>=0.29"]
 # 开发工具：单元测试、覆盖率、代码检查
-dev = ["pytest>=8.0", "pytest-asyncio>=0.23", "pytest-httpx>=0.30", "pytest-cov>=4", "ruff==0.16.0", "markdown-it-py>=2.2"]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23",
+    "pytest-httpx>=0.30",
+    "pytest-cov>=4",
+    "ruff==0.16.0",
+    "markdown-it-py>=2.2",
+    "tomli>=2.0; python_version < '3.11'",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/souwen"]

--- a/tests/test_hfs_v2_registry.py
+++ b/tests/test_hfs_v2_registry.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
 import re
-import tomllib
 from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - exercised by the Python 3.10 CI lane.
+    import tomli as tomllib
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## 结果

修复 #269 合并后由 deployment matrix 发现的 Python 3.10 测试收集失败。HFS registry 测试改为在 Python 3.11+ 使用 `tomllib`、Python 3.10 使用条件 dev dependency `tomli`，不改变生产运行时依赖或 HFS 行为。

失败的 deployment run `30476341946` 已取消；candidate-only HF Space promotion 为 skipped，未执行 Space repo/settings/rebuild 写操作。修复合并后会使用新的 exact main SHA 重新运行 deployment。

## 变更

- 在 `dev` extra 中增加 `tomli>=2.0; python_version < '3.11'`。
- `tests/test_hfs_v2_registry.py` 增加 Python 3.10 fallback import。

## 验证

- 独立 Python 3.10.20 venv 安装 `.[dev]` 后：`tests/test_hfs_v2_registry.py` 3 passed。
- 当前 Python：HFS registry + import surface 42 passed。
- Ruff、TOML parse、`git diff --check`：PASS。

## 边界

不修改 HFS workflow、Panel、runtime、Secret 或远端资源；只恢复仓库声明的 Python 3.10+ 测试兼容性。
