### PR TITLE
fix(runtime): 收口 Search、Fetch 与在线预览验收边界

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,9 @@ SOUWEN_LOCAL_CATALOG_PATH=
 SOUWEN_MAX_CONCURRENCY=10
 # auto | curl_cffi | httpx
 SOUWEN_DEFAULT_HTTP_BACKEND=auto
+# Search 有序默认表必须用完整 JSON object 覆盖 13 个 domain；推荐在 souwen.yaml 配置。
+# 省略时使用内置表（paper primary 为 crossref）。
+# SOUWEN_SEARCH_DEFAULTS={"paper":["crossref","openalex","eric"],"book":["open_library"],"research_output":["datacite"],"patent":["google_patents"],"web":["bing","duckduckgo"],"news":["duckduckgo_news"],"images":["duckduckgo_images"],"videos":["bilibili","duckduckgo_videos"],"social":["reddit","weibo","zhihu"],"office":["feishu_drive"],"developer":["github","stackoverflow"],"cn_tech":["linuxdo","v2ex"],"knowledge":["wikipedia"]}
 # LLM Search 共享 gateway（JSON）；Ark concrete sources remain disabled until enabled in sources YAML.
 # SOUWEN_LLM_SEARCH_GATEWAYS={"uniapi":{"api_key":"","base_url":"https://gateway.example.com/v1"}}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@
   credential-shaped string fail closed。
 - 修正 Docker 文档：应用配置只读挂载到 `/app/souwen.yaml`，`/app/data` 专用于 WARP/runtime
   persistence。
+- 修复 final-main 浏览器验收暴露的交互与运行时边界：Search 的 YAML
+  `search_defaults` 精确覆盖 13 个 canonical domain，`paper` primary 改为 `crossref`，Panel domain
+  从 frozen OpenAPI 生成；LLM Search 明确区分 evidence-only 与可选 answer；Fetch 实现 RC4
+  `fallback`/`fanout` 契约，Panel 保持 `fallback`，IP-pinned HTTPX 以流式 gzip/deflate 解码执行
+  解压后 10 MiB hard cap；Settings 不再读取已退休的 legacy `llm` 字段，并把 gateway 声明与
+  Provider 实际可用性分开。
 
 ## v2.0.0rc4 — Release Candidate（2026-07-29）
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -35,8 +35,9 @@ AUTH_HEADER="X-SouWen-Token: $SOUWEN_TOKEN"
 
 ## Providers
 
-先读取 catalog，再为 Search、LLM Search 和 Fetch 选择 `availability=available` 且声明对应
-capability 的 Provider。不要在客户端维护平行 Provider 清单。
+先读取 catalog，了解 Search、LLM Search 和 Fetch Provider 的当前 eligibility/availability。
+LLM Search 必须显式选择 Provider；Search/Fetch 可以使用 Server default，也可以由 SDK/API
+caller 显式选择。不要在客户端维护平行 Provider 清单。
 
 ```bash
 curl --fail-with-body "$BASE_URL/api/v1/providers" \
@@ -57,13 +58,14 @@ curl --fail-with-body "$BASE_URL/api/v1/search" \
   -d '{
     "query": "retrieval augmented generation",
     "domains": ["paper"],
-    "providers": [{"id": "openalex", "kind": "search"}],
     "page": {"limit": 3}
   }'
 ```
 
 响应是 `SearchPage`：`items` 为 canonical results，`page` 提供 limit/cursor，`meta` 和
-`context` 提供本次执行与请求信息。调用方应保留每条结果的 provenance。
+`context` 提供本次执行与请求信息。调用方应保留每条结果的 provenance。`providers` 缺省时，
+`search_defaults` 为该 domain 选择一个 primary；当前 `paper` primary 是 `crossref`。显式传入
+一个 Provider 时只调用该 Provider；显式传入多个 Provider 时按 Search contract fanout/merge。
 
 ## LLM Search
 
@@ -82,8 +84,10 @@ curl --fail-with-body "$BASE_URL/api/v1/llm-search" \
   }'
 ```
 
-响应是 `LLMSearchResult`，包含 `answer`、`evidence`、`items` 和始终存在的 `usage` 对象。
-`usage` 只反映 Provider 回报，未知值为 `null`，不能推导平台账单。
+响应是 `LLMSearchResult`，包含 `evidence`、`items`、可空的 `answer` 和始终存在的 `usage`
+对象。`answer` 是非必填、nullable 字段：Provider 只返回可验证结构化证据时为 `null`，这仍是有效
+成功；只有 Provider 返回可引用的 synthesis 时才有文本回答。`usage` 只反映 Provider 回报，未知值
+为 `null`，不能推导平台账单。
 
 ## Fetch
 
@@ -103,6 +107,15 @@ curl --fail-with-body "$BASE_URL/api/v1/fetch" \
 Fetch 一次接受 1–20 个 `http/https` target。`respect_robots` 只能保持为 `true`；客户端选项
 不能关闭服务端 SSRF、redirect、DNS、robots 或 response-size 保护。每个 `FetchResult` 独立报告
 `success`、`failed` 或 `blocked`，以及自己的 provenance 或安全错误。
+
+`strategy=fallback` 按 Provider 顺序逐 target 尝试，获得高质量成功后停止；低质量成功在没有
+更好结果时保留为 partial item。`strategy=fanout` 对每个 `target × provider` 组合并发执行，
+按 target-major、provider-minor 顺序返回独立 `FetchResult`，不合并不同 Provider 的正文。
+Panel 为降低日常操作成本固定发送 `fallback`；SDK/API caller 可以显式请求 `fanout`。完整执行
+语义见 [SPEC-04](./internal/spec-04-fetch-module-lld.md)。
+
+IP-pinned builtin Fetch 只广告 `gzip, deflate`，并在 raw stream 上增量解码；解压后正文达到
+`10 MiB + 1 byte` 时立即关闭 stream 并返回 `payload_too_large`，不会先完整缓冲压缩响应。
 
 ## Admin 与 probes
 

--- a/docs/appearance.md
+++ b/docs/appearance.md
@@ -7,10 +7,13 @@ SouWen 管理面板位于 `panel/`，是一个固定的 React/Vite 管理界面�
 
 面板只提供以下顶层工作区：
 
-1. **Search**：从 13 个领域中选择一个，使用 Server 默认 Provider 完成规范化检索；多 Provider
-   fanout 由显式 SDK/API 请求承担。
-2. **LLM Search**：选择一个当前部署 configured provider，使用固定 `single` 策略完成带证据综合检索。
-3. **Fetch**：受服务端 SSRF、robots 和 provider 策略保护的内容获取。
+1. **Search**：从 frozen OpenAPI 生成的 13 个领域中选择一个，由 Server 的
+   `search_defaults` 有序表选择一个 primary Provider；Panel 始终只发送一个领域且不覆盖
+   Provider policy。
+2. **LLM Search**：选择一个当前部署 configured provider，使用固定 `single` 策略返回结构化证据；
+   Provider 返回可验证 synthesis 时同时展示综合回答。
+3. **Fetch**：受服务端 SSRF、robots 和 provider 策略保护的内容获取；Panel 固定发送
+   `fallback`，已实现的多 Provider `fanout` 保留给显式 SDK/API workflow。
 4. **Providers**：只读 provider 可用性、能力与缺失配置字段。
 5. **Runtime / Settings**：仅 admin 可见的只读运行诊断和安全姿态摘要。
 
@@ -46,8 +49,9 @@ contract。
 无密码管理员访问只由服务端的 `SOUWEN_ADMIN_OPEN=1` 决定。
 
 Runtime / Settings 仅使用必要的 admin 读取接口。Settings 只投影访问策略、Provider 配置
-数量和 LLM Search 姿态，不把完整 server config 发送到 DOM。面板不提供 token、password、
-cookie、credential 或 API key 的回显和保存。
+数量和 LLM Search gateway 是否已声明；实际 Provider 可用性仍以 Providers 页为准，不读取已退休的
+legacy `llm` 字段，也不把完整 server config 发送到 DOM。面板不提供 token、password、cookie、
+credential 或 API key 的回显和保存。
 
 嵌入式 Panel 的认证只支持两种单一浏览器场景：同源 private-edge browser session/cookie，或普通的
 单一 Bearer application token。前者由浏览器自动携带，Panel 不读取、采集或持久化 cookie；后者只按

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -115,6 +115,21 @@ warp:
   warp_endpoint: ~
   warp_external_proxy: ~
 
+search_defaults:
+  paper: [crossref, openalex, eric]
+  book: [open_library]
+  research_output: [datacite]
+  patent: [google_patents]
+  web: [bing, duckduckgo]
+  news: [duckduckgo_news]
+  images: [duckduckgo_images]
+  videos: [bilibili, duckduckgo_videos]
+  social: [reddit, weibo, zhihu]
+  office: [feishu_drive]
+  developer: [github, stackoverflow]
+  cn_tech: [linuxdo, v2ex]
+  knowledge: [wikipedia]
+
 sources: {}
 llm_search_gateways: {}
 ```
@@ -367,6 +382,39 @@ server:
 | `warp_external_proxy` | `SOUWEN_WARP_EXTERNAL_PROXY` / `WARP_EXTERNAL_PROXY` | None | `external` 模式使用的外部代理地址 |
 
 > WARP 字段支持不带 `SOUWEN_` 前缀的环境变量（供 Docker entrypoint 使用）。
+
+### Search 有序默认 Provider（search_defaults）
+
+`SearchRequest.providers` 缺省时，Server 按 `search_defaults` 为请求中的唯一 domain
+选择列表第一个 primary。表必须精确覆盖 13 个 canonical domain；Provider ID 必须存在于
+manifest catalog、声明 `search` capability，且 Provider spec 的 domain 必须一致，否则
+runtime fail closed。列表顺序不会在一次缺省请求中触发 sequential fallback，也不会触发
+fanout；显式多 Provider 仍由调用方通过 `SearchRequest.providers` 请求。
+
+默认 `paper` primary 为 `crossref`。这是为避免匿名 OpenAlex 上游配额耗尽使 Panel 默认路径
+直接 429；`openalex` 和 `eric` 仍是已登记的后续候选，但只有修改 YAML 顺序后才会成为 primary。
+可以通过 JSON 环境变量 `SOUWEN_SEARCH_DEFAULTS` 覆盖整张表；不能只提供局部 domain。
+
+```yaml
+search_defaults:
+  paper: [crossref, openalex, eric]
+  book: [open_library]
+  research_output: [datacite]
+  patent: [google_patents]
+  web: [bing, duckduckgo]
+  news: [duckduckgo_news]
+  images: [duckduckgo_images]
+  videos: [bilibili, duckduckgo_videos]
+  social: [reddit, weibo, zhihu]
+  office: [feishu_drive]
+  developer: [github, stackoverflow]
+  cn_tech: [linuxdo, v2ex]
+  knowledge: [wikipedia]
+```
+
+Provider 的 catalog `availability` 表示当前配置/eligibility，不是上游在线保证。当前部署若未配置
+某个 domain 的 primary（例如 `office` 的 `feishu_drive` 凭据），该 domain 会返回 canonical
+`provider_unavailable`，但不会回退到不兼容 domain 的 Provider。
 
 ### 数据源频道配置（sources）
 

--- a/docs/internal/spec-01-external-api-canonical-dto.md
+++ b/docs/internal/spec-01-external-api-canonical-dto.md
@@ -227,7 +227,7 @@ migration evidence, not the target default.
 |---|---|---:|---|
 | `targets` | array of URL target | 是 | 非空、有上限；最终 count/URL/scheme rule 由 SPEC-04。 |
 | `providers` | `ProviderRef[]` or absent | 否 | absence 使用 approved default；不得暴露 current legacy single `provider` field。 |
-| `strategy` | enum | 否 | `fallback`/`fanout` 仅作为 current evidence；canonical final set 和 cardinality 由 SPEC-04。 |
+| `strategy` | enum | 否 | frozen RC4 集合为 `fallback`/`fanout`；执行、cardinality、顺序和 partial 语义由 [SPEC-04](./spec-04-fetch-module-lld.md) 冻结。 |
 | `content` | bounded extraction options | 否 | selector/range/content limit 需 schema-listed；不能返回 raw HTML 或无上限正文。 |
 | `policy` | bounded policy options | 否 | robots / content-type choices 必须不能弱化 server security policy。 |
 

--- a/docs/internal/spec-04-fetch-module-lld.md
+++ b/docs/internal/spec-04-fetch-module-lld.md
@@ -1,0 +1,82 @@
+# SPEC-04：Fetch Module 执行与聚合
+
+**状态**：Implemented target clarification for the frozen `2.0.0rc4` wire contract
+
+**范围**：`FetchRequest` 的 `fallback` / `fanout` 执行语义、结果顺序、partial/error 规则、
+Browser Worker 边界与解压后响应大小上限
+
+**上游契约**：[SPEC-01/API-006](./spec-01-external-api-canonical-dto.md#api-006fetch-contract)
+
+## 1. 不变量
+
+1. `targets` 保持 frozen DTO 的 1–20 个 `http/https` URL 上限。
+2. `providers` 缺省时只使用部署注册的 default Fetch Provider；当前为 `builtin-fetch`。
+3. 显式 Provider 必须声明 `kind=fetch`，必须解析到已登记的 Fetch adapter，且顺序保持不变。
+4. Provider 只能执行单 target Fetch。选择、fallback、fanout、聚合和 Browser Worker 决策属于
+   Fetch Module，不下放到 Provider。
+5. 所有 attempt 共享调用方的 `ExecutionContext`；dispatch 前后都检查 cancellation/deadline。
+6. SSRF、DNS binding、redirect、robots、media type 和大小策略不能被请求字段关闭。
+
+## 2. fallback
+
+`strategy` 缺省或等于 `fallback` 时，每个 target 独立按显式 Provider 顺序执行：
+
+1. 获得非 low-quality 的成功结果后停止，不再调用后续 Provider。
+2. `quality=low` 的成功结果暂存为候选，并继续寻找更好的成功结果；若没有更好结果，保留第一个
+   low-quality 候选并将 batch 标记为 `partial=true`。
+3. `invalid_request`、`policy_blocked`、`payload_too_large`、`unsupported_media_type` 是
+   non-recoverable target outcome，不调用后续 Provider；若此前已有 low-quality 成功候选，则停止
+   并返回该候选，同时在 provenance 中保留本次失败 attempt。
+4. timeout、rate limit、provider unavailable 或 failed result 可以继续下一个 Provider。
+5. 返回 item 的 provenance 按实际 attempt 顺序合并，不伪造未执行的 Provider。
+
+不同 target 可并发；同一 target 内的 Provider attempt 按配置顺序串行。
+
+## 3. fanout
+
+`strategy=fanout` 时，Fetch Module 对每个 `target × provider` 组合并发执行，并返回每个组合的
+独立 `FetchResult`。不选择“最佳正文”，不合并不同 Provider 的 content，也不把 fanout 静默降级
+成 fallback。
+
+结果顺序固定为 target-major、provider-minor：先按 `targets` 输入顺序，再按 `providers` 输入顺序。
+因此两个 target、三个 Provider 最多返回六个 item。每个 item 的 target、status、content/error
+和 provenance 都只描述该组合的真实 outcome。公开 provenance/error 中使用 `ProviderRef.id`，内部
+adapter ID 只用于 runtime dispatch，不进入 wire result。
+
+任一组合成功时 HTTP operation 返回 `FetchBatch`；存在 failed、blocked、缺 metadata 或
+low-quality item 时 `meta.partial=true`。全部组合失败时抛出 canonical Provider error；只有单一
+adapter 时可以保留其公开 provider/retry metadata，多 adapter 时不伪造单一失败归属。
+
+`providers` 缺省且选择到一个 default Provider 时，`fanout` 退化为一个 Provider 的单次执行，
+但仍是合法请求。
+
+## 4. Browser Worker
+
+Browser Worker 是 `builtin-fetch` 的第二 execution mode，不是第二个业务 Provider：
+
+- 只有 default `builtin-fetch` adapter 可以触发 Browser Worker。
+- 显式选择其他 Fetch Provider 时不触发 builtin Browser Worker。
+- `respect_robots=true` 时不触发 Browser Worker。
+- builtin 低质量或可恢复失败时可尝试 Worker；最终 provenance 同时记录 builtin 与 Worker attempt。
+- fanout 中若某一组合是 `builtin-fetch`，该组合仍遵守上述规则；其他组合不受影响。
+
+## 5. 解压后 10 MiB hard cap
+
+IP-pinned target Fetch 使用 HTTPX raw streaming，只广告 `gzip, deflate`，并由 SouWen 对 raw stream
+做增量解码。实现最多保留 `10 MiB + 1 byte` 的解压后数据：一旦读到第 `10 MiB + 1` 字节，立即
+关闭响应 stream，返回 `PAYLOAD_TOO_LARGE`，不等待完整压缩体进入内存。
+
+`Content-Length` 和完整缓冲后的检查保留为 defense in depth，但不能替代流式解压上限。未知或
+组合 `Content-Encoding` fail closed，不作为文本渲染。多个合法 gzip member 共用同一个累计上限；
+截断 stream 和非编码 member 的 trailing data 同样 fail closed。普通 pytest 使用分块高压缩比
+fixture 证明读取会在 transport stream 完成前停止。
+
+## 6. 验证映射
+
+| 规则 | 代码 / 测试 |
+|---|---|
+| fallback 顺序、停止与 provenance | `src/souwen/modules/fetch/application/orchestration.py`；`tests/test_fetch_module_v2.py` |
+| fanout 并发、结果基数与顺序 | `src/souwen/modules/fetch/application/orchestration.py`；`tests/test_fetch_module_v2.py` |
+| 10 MiB 流式解压上限 | `src/souwen/common_runtime/provider_support/scraper/base.py`；`tests/test_web/test_ssrf_binding.py` |
+| target DTO 与错误映射 | `src/souwen/platform/provider_spi/dto.py`；`tests/test_target_canonical_dto.py` |
+| HFS 可读正文 smoke | `scripts/hf_space_smoke.py`；`tests/test_hf_space_smoke.py` |

--- a/docs/live-preview.md
+++ b/docs/live-preview.md
@@ -25,12 +25,12 @@ token，也不会把两个 token 拼接或写入 URL。
 | 功能 | 直达地址 | 最低角色 | 验收内容 |
 |---|---|---|---|
 | Login | <https://blueskyxn-souwen.hf.space/panel#/login> | 无 | 同源 Server URL、application token、错误提示与会话选项 |
-| Search | <https://blueskyxn-souwen.hf.space/panel#/search> | user | 单领域选择、请求状态、标题、snippet 与规范化结果 |
-| LLM Search | <https://blueskyxn-souwen.hf.space/panel#/llm-search> | user | 单个 configured Provider ID、固定 `single`、综合回答与 evidence |
-| Fetch | <https://blueskyxn-souwen.hf.space/panel#/fetch> | user | 最多 20 个 URL、fallback/fanout、SSRF/robots 保护结果 |
+| Search | <https://blueskyxn-souwen.hf.space/panel#/search> | user | 单领域、Server primary Provider、标题、snippet 与规范化结果 |
+| LLM Search | <https://blueskyxn-souwen.hf.space/panel#/llm-search> | user | 单个 configured Provider ID、固定 `single`、结构化 evidence 与可选 answer |
+| Fetch | <https://blueskyxn-souwen.hf.space/panel#/fetch> | user | 最多 20 个 URL、固定 `fallback`、SSRF/robots 保护结果 |
 | Providers | <https://blueskyxn-souwen.hf.space/panel#/providers> | user | 104 个 Provider package 的能力、可用性和缺失配置 |
 | Runtime | <https://blueskyxn-souwen.hf.space/panel#/runtime> | admin | 脱敏、只读的 Provider/runtime 诊断 |
-| Settings | <https://blueskyxn-souwen.hf.space/panel#/settings> | admin | 访问策略、配置数量与 LLM Search 姿态摘要 |
+| Settings | <https://blueskyxn-souwen.hf.space/panel#/settings> | admin | 访问策略、配置数量与 LLM Search gateway 声明摘要 |
 | Swagger | <https://blueskyxn-souwen.hf.space/docs> | 无 | 当前 runtime OpenAPI 的交互式文档 |
 | OpenAPI JSON | <https://blueskyxn-souwen.hf.space/openapi.json> | 无 | 8 条 canonical public contract paths |
 | Health | <https://blueskyxn-souwen.hf.space/healthz> | 无 | version、source SHA、wrapper SHA、target rollout |
@@ -45,16 +45,21 @@ token，也不会把两个 token 拼接或写入 URL。
 2. 在 Login 页保留自动填入的同源 Server URL。输入获批的 SouWen user 或 admin token；不要
    在 URL、Issue、截图、日志或聊天中粘贴凭据。
 3. 先打开 Providers，确认至少一个 `search`、一个 `llm_search` 和一个 `fetch` Provider 为
-   available。LLM Search 页的 Provider ID 应从这里选择，不使用文档中的硬编码私有配置。
-4. 在 Search 输入研究问题并选择一个领域。未显式指定 Provider 的 Server contract 一次只接受
-   一个 domain；Panel 默认选择 `paper`，避免生成必然失败的多 domain 请求。成功状态应展示规范化结果；
-   零结果应展示明确 empty state，而不是空白页面。
+   available。LLM Search ID 从当前 available 项选择，只填写 Provider ID，不填写或记录私有配置值。
+4. 在 Search 输入研究问题并选择一个领域；Panel 默认选择 `paper`，Server 按
+   `search_defaults` 选择一个 primary（当前默认 `crossref`）。Panel 不覆盖 Provider policy；
+   成功状态应展示规范化结果，零结果应展示明确 empty state。Provider catalog 的 available 不等于
+   上游永远在线，未配置的 domain primary 会安全返回 canonical error。
 5. 在 LLM Search 输入问题和一个 available Provider ID。Target runtime 的策略固定为 `single`；
-   成功状态应同时展示回答和 evidence，Provider 错误应进入可读 error state。
-6. 在 Fetch 输入一个获准的公开 `http/https` URL。成功结果应显示 target、status、title/content；
-   内网、非 HTTP scheme 或违反 server policy 的目标必须 fail closed。
-7. 使用 admin token 打开 Runtime 和 Settings。两页都只能读取；页面不得显示 token、password、
-   cookie、credential、API key 或完整私有 endpoint。
+   成功状态必须展示结构化 evidence。`answer` 按 canonical contract 可为 `null`：只有 Provider 返回
+   可验证 synthesis 时才展示回答，evidence-only 仍是有效成功，Provider 错误应进入可读 error state。
+6. 在 Fetch 输入一个获准的公开 `http/https` URL。Panel 固定使用 `fallback`；SDK/API 可显式使用
+   已实现的 `fanout`。成功结果应显示 target、status 与解压后的可读 title/content，不得把 Brotli
+   等传输编码字节当作文本；内网、非 HTTP scheme、解压后超过 10 MiB 或违反 server policy 的目标
+   必须 fail closed。
+7. 使用 admin token 打开 Runtime 和 Settings。两页都只能读取；Settings 的 gateway 配置不等于
+   Provider 已可用，实际可用性以 Providers 为准。页面不得显示 token、password、cookie、
+   credential、API key 或完整私有 endpoint。
 8. 切换 light/dark，并在窄屏下检查所有导航和表单；使用 `Tab` 验证 skip link、焦点环和按钮顺序。
 
 ## HTTP 快速核对

--- a/docs/python-sdk.md
+++ b/docs/python-sdk.md
@@ -12,7 +12,7 @@ from souwen import SouWenClient
 from souwen.delivery.client_sdk import SearchRequest
 
 with SouWenClient("https://souwen.example", token="your-user-token") as client:
-    page = client.search(SearchRequest(query="retrieval", domains=["paper", "web"]))
+    page = client.search(SearchRequest(query="retrieval", domains=["paper"]))
 ```
 
 ```python

--- a/docs/typescript-sdk.md
+++ b/docs/typescript-sdk.md
@@ -13,7 +13,8 @@ PYTHONPATH=src pytest tests/test_typescript_sdk_generator.py -v --tb=short
 cd panel && npm test -- --run src/core/sdk/index.test.ts
 ```
 
-Generator 固定记录 `SDK_VERSION`、`SUPPORTED_API_MAJOR` 和 canonical artifact 的
+Generator 固定记录 `SDK_VERSION`、`SUPPORTED_API_MAJOR`、由 OpenAPI enum 派生的
+`SEARCH_DOMAINS` 和 canonical artifact 的
 SHA-256，并对 35 个 DTO、8 个 operation、security/header contract、schema ref、重复
 operation/schema 和不能安全映射的 schema shape 进行 fail-closed 校验。`--check` 只比较
 生成结果，不写文件。

--- a/panel/src/CalmPrecisionApp.tsx
+++ b/panel/src/CalmPrecisionApp.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState, type FormEvent, type ReactNode } from 'react'
 import { HashRouter, Navigate, NavLink, Outlet, Route, Routes, useNavigate } from 'react-router'
 import { Database, FileSearch, LogOut, Moon, Network, Search, Sparkles, Sun, type LucideIcon } from 'lucide-react'
-import { SouWenClient, type FetchBatch, type LLMSearchResult, type SearchPage } from '@core/sdk'
+import { SEARCH_DOMAINS, SouWenClient, type FetchBatch, type LLMSearchResult, type SearchPage } from '@core/sdk'
 import { useSouWenClient } from '@core/sdk-client'
 import { formatError } from '@core/lib/errors'
 import { adminClient } from '@core/services/admin-client'
@@ -12,10 +12,6 @@ type DataState<T> = { status: 'idle' | 'loading' | 'success' | 'error'; data?: T
 type RequestFor<T extends 'search' | 'llmSearch' | 'fetch'> = Parameters<SouWenClient[T]>[0]
 type Item = Record<string, unknown>
 
-const DOMAINS = [
-  'paper', 'book', 'research_output', 'patent', 'web', 'news', 'images', 'videos', 'social',
-  'office', 'developer', 'cn_tech', 'knowledge',
-]
 const SECRET_KEY = /(?:token|secret|password|api[_-]?key|authorization|cookie|credential)/i
 
 export function redactForDisplay(value: unknown, key = ''): unknown {
@@ -32,9 +28,9 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 /** Keep Settings focused on safe product posture instead of echoing the full server config. */
 export function projectSettingsForDisplay(value: unknown): Record<string, unknown> {
   const config = isRecord(value) ? value : {}
-  const llm = isRecord(config.llm) ? config.llm : {}
   const sources = isRecord(config.sources) ? config.sources : {}
   const gateways = isRecord(config.llm_search_gateways) ? config.llm_search_gateways : {}
+  const gatewayCount = Object.keys(gateways).length
   return {
     access: {
       guest_enabled: config.guest_enabled === true,
@@ -44,12 +40,11 @@ export function projectSettingsForDisplay(value: unknown): Record<string, unknow
     },
     providers: {
       configured_source_count: Object.keys(sources).length,
-      llm_gateway_count: Object.keys(gateways).length,
+      llm_gateway_count: gatewayCount,
     },
     llm_search: {
-      enabled: llm.enabled === true,
-      protocol: typeof llm.protocol === 'string' ? llm.protocol : null,
-      model: typeof llm.model === 'string' ? llm.model : null,
+      gateway_declared: gatewayCount > 0,
+      availability_source: 'Providers',
     },
   }
 }
@@ -123,7 +118,7 @@ function SearchPage() {
       (error) => setState({ status: 'error', error: formatError(error) }),
     )
   }
-  return <><Header eyebrow="Search" title="搜索" description="选择一个领域并提交查询，结果统一规范化，只展示可追溯的公共字段。" /><section className={`${styles.panel} ${styles.formPanel}`}><form className={styles.form} onSubmit={submit}><div className={styles.field}><label className={styles.label} htmlFor="search-query">查询</label><input className={styles.input} id="search-query" name="query" type="search" value={query} onChange={(event) => setQuery(event.target.value)} required maxLength={4096} placeholder="输入研究问题、主题或作者" /></div><div className={styles.field}><label className={styles.label} htmlFor="search-domain">领域</label><select className={styles.select} id="search-domain" name="domain" value={domain} onChange={(event) => setDomain(event.target.value)}>{DOMAINS.map((value) => <option key={value} value={value}>{value}</option>)}</select><span className={styles.hint}>默认 Provider 选择一次只接受一个领域。</span></div><div className={styles.formFooter}><span className={styles.hint}>由 generated SouWenClient 发送请求。</span><button className={styles.button} disabled={state.status === 'loading' || !query.trim()} type="submit" aria-busy={state.status === 'loading'}>运行搜索</button></div></form></section><Status state={state} name="搜索结果" />{state.status === 'success' && <Results items={state.data?.items ?? []} />}</>
+  return <><Header eyebrow="Search" title="搜索" description="选择一个领域，由 Server 的有序默认策略选择一个 Provider；结果只展示可追溯的公共字段。" /><section className={`${styles.panel} ${styles.formPanel}`}><form className={styles.form} onSubmit={submit}><div className={styles.field}><label className={styles.label} htmlFor="search-query">查询</label><input className={styles.input} id="search-query" name="query" type="search" value={query} onChange={(event) => setQuery(event.target.value)} required maxLength={4096} placeholder="输入研究问题、主题或作者" /></div><div className={styles.field}><label className={styles.label} htmlFor="search-domain">领域</label><select className={styles.select} id="search-domain" name="domain" value={domain} onChange={(event) => setDomain(event.target.value)}>{SEARCH_DOMAINS.map((value) => <option key={value} value={value}>{value}</option>)}</select><span className={styles.hint}>一次只接受一个领域；默认 paper 使用部署配置中的 primary Provider。</span></div><div className={styles.formFooter}><span className={styles.hint}>由 generated SouWenClient 发送请求。</span><button className={styles.button} disabled={state.status === 'loading' || !query.trim()} type="submit" aria-busy={state.status === 'loading'}>运行搜索</button></div></form></section><Status state={state} name="搜索结果" />{state.status === 'success' && <Results items={state.data?.items ?? []} />}</>
 }
 
 function LlmSearchPage() {
@@ -140,14 +135,13 @@ function LlmSearchPage() {
       (error) => setState({ status: 'error', error: formatError(error) }),
     )
   }
-  return <><Header eyebrow="LLM Search" title="综合搜索" description="选定当前部署配置的 provider，由 LLM 汇总回答并附带来源证据。" /><section className={`${styles.panel} ${styles.formPanel}`}><form className={styles.form} onSubmit={submit}><div className={styles.field}><label className={styles.label} htmlFor="llm-query">问题</label><textarea className={styles.textarea} id="llm-query" name="query" value={query} onChange={(event) => setQuery(event.target.value)} required maxLength={4096} placeholder="提出一个需要依据的研究问题" /></div><div className={styles.field}><label className={styles.label} htmlFor="llm-provider">Provider ID</label><input className={styles.input} id="llm-provider" name="provider" value={provider} onChange={(event) => setProvider(event.target.value)} required placeholder="从 Providers 页复制 available 的 LLM Search ID" /><span className={styles.hint}>Target runtime 只接受一个已配置 provider，策略固定为 single。</span></div><div className={styles.formFooter}><span className={styles.hint}>预算与认证边界由服务端执行。</span><button className={styles.button} disabled={state.status === 'loading' || !query.trim() || !provider.trim()} type="submit" aria-busy={state.status === 'loading'}>综合回答</button></div></form></section><Status state={state} name="LLM Search" />{state.status === 'success' && <section className={styles.responseStack} aria-live="polite">{state.data?.answer && <article className={`${styles.panel} ${styles.answer}`}><h2 className={styles.sectionTitle}>回答</h2><p className={styles.resultBody}>{state.data.answer}</p></article>}<Results items={state.data?.evidence ?? state.data?.items ?? []} /></section>}</>
+  return <><Header eyebrow="LLM Search" title="综合搜索" description="返回结构化来源证据；Provider 支持可验证 synthesis 时同时展示综合回答。" /><section className={`${styles.panel} ${styles.formPanel}`}><form className={styles.form} onSubmit={submit}><div className={styles.field}><label className={styles.label} htmlFor="llm-query">问题</label><textarea className={styles.textarea} id="llm-query" name="query" value={query} onChange={(event) => setQuery(event.target.value)} required maxLength={4096} placeholder="提出一个需要依据的研究问题" /></div><div className={styles.field}><label className={styles.label} htmlFor="llm-provider">Provider ID</label><input className={styles.input} id="llm-provider" name="provider" value={provider} onChange={(event) => setProvider(event.target.value)} required placeholder="从 Providers 页复制 available 的 LLM Search ID" /><span className={styles.hint}>Target runtime 只接受一个已配置 provider，策略固定为 single。</span></div><div className={styles.formFooter}><span className={styles.hint}>预算与认证边界由服务端执行。</span><button className={styles.button} disabled={state.status === 'loading' || !query.trim() || !provider.trim()} type="submit" aria-busy={state.status === 'loading'}>运行 LLM Search</button></div></form></section><Status state={state} name="LLM Search" />{state.status === 'success' && <section className={styles.responseStack} aria-live="polite">{state.data?.answer ? <article className={`${styles.panel} ${styles.answer}`}><h2 className={styles.sectionTitle}>回答</h2><p className={styles.resultBody}>{state.data.answer}</p></article> : <p className={`${styles.panel} ${styles.empty}`}>当前 Provider 返回了结构化证据，但未提供可验证的综合回答。</p>}<Results items={state.data?.evidence ?? state.data?.items ?? []} /></section>}</>
 }
 
 function FetchPage() {
   const client = useSouWenClient()
   const request = useLatestRequest<FetchBatch>()
   const [targets, setTargets] = useState('')
-  const [strategy, setStrategy] = useState<'fallback' | 'fanout'>('fallback')
   const [state, setState] = useState<DataState<{ items: Item[] }>>({ status: 'idle' })
   async function submit(event: FormEvent) {
     event.preventDefault(); const urls = targets.split(/\n|,/).map((value) => value.trim()).filter(Boolean); if (!urls.length) return
@@ -158,12 +152,12 @@ function FetchPage() {
     }
     setState({ status: 'loading' })
     void request.run(
-      (signal) => client.fetch({ targets: urls, strategy, policy: { respect_robots: true } } as RequestFor<'fetch'>, { signal }),
+      (signal) => client.fetch({ targets: urls, strategy: 'fallback', policy: { respect_robots: true } } as RequestFor<'fetch'>, { signal }),
       (data) => setState({ status: 'success', data: data as unknown as { items: Item[] } }),
       (error) => setState({ status: 'error', error: formatError(error) }),
     )
   }
-  return <><Header eyebrow="Fetch" title="网页抓取" description="每行一个 URL，最多 20 个。抓取与 robots 策略全部由服务端执行。" /><section className={`${styles.panel} ${styles.formPanel}`}><form className={styles.form} onSubmit={submit}><div className={styles.field}><label className={styles.label} htmlFor="fetch-targets">URLs</label><textarea className={styles.textarea} id="fetch-targets" name="targets" value={targets} onChange={(event) => setTargets(event.target.value)} required placeholder={'https://example.org/article\nhttps://example.org/report'} /><span className={styles.hint}>仅接受 http/https URL，服务端负责最终校验。</span></div><div className={styles.field}><label className={styles.label} htmlFor="fetch-strategy">Provider 策略</label><select className={styles.select} id="fetch-strategy" name="strategy" value={strategy} onChange={(event) => setStrategy(event.target.value as typeof strategy)}><option value="fallback">fallback</option><option value="fanout">fanout</option></select></div><div className={styles.formFooter}><span className={styles.hint}>可用性取决于当前角色和 provider 配置。</span><button className={styles.button} disabled={state.status === 'loading' || !targets.trim()} type="submit" aria-busy={state.status === 'loading'}>开始 Fetch</button></div></form></section><Status state={state} name="Fetch 结果" />{state.status === 'success' && <Results items={state.data?.items ?? []} />}</>
+  return <><Header eyebrow="Fetch" title="网页抓取" description="每行一个 URL，最多 20 个。抓取与 robots 策略全部由服务端执行。" /><section className={`${styles.panel} ${styles.formPanel}`}><form className={styles.form} onSubmit={submit}><div className={styles.field}><label className={styles.label} htmlFor="fetch-targets">URLs</label><textarea className={styles.textarea} id="fetch-targets" name="targets" value={targets} onChange={(event) => setTargets(event.target.value)} required placeholder={'https://example.org/article\nhttps://example.org/report'} /><span className={styles.hint}>仅接受 http/https URL，服务端负责最终校验。</span></div><div className={styles.field}><span className={styles.label}>Provider 策略</span><span className={styles.hint}>Panel 固定使用 fallback；多 Provider fanout 由显式 SDK/API workflow 使用。</span></div><div className={styles.formFooter}><span className={styles.hint}>可用性取决于当前角色和 provider 配置。</span><button className={styles.button} disabled={state.status === 'loading' || !targets.trim()} type="submit" aria-busy={state.status === 'loading'}>开始 Fetch</button></div></form></section><Status state={state} name="Fetch 结果" />{state.status === 'success' && <Results items={state.data?.items ?? []} />}</>
 }
 
 function ProvidersPage() {

--- a/panel/src/core/sdk/index.ts
+++ b/panel/src/core/sdk/index.ts
@@ -1,11 +1,13 @@
 /* Generated from contracts/openapi/souwen-openapi-2.0.0rc4.json; do not edit. */
-/* generator_version=1 */
+/* generator_version=2 */
 /* openapi_sha256=d036abf271f31022396d3f549da04fde1da2000dd74fe8f21f22111adbd76709 */
 
 export const SDK_VERSION = '2.0.0rc4' as const
 export const SUPPORTED_API_MAJOR = 2 as const
 export const OPENAPI_SHA256 = 'd036abf271f31022396d3f549da04fde1da2000dd74fe8f21f22111adbd76709' as const
 export const DEFAULT_TIMEOUT_MS = 125_000
+export const SEARCH_DOMAINS = ["paper", "book", "research_output", "patent", "web", "news", "images", "videos", "social", "office", "developer", "cn_tech", "knowledge"] as const
+export type SearchDomain = typeof SEARCH_DOMAINS[number]
 
 export interface ClientRequestContext {
   request_id?: string | null

--- a/panel/src/core/test/calmPrecisionApp.test.tsx
+++ b/panel/src/core/test/calmPrecisionApp.test.tsx
@@ -39,8 +39,14 @@ function searchPage(items: Array<Record<string, unknown>>) {
   return { items, page: { limit: 20 }, meta: {}, context: { request_id: 'test', api_major: 2 } }
 }
 
-function llmResult(answer: string, evidence: Array<Record<string, unknown>> = []) {
-  return { answer, evidence, items: [], meta: {}, usage: {}, query: 'query', context: { request_id: 'test', api_major: 2 } }
+function llmResult(answer: string | null, evidence: Array<Record<string, unknown>> = []) {
+  const items = evidence.map((item, index) => ({
+    id: String(item.item_id ?? `item-${index + 1}`),
+    title: String(item.title_or_snippet ?? `item-${index + 1}`),
+    url: item.public_url,
+    provenance: [{ provider: String(item.provider ?? 'provider'), outcome: 'success' }],
+  }))
+  return { answer, evidence, items, meta: {}, usage: {}, query: 'query', context: { request_id: 'test', api_major: 2 } }
 }
 
 function fetchBatch(items: Array<Record<string, unknown>>) {
@@ -102,7 +108,7 @@ describe('Calm Precision Panel', () => {
     })
   })
 
-  it('projects Settings to a safe posture summary without legacy or secret fields', () => {
+  it('projects Settings to a safe gateway posture without legacy or secret fields', () => {
     const summary = projectSettingsForDisplay({
       admin_password: 'masked',
       proxy: 'http://private.example',
@@ -124,7 +130,7 @@ describe('Calm Precision Panel', () => {
         trusted_proxy_count: 1,
       },
       providers: { configured_source_count: 1, llm_gateway_count: 1 },
-      llm_search: { enabled: true, protocol: 'openai_chat', model: 'test-model' },
+      llm_search: { gateway_declared: true, availability_source: 'Providers' },
     })
     expect(JSON.stringify(summary)).not.toMatch(
       /admin_password|warp_enabled|api_key|private\.example|masked|secret/i,
@@ -150,6 +156,20 @@ describe('Calm Precision Panel', () => {
     expect(await screen.findByRole('alert')).toHaveTextContent('request failed')
   })
 
+  it('uses the generated domain list and leaves Provider selection to the Server', async () => {
+    authenticate('user')
+    sdk.search.mockResolvedValueOnce(searchPage([]))
+    const user = userEvent.setup()
+    render(<CalmPrecisionApp />)
+
+    await user.type(await screen.findByLabelText('查询'), 'default provider query')
+    await user.selectOptions(screen.getByRole('combobox', { name: '领域' }), 'knowledge')
+    await user.click(screen.getByRole('button', { name: '运行搜索' }))
+
+    expect(sdk.search.mock.calls[0][0]).toMatchObject({ domains: ['knowledge'] })
+    expect(sdk.search.mock.calls[0][0]).not.toHaveProperty('providers')
+  })
+
   it('rejects an untrusted base URL before a token can be sent', () => {
     expect(() => assertBaseUrlAllowed('https://untrusted.example')).toThrow('白名单')
   })
@@ -157,7 +177,7 @@ describe('Calm Precision Panel', () => {
   it('renders contract-shaped LLM evidence with title_or_snippet and public_url', async () => {
     authenticate('user')
     window.location.hash = '#/llm-search'
-    sdk.llmSearch.mockResolvedValueOnce(llmResult('依据已汇总。', [{
+    sdk.llmSearch.mockResolvedValueOnce(llmResult('依据已汇总。[evidence-1]', [{
       id: 'evidence-1', item_id: 'item-1', provider: 'provider-a', public_url: 'https://example.test/evidence',
       retrieved_at: '2026-07-27T00:00:00Z', title_or_snippet: '规范化证据标题',
     }]))
@@ -166,7 +186,7 @@ describe('Calm Precision Panel', () => {
 
     await user.type(await screen.findByLabelText('问题'), 'evidence query')
     await user.type(screen.getByLabelText('Provider ID'), 'provider-a')
-    await user.click(screen.getByRole('button', { name: '综合回答' }))
+    await user.click(screen.getByRole('button', { name: '运行 LLM Search' }))
 
     expect(sdk.llmSearch.mock.calls[0][0]).toMatchObject({
       providers: [{ id: 'provider-a', kind: 'llm_search' }],
@@ -174,6 +194,25 @@ describe('Calm Precision Panel', () => {
     })
     expect(await screen.findByRole('link', { name: '规范化证据标题' })).toHaveAttribute('href', 'https://example.test/evidence')
     expect(screen.getByText('provider-a')).toBeInTheDocument()
+  })
+
+  it('treats evidence-only LLM Search as a successful contract response', async () => {
+    authenticate('user')
+    window.location.hash = '#/llm-search'
+    sdk.llmSearch.mockResolvedValueOnce(llmResult(null, [{
+      id: 'evidence-1', item_id: 'item-1', provider: 'provider-a', public_url: 'https://example.test/evidence',
+      retrieved_at: '2026-07-27T00:00:00Z', title_or_snippet: '仅证据结果',
+    }]))
+    const user = userEvent.setup()
+    render(<CalmPrecisionApp />)
+
+    await user.type(await screen.findByLabelText('问题'), 'evidence-only query')
+    await user.type(screen.getByLabelText('Provider ID'), 'provider-a')
+    await user.click(screen.getByRole('button', { name: '运行 LLM Search' }))
+
+    expect(await screen.findByRole('link', { name: '仅证据结果' })).toBeInTheDocument()
+    expect(screen.getByText('当前 Provider 返回了结构化证据，但未提供可验证的综合回答。')).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: '回答' })).not.toBeInTheDocument()
   })
 
   it('rejects a Fetch batch over 20 URLs without calling the SDK', async () => {
@@ -191,6 +230,24 @@ describe('Calm Precision Panel', () => {
 
     expect(await screen.findByRole('alert')).toHaveTextContent('最多支持 20 个 URL')
     expect(sdk.fetch).not.toHaveBeenCalled()
+  })
+
+  it('uses the target runtime fallback Fetch strategy without exposing fanout', async () => {
+    authenticate('user')
+    window.location.hash = '#/fetch'
+    sdk.fetch.mockResolvedValueOnce(fetchBatch([]))
+    const user = userEvent.setup()
+    render(<CalmPrecisionApp />)
+
+    await user.type(await screen.findByLabelText('URLs'), 'https://example.test/article')
+    expect(screen.queryByRole('option', { name: 'fanout' })).not.toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: '开始 Fetch' }))
+
+    expect(sdk.fetch.mock.calls[0][0]).toMatchObject({
+      targets: ['https://example.test/article'],
+      strategy: 'fallback',
+      policy: { respect_robots: true },
+    })
   })
 
   it('keeps the latest Search result, aborts the replaced request, and aborts on unmount', async () => {
@@ -235,7 +292,7 @@ describe('Calm Precision Panel', () => {
     const form = query.closest('form')!
     await user.type(query, 'first')
     await user.type(screen.getByLabelText('Provider ID'), 'provider-a')
-    await user.click(screen.getByRole('button', { name: '综合回答' }))
+    await user.click(screen.getByRole('button', { name: '运行 LLM Search' }))
     const firstSignal = sdk.llmSearch.mock.calls[0][1].signal as AbortSignal
     await user.clear(query)
     await user.type(query, 'second')

--- a/scripts/hf_space_smoke.py
+++ b/scripts/hf_space_smoke.py
@@ -370,12 +370,32 @@ def _capability_checks(
     checks: list[Check],
     providers: list[dict],
 ) -> None:
+    def search_default():
+        status, _headers, payload = client.json(
+            "/api/v1/search",
+            method="POST",
+            payload={
+                "query": "retrieval augmented generation",
+                "domains": ["paper"],
+                "page": {"limit": 3},
+            },
+        )
+        _expect(
+            status == 200 and isinstance(payload.get("items"), list),
+            f"default search {status}",
+        )
+        requested = payload.get("meta", {}).get("requested", [])
+        _expect(len(requested) == 1, "default search did not select exactly one Provider")
+        return f"{requested[0]}: {len(payload['items'])} results", payload
+
+    _record(checks, "search_default_live", search_default)
+
     def search():
         failures: list[str] = []
         for search_provider in _preferred_available(
             providers,
             "search",
-            ("openalex", "crossref", "semantic_scholar"),
+            ("crossref", "openalex", "semantic_scholar"),
         ):
             status, _headers, payload = client.json(
                 "/api/v1/search",
@@ -442,6 +462,35 @@ def _capability_checks(
         return f"{fetch_provider}: immutable target fetched", payload
 
     _record(checks, "fetch_live", fetch)
+
+    def fetch_readable_content():
+        fetch_provider = _first_available(
+            providers,
+            "fetch",
+            ("builtin-fetch",),
+        )
+        _expect(fetch_provider == "builtin-fetch", "builtin Fetch provider is unavailable")
+        status, _headers, payload = client.json(
+            "/api/v1/fetch",
+            method="POST",
+            payload={
+                "targets": ["https://example.com/"],
+                "providers": [{"id": fetch_provider, "kind": "fetch"}],
+                "strategy": "fanout",
+                "policy": {"respect_robots": True},
+            },
+        )
+        items = payload.get("items") if isinstance(payload, dict) else None
+        _expect(status == 200 and isinstance(items, list) and items, f"fetch readable {status}")
+        content = items[0].get("content")
+        _expect(items[0].get("status") == "success", "readable Fetch result failed")
+        _expect(
+            isinstance(content, str) and "Example Domain" in content, "Fetch content unreadable"
+        )
+        _expect("\ufffd" not in content, "Fetch content contains replacement characters")
+        return "builtin-fetch fanout: readable public content", payload
+
+    _record(checks, "fetch_readable_live", fetch_readable_content)
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:

--- a/souwen.example.yaml
+++ b/souwen.example.yaml
@@ -220,6 +220,24 @@ warp:
   # external 模式: 外部 WARP 代理地址（如 socks5://warp:1080）
   warp_external_proxy: ~
 
+# ===== Search 有序默认 Provider =====
+# providers 缺省时，每个 domain 只选择列表中的第一个 primary；
+# 这里的后续候选用于显式配置排序，不会在一次请求内自动 fallback/fanout。
+search_defaults:
+  paper: [crossref, openalex, eric]
+  book: [open_library]
+  research_output: [datacite]
+  patent: [google_patents]
+  web: [bing, duckduckgo]
+  news: [duckduckgo_news]
+  images: [duckduckgo_images]
+  videos: [bilibili, duckduckgo_videos]
+  social: [reddit, weibo, zhihu]
+  office: [feishu_drive]
+  developer: [github, stackoverflow]
+  cn_tech: [linuxdo, v2ex]
+  knowledge: [wikipedia]
+
 # ===== LLM Search 共享 Gateway =====
 # 多个 concrete source 共享一份 gateway 配置；API Key 与私有 URL 不应写入公开产物。
 # 可通过对应的 LLM Search gateway 环境配置注入；private URL 不会进入 catalog。

--- a/src/souwen/common_runtime/provider_support/scraper/base.py
+++ b/src/souwen/common_runtime/provider_support/scraper/base.py
@@ -54,6 +54,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import random
+import zlib
 from typing import Any
 from urllib.parse import urljoin, urlparse
 
@@ -76,6 +77,139 @@ from souwen.common_runtime.provider_support.fingerprint import get_random_finger
 
 logger = logging.getLogger("souwen.common_runtime.provider_support.scraper")
 _REDIRECT_CODES = frozenset({301, 302, 303, 307, 308})
+
+
+def _decoded_response_headers(headers: httpx.Headers, content_length: int) -> httpx.Headers:
+    normalized = httpx.Headers(headers)
+    for name in ("content-encoding", "content-length"):
+        if name in normalized:
+            del normalized[name]
+    normalized["Content-Length"] = str(content_length)
+    return normalized
+
+
+def _response_too_large(response: httpx.Response, max_response_bytes: int) -> httpx.Response:
+    extensions = dict(response.extensions)
+    extensions.update(
+        {
+            "souwen_response_too_large": True,
+            "souwen_response_size_lower_bound": max_response_bytes + 1,
+        }
+    )
+    return httpx.Response(
+        response.status_code,
+        headers=_decoded_response_headers(response.headers, 0),
+        content=b"",
+        request=response.request,
+        extensions=extensions,
+    )
+
+
+def _is_zlib_wrapped_deflate(prefix: bytes) -> bool:
+    """Choose the RFC zlib wrapper deterministically from its two-byte header."""
+
+    if len(prefix) < 2:
+        return False
+    compression_method, flags = prefix[0], prefix[1]
+    return (
+        compression_method & 0x0F == 8
+        and compression_method >> 4 <= 7
+        and (compression_method << 8 | flags) % 31 == 0
+    )
+
+
+async def _read_bounded_httpx_response(
+    response: httpx.Response,
+    max_response_bytes: int,
+) -> httpx.Response:
+    """Read at most ``max + 1`` decoded bytes from one streamed HTTPX response."""
+
+    if max_response_bytes < 1:
+        raise ValueError("max_response_bytes must be positive")
+    encoding_header = response.headers.get("content-encoding", "").strip().lower()
+    encodings = tuple(part.strip() for part in encoding_header.split(",") if part.strip())
+    if len(encodings) > 1 or (encodings and encodings[0] not in {"identity", "gzip", "deflate"}):
+        raise httpx.DecodingError(f"unsupported content encoding: {encoding_header}")
+    encoding = encodings[0] if encodings else "identity"
+    body = bytearray()
+
+    if encoding == "identity":
+        async for raw_chunk in response.aiter_raw():
+            remaining = max_response_bytes + 1 - len(body)
+            body.extend(raw_chunk[:remaining])
+            if len(body) > max_response_bytes:
+                return _response_too_large(response, max_response_bytes)
+        return httpx.Response(
+            response.status_code,
+            headers=_decoded_response_headers(response.headers, len(body)),
+            content=bytes(body),
+            request=response.request,
+            extensions=dict(response.extensions),
+        )
+
+    decoder: Any | None = None
+    deflate_prefix = bytearray()
+    deflate_raw: bool | None = None
+    completed_stream = False
+    async for raw_chunk in response.aiter_raw():
+        if not raw_chunk:
+            continue
+        if encoding == "deflate" and completed_stream:
+            raise httpx.DecodingError("trailing data after deflate stream")
+        if encoding == "deflate" and deflate_raw is None:
+            deflate_prefix.extend(raw_chunk)
+            if len(deflate_prefix) < 2:
+                continue
+            pending = bytes(deflate_prefix)
+            deflate_prefix.clear()
+            deflate_raw = not _is_zlib_wrapped_deflate(pending[:2])
+        else:
+            pending = raw_chunk
+        while pending:
+            if decoder is None:
+                decoder = zlib.decompressobj(
+                    -zlib.MAX_WBITS
+                    if deflate_raw is True
+                    else zlib.MAX_WBITS | 16
+                    if encoding == "gzip"
+                    else zlib.MAX_WBITS
+                )
+            remaining = max_response_bytes + 1 - len(body)
+            input_chunk = pending
+            try:
+                decoded = decoder.decompress(input_chunk, remaining)
+            except zlib.error as exc:
+                raise httpx.DecodingError(str(exc)) from exc
+            body.extend(decoded)
+            if len(body) > max_response_bytes:
+                return _response_too_large(response, max_response_bytes)
+
+            pending = decoder.unconsumed_tail
+            if decoder.eof:
+                try:
+                    body.extend(decoder.flush(max_response_bytes + 1 - len(body)))
+                except zlib.error as exc:
+                    raise httpx.DecodingError(str(exc)) from exc
+                if len(body) > max_response_bytes:
+                    return _response_too_large(response, max_response_bytes)
+                pending = decoder.unused_data or pending
+                completed_stream = True
+                decoder = None
+                if encoding == "deflate" and pending:
+                    raise httpx.DecodingError("trailing data after deflate stream")
+            elif pending == input_chunk and not decoded:
+                raise httpx.DecodingError("content decoder made no progress")
+
+    if deflate_prefix or decoder is not None or not completed_stream:
+        raise httpx.DecodingError(f"incomplete {encoding} stream")
+    return httpx.Response(
+        response.status_code,
+        headers=_decoded_response_headers(response.headers, len(body)),
+        content=bytes(body),
+        request=response.request,
+        extensions=dict(response.extensions),
+    )
+
 
 # 尝试导入 curl_cffi（TLS 指纹模拟）— 可选依赖，缺失时自动回退 httpx
 _HAS_CURL_CFFI = False
@@ -252,6 +386,7 @@ class BaseScraper:
         *,
         _resolved_target: ResolvedFetchTarget | None = None,
         _include_configured_headers: bool = True,
+        _max_response_bytes: int | None = None,
     ) -> httpx.Response:
         """带重试和礼貌延迟的请求方法
 
@@ -293,12 +428,15 @@ class BaseScraper:
 
             try:
                 if _resolved_target is not None:
+                    resolved_kwargs: dict[str, Any] = {"data": data}
+                    if _max_response_bytes is not None:
+                        resolved_kwargs["_max_response_bytes"] = _max_response_bytes
                     resp = await self._do_resolved_request(
                         method,
                         _resolved_target,
                         params,
                         request_headers,
-                        data=data,
+                        **resolved_kwargs,
                     )
                 else:
                     resp = await self._do_request(method, url, params, request_headers, data=data)
@@ -465,6 +603,8 @@ class BaseScraper:
         params: dict[str, Any] | None,
         headers: dict[str, str],
         data: dict[str, Any] | None = None,
+        *,
+        _max_response_bytes: int | None = None,
     ) -> httpx.Response:
         """Request an IP-pinned target while preserving the original Host and HTTPS SNI.
 
@@ -488,12 +628,29 @@ class BaseScraper:
         extensions = (
             {"sni_hostname": target.sni_hostname} if target.sni_hostname is not None else None
         )
-        return await safe_httpx_client.request(
-            method,
-            target.connect_url,
-            params=params,
-            headers=headers,
-            data=data,
-            follow_redirects=False,
-            extensions=extensions,
-        )
+        safe_headers = dict(headers)
+        for header_name in tuple(safe_headers):
+            if header_name.lower() == "accept-encoding":
+                safe_headers.pop(header_name)
+        # The IP-pinned path always uses HTTPX, which only guarantees gzip/deflate decoders.
+        # Do not advertise optional Brotli support inherited from the browser fingerprint.
+        safe_headers["Accept-Encoding"] = "gzip, deflate"
+        request_kwargs = {
+            "params": params,
+            "headers": safe_headers,
+            "data": data,
+            "extensions": extensions,
+        }
+        if _max_response_bytes is None:
+            return await safe_httpx_client.request(
+                method,
+                target.connect_url,
+                follow_redirects=False,
+                **request_kwargs,
+            )
+        request = safe_httpx_client.build_request(method, target.connect_url, **request_kwargs)
+        response = await safe_httpx_client.send(request, stream=True, follow_redirects=False)
+        try:
+            return await _read_bounded_httpx_response(response, _max_response_bytes)
+        finally:
+            await response.aclose()

--- a/src/souwen/config/__init__.py
+++ b/src/souwen/config/__init__.py
@@ -25,11 +25,19 @@ from .loader import (
     get_config,
     reload_config,
 )
-from .models import LLMSearchGatewayConfig, SourceChannelConfig, SouWenConfig
+from .models import (
+    DEFAULT_SEARCH_PROVIDERS,
+    SEARCH_DOMAINS,
+    LLMSearchGatewayConfig,
+    SourceChannelConfig,
+    SouWenConfig,
+)
 from .template import _DEFAULT_CONFIG_TEMPLATE
 from .validators import _ALLOWED_PROXY_SCHEMES, _validate_proxy_url
 
 __all__ = [
+    "DEFAULT_SEARCH_PROVIDERS",
+    "SEARCH_DOMAINS",
     "SouWenConfig",
     "SourceChannelConfig",
     "LLMSearchGatewayConfig",

--- a/src/souwen/config/loader.py
+++ b/src/souwen/config/loader.py
@@ -41,7 +41,7 @@ _RETIRED_FEATURE_FIELDS = {
     "unpaywall_email": "Unpaywall provider 已退休",
 }
 
-_NESTED_CONFIG_FIELDS = frozenset({"sources", "llm_search_gateways"})
+_NESTED_CONFIG_FIELDS = frozenset({"sources", "search_defaults", "llm_search_gateways"})
 _EXACT_ENV_REFERENCE = re.compile(r"^\$\{([A-Z_][A-Z0-9_]*)\}$")
 
 

--- a/src/souwen/config/models.py
+++ b/src/souwen/config/models.py
@@ -8,7 +8,10 @@ from __future__ import annotations
 
 import logging
 import random
+import re
+from collections.abc import Mapping
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any, Literal
 from urllib.parse import urlsplit
 
@@ -24,6 +27,39 @@ UNIAPI_ARK_TARGET_SOURCE_IDS = (
     "uniapi_ark_annotations_deepseek_v3_2_251201",
     "uniapi_ark_annotations_doubao_seed_2_0_lite_260428",
 )
+SEARCH_DOMAINS = (
+    "paper",
+    "book",
+    "research_output",
+    "patent",
+    "web",
+    "news",
+    "images",
+    "videos",
+    "social",
+    "office",
+    "developer",
+    "cn_tech",
+    "knowledge",
+)
+DEFAULT_SEARCH_PROVIDERS: Mapping[str, tuple[str, ...]] = MappingProxyType(
+    {
+        "paper": ("crossref", "openalex", "eric"),
+        "book": ("open_library",),
+        "research_output": ("datacite",),
+        "patent": ("google_patents",),
+        "web": ("bing", "duckduckgo"),
+        "news": ("duckduckgo_news",),
+        "images": ("duckduckgo_images",),
+        "videos": ("bilibili", "duckduckgo_videos"),
+        "social": ("reddit", "weibo", "zhihu"),
+        "office": ("feishu_drive",),
+        "developer": ("github", "stackoverflow"),
+        "cn_tech": ("linuxdo", "v2ex"),
+        "knowledge": ("wikipedia",),
+    }
+)
+_PROVIDER_ID_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,127}$")
 
 
 def _normalize_llm_search_base_url(value: str | None) -> str | None:
@@ -333,8 +369,50 @@ class SouWenConfig(BaseModel):
     # ===== 数据源频道配置 =====
     sources: dict[str, SourceChannelConfig] = Field(default_factory=dict)
 
+    # ===== Search domain/capability 有序默认表 =====
+    search_defaults: dict[str, tuple[str, ...]] = Field(
+        default_factory=lambda: dict(DEFAULT_SEARCH_PROVIDERS)
+    )
+
     # ===== LLM Search 共享 gateway 配置 =====
     llm_search_gateways: dict[str, LLMSearchGatewayConfig] = Field(default_factory=dict)
+
+    @field_validator("search_defaults", mode="before")
+    @classmethod
+    def _validate_search_defaults(cls, value: Any) -> dict[str, tuple[str, ...]]:
+        if not isinstance(value, dict):
+            raise ValueError("search_defaults must be an object")
+        observed = set(value)
+        expected = set(SEARCH_DOMAINS)
+        if observed != expected:
+            missing = ",".join(sorted(expected - observed)) or "none"
+            extra = ",".join(sorted(observed - expected)) or "none"
+            raise ValueError(
+                "search_defaults must exactly cover canonical domains "
+                f"(missing={missing}; extra={extra})"
+            )
+        normalized: dict[str, tuple[str, ...]] = {}
+        for domain in SEARCH_DOMAINS:
+            providers = value[domain]
+            if not isinstance(providers, (list, tuple)) or not providers:
+                raise ValueError(f"search_defaults.{domain} requires at least one provider")
+            provider_ids = tuple(
+                provider.strip() if isinstance(provider, str) else "" for provider in providers
+            )
+            invalid = next(
+                (
+                    provider
+                    for provider in provider_ids
+                    if not _PROVIDER_ID_PATTERN.fullmatch(provider)
+                ),
+                None,
+            )
+            if invalid is not None:
+                raise ValueError(f"search_defaults.{domain} has invalid provider ID")
+            if len(provider_ids) != len(set(provider_ids)):
+                raise ValueError(f"search_defaults.{domain} provider IDs must be unique")
+            normalized[domain] = provider_ids
+        return normalized
 
     @field_validator("proxy")
     @classmethod

--- a/src/souwen/config/template.py
+++ b/src/souwen/config/template.py
@@ -126,6 +126,24 @@ warp:
   # external 模式
   warp_external_proxy: ~  # 外部 WARP 代理地址(如 socks5://warp:1080)
 
+# ===== Search 有序默认 Provider =====
+# 每个 canonical domain 必须完整声明；运行时只选择列表中的第一个 primary，
+# 不会把候选列表当作一次请求中的 fallback 或 fanout。
+search_defaults:
+  paper: [crossref, openalex, eric]
+  book: [open_library]
+  research_output: [datacite]
+  patent: [google_patents]
+  web: [bing, duckduckgo]
+  news: [duckduckgo_news]
+  images: [duckduckgo_images]
+  videos: [bilibili, duckduckgo_videos]
+  social: [reddit, weibo, zhihu]
+  office: [feishu_drive]
+  developer: [github, stackoverflow]
+  cn_tech: [linuxdo, v2ex]
+  knowledge: [wikipedia]
+
 # ===== 数据源频道配置 =====
 # 按源名称配置,覆盖全局默认值.
 # 可用字段: enabled, proxy, http_backend, base_url, timeout, api_key, headers, params

--- a/src/souwen/modules/fetch/application/orchestration.py
+++ b/src/souwen/modules/fetch/application/orchestration.py
@@ -31,6 +31,12 @@ class _TargetOutcome:
     error: ProviderError | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class _ProviderSelection:
+    provider_id: str
+    adapter_id: str
+
+
 class FetchProviderManager(Protocol):
     async def execute(
         self,
@@ -53,7 +59,7 @@ class BrowserFetchExecutor(Protocol):
 
 
 class FetchModuleService:
-    """Run the target builtin Fetch provider for every canonical target."""
+    """Execute canonical per-target fallback or explicit multi-provider fanout."""
 
     def __init__(
         self,
@@ -84,26 +90,32 @@ class FetchModuleService:
         execution: ExecutionContext,
     ) -> FetchBatch:
         execution.raise_if_cancelled_or_expired()
-        if request.strategy not in {None, "fallback"}:
-            raise ProviderError(ProviderErrorCode.INVALID_REQUEST)
-        adapter_id = self._adapter_id
-        if request.providers is not None:
-            if len(request.providers) != 1 or request.providers[0].kind != "fetch":
-                raise ProviderError(ProviderErrorCode.INVALID_REQUEST)
-            adapter_id = self._provider_adapter_ids.get(request.providers[0].id, "")
-            if not adapter_id:
-                raise ProviderError(ProviderErrorCode.INVALID_REQUEST)
-
-        outcomes = await asyncio.gather(
-            *(
-                self._fetch_target(target, request, context, execution, adapter_id)
-                for target in request.targets
+        selections = self._resolve_selections(request)
+        if request.strategy == "fanout":
+            outcomes = await asyncio.gather(
+                *(
+                    self._fetch_target(target, request, context, execution, selection)
+                    for target in request.targets
+                    for selection in selections
+                )
             )
-        )
+        else:
+            outcomes = await asyncio.gather(
+                *(
+                    self._fetch_target_with_fallback(
+                        target,
+                        request,
+                        context,
+                        execution,
+                        selections,
+                    )
+                    for target in request.targets
+                )
+            )
         items = [outcome.result for outcome in outcomes]
         execution.raise_if_cancelled_or_expired()
         if not any(item.status == "success" for item in items):
-            raise _all_failed_error(outcomes, adapter_id)
+            raise _all_failed_error(outcomes, selections)
         partial = any(
             item.status != "success"
             or item.content_metadata is None
@@ -112,14 +124,76 @@ class FetchModuleService:
         )
         return FetchBatch(items=items, meta=FetchMeta(partial=partial), context=context)
 
+    def _resolve_selections(self, request: FetchRequest) -> tuple[_ProviderSelection, ...]:
+        if request.providers is None:
+            return (_ProviderSelection(self._adapter_id, self._adapter_id),)
+        selections: list[_ProviderSelection] = []
+        for provider in request.providers:
+            if provider.kind != "fetch":
+                raise ProviderError(ProviderErrorCode.INVALID_REQUEST)
+            adapter_id = self._provider_adapter_ids.get(provider.id, "")
+            if not adapter_id:
+                raise ProviderError(ProviderErrorCode.INVALID_REQUEST)
+            selections.append(_ProviderSelection(provider.id, adapter_id))
+        if not selections:
+            raise ProviderError(ProviderErrorCode.INVALID_REQUEST)
+        return tuple(selections)
+
+    async def _fetch_target_with_fallback(
+        self,
+        target: object,
+        request: FetchRequest,
+        context: RequestContext,
+        execution: ExecutionContext,
+        selections: tuple[_ProviderSelection, ...],
+    ) -> _TargetOutcome:
+        provenance: list[Provenance] = []
+        low_quality: _TargetOutcome | None = None
+        last_outcome: _TargetOutcome | None = None
+        for selection in selections:
+            execution.raise_if_cancelled_or_expired()
+            outcome = await self._fetch_target(target, request, context, execution, selection)
+            provenance.extend(outcome.result.provenance)
+            result = outcome.result.model_copy(update={"provenance": tuple(provenance)})
+            outcome = _TargetOutcome(result=result, error=outcome.error)
+            last_outcome = outcome
+            if outcome.error is not None and outcome.error.code in {
+                ProviderErrorCode.INVALID_REQUEST,
+                ProviderErrorCode.POLICY_BLOCKED,
+                ProviderErrorCode.PAYLOAD_TOO_LARGE,
+                ProviderErrorCode.UNSUPPORTED_MEDIA_TYPE,
+            }:
+                if low_quality is not None:
+                    return _TargetOutcome(
+                        result=low_quality.result.model_copy(
+                            update={"provenance": tuple(provenance)}
+                        )
+                    )
+                return outcome
+            if result.status != "success":
+                continue
+            if result.content_metadata is None or result.content_metadata.quality != "low":
+                return _TargetOutcome(result=result)
+            if low_quality is None:
+                low_quality = _TargetOutcome(result=result)
+
+        if low_quality is not None:
+            return _TargetOutcome(
+                result=low_quality.result.model_copy(update={"provenance": tuple(provenance)})
+            )
+        if last_outcome is None:  # pragma: no cover - guarded by _resolve_selections.
+            raise ProviderError(ProviderErrorCode.INVALID_REQUEST)
+        return last_outcome
+
     async def _fetch_target(
         self,
         target: object,
         request: FetchRequest,
         context: RequestContext,
         execution: ExecutionContext,
-        adapter_id: str,
+        selection: _ProviderSelection,
     ) -> _TargetOutcome:
+        adapter_id = selection.adapter_id
         target_request = FetchTargetRequest(
             target=target,
             content=request.content,
@@ -135,13 +209,13 @@ class FetchModuleService:
             builtin_error = None
         except ProviderError as exc:
             builtin_error = exc
-            builtin_result = _failed_result(target_request, context, adapter_id, exc)
+            builtin_result = _failed_result(target_request, context, selection.provider_id, exc)
         except Exception:
             builtin_error = ProviderError(ProviderErrorCode.PROVIDER_UNAVAILABLE)
             builtin_result = _failed_result(
                 target_request,
                 context,
-                adapter_id,
+                selection.provider_id,
                 builtin_error,
             )
 
@@ -158,13 +232,18 @@ class FetchModuleService:
             browser_error = None
         except ProviderError as exc:
             browser_error = exc
-            browser_result = _failed_result(target_request, context, adapter_id, exc)
+            browser_result = _failed_result(
+                target_request,
+                context,
+                selection.provider_id,
+                exc,
+            )
         except Exception:
             browser_error = ProviderError(ProviderErrorCode.WORKER_UNAVAILABLE)
             browser_result = _failed_result(
                 target_request,
                 context,
-                adapter_id,
+                selection.provider_id,
                 browser_error,
             )
         if builtin_result.status == "success":
@@ -212,7 +291,7 @@ class FetchModuleService:
 def _failed_result(
     request: FetchTargetRequest,
     context: RequestContext,
-    adapter_id: str,
+    provider_id: str,
     error: ProviderError,
 ) -> FetchResult:
     code = _canonical_error_code(error.code)
@@ -220,13 +299,13 @@ def _failed_result(
         target=request.target,
         final_url=None,
         status="blocked" if error.code is ProviderErrorCode.POLICY_BLOCKED else "failed",
-        provenance=(Provenance(provider=adapter_id, outcome="failed"),),
+        provenance=(Provenance(provider=provider_id, outcome="failed"),),
         error=ErrorDetail(
             code=code,
             message=_safe_error_message(code),
             retryable=error.retryable,
             request_id=context.request_id,
-            provider=adapter_id,
+            provider=provider_id,
         ),
     )
 
@@ -265,7 +344,9 @@ def _safe_error_message(code: str) -> str:
     }[code]
 
 
-def _all_failed_error(outcomes: list[_TargetOutcome], adapter_id: str) -> ProviderError:
+def _all_failed_error(
+    outcomes: list[_TargetOutcome], selections: tuple[_ProviderSelection, ...]
+) -> ProviderError:
     errors = [outcome.error for outcome in outcomes if outcome.error is not None]
     codes = {error.code for error in errors}
     provider_code = next(iter(codes)) if len(codes) == 1 else ProviderErrorCode.PROVIDER_UNAVAILABLE
@@ -277,7 +358,7 @@ def _all_failed_error(outcomes: list[_TargetOutcome], adapter_id: str) -> Provid
         retry_after = max(retry_values) if retry_values else None
     return ProviderError(
         provider_code,
-        provider_id=adapter_id,
+        provider_id=selections[0].provider_id if len(selections) == 1 else None,
         retry_after_seconds=retry_after,
     )
 

--- a/src/souwen/modules/search/application/orchestration.py
+++ b/src/souwen/modules/search/application/orchestration.py
@@ -367,8 +367,16 @@ def _canonical_failure_code(code: ProviderErrorCode) -> str:
 
 
 def _all_fail_error(errors: list[ProviderError]) -> ProviderError:
+    if len(errors) == 1:
+        return errors[0]
     if errors and all(error.code is ProviderErrorCode.RATE_LIMITED for error in errors):
-        return ProviderError(ProviderErrorCode.RATE_LIMITED)
+        retry_values = [
+            error.retry_after_seconds for error in errors if error.retry_after_seconds is not None
+        ]
+        return ProviderError(
+            ProviderErrorCode.RATE_LIMITED,
+            retry_after_seconds=max(retry_values) if retry_values else None,
+        )
     if errors and all(error.code is ProviderErrorCode.POLICY_BLOCKED for error in errors):
         return ProviderError(ProviderErrorCode.POLICY_BLOCKED)
     if errors and all(

--- a/src/souwen/providers/runtime_clients/web/builtin.py
+++ b/src/souwen/providers/runtime_clients/web/builtin.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+from collections.abc import Mapping
 from typing import Any
 from urllib.parse import urljoin, urlparse
 
@@ -408,7 +409,33 @@ class BuiltinFetcherClient(BaseScraper):
                     current_url,
                     _resolved_target=target,
                     _include_configured_headers=include_configured_headers,
+                    _max_response_bytes=(
+                        self.MAX_RESPONSE_SIZE if enforce_target_contract else None
+                    ),
                 )
+
+                response_extensions = getattr(resp, "extensions", {})
+                if (
+                    enforce_target_contract
+                    and isinstance(response_extensions, Mapping)
+                    and response_extensions.get("souwen_response_too_large")
+                ):
+                    lower_bound = response_extensions.get(
+                        "souwen_response_size_lower_bound", self.MAX_RESPONSE_SIZE + 1
+                    )
+                    return FetchResult(
+                        url=url,
+                        final_url=current_url,
+                        source=self.PROVIDER_NAME,
+                        error="解压后响应体超过上限",
+                        raw={
+                            "provider": "builtin",
+                            "status_code": resp.status_code,
+                            "content_length": lower_bound,
+                            "oversized": True,
+                            "target_error_code": "response_too_large",
+                        },
+                    )
 
                 if resp.status_code not in self._REDIRECT_CODES:
                     break

--- a/src/souwen/server/v2_runtime.py
+++ b/src/souwen/server/v2_runtime.py
@@ -90,6 +90,7 @@ from souwen.platform.provider_spi import (
     ProviderRef,
     Provenance,
     RequestContext,
+    SearchRequest,
 )
 from souwen.providers.fetch_sources.arxiv_fulltext import (
     ARXIV_FULLTEXT_FETCH_PROFILE,
@@ -292,6 +293,7 @@ from souwen.providers.information_sources.metaso import (
 )
 from souwen.providers.information_sources.openalex import (
     OPENALEX_PROVIDER_MANIFEST,
+    OPENALEX_REST_SPEC,
     OpenAlexSearchProvider,
 )
 from souwen.providers.information_sources.openaire import (
@@ -1427,27 +1429,98 @@ _MIGRATED_PROVIDER_IDS = (
     | _BATCH_FIVE_MANIFEST_IDS
     | _BATCH_SIX_MANIFEST_IDS
 )
-_DEFAULT_PROVIDER_IDS = frozenset(
-    {
-        "arxiv",
-        "bilibili",
-        "bing",
-        "biorxiv",
-        "builtin",
-        "crossref",
-        "datacite",
-        "dblp",
-        "duckduckgo",
-        "duckduckgo_images",
-        "duckduckgo_news",
-        "duckduckgo_videos",
-        "google_patents",
-        "open_library",
-        "openalex",
-        "pubmed",
-        "youtube",
-    }
-)
+
+
+def _search_provider_declarations() -> tuple[tuple[ProviderManifest, ProviderSpec], ...]:
+    """Return the one reviewed manifest/spec declaration for every Search provider."""
+
+    return (
+        (OPENALEX_PROVIDER_MANIFEST, OPENALEX_REST_SPEC),
+        (ERIC_PROVIDER_MANIFEST, ERIC_REST_SPEC),
+        (PATENTSVIEW_PROVIDER_MANIFEST, PATENTSVIEW_REST_SPEC),
+        *((manifest, spec) for manifest, spec, _provider, _factory in _BATCH_ONE_SEARCH_BINDINGS),
+        *((manifest, spec) for manifest, spec, _provider, _factory in _BATCH_TWO_SEARCH_BINDINGS),
+        *(
+            (manifest, spec)
+            for manifest, spec, _provider, _factory in _BATCH_THREE_SEARCH_ONLY_BINDINGS
+        ),
+        *(
+            (manifest, search_spec)
+            for (
+                manifest,
+                search_spec,
+                _fetch_spec,
+                _search_provider,
+                _fetch_provider,
+                _factory,
+            ) in _BATCH_THREE_MULTI_BINDINGS
+        ),
+        *((manifest, spec) for manifest, spec, _provider, _factory in _BATCH_FOUR_SEARCH_BINDINGS),
+        *(
+            (manifest, spec)
+            for manifest, spec, _provider, _provider_id in _BATCH_FIVE_SEARCH_BINDINGS
+        ),
+        *(
+            (manifest, spec)
+            for manifest, spec, _provider, _provider_id in _BATCH_SIX_SEARCH_BINDINGS
+        ),
+    )
+
+
+def _build_search_selector(config: SouWenConfig) -> OrderedSearchProviderSelector:
+    """Resolve the configured ordered defaults against reviewed Provider declarations."""
+
+    declared: dict[str, tuple[str, str]] = {}
+    declaration_order: dict[str, int] = {}
+    for order, (manifest, spec) in enumerate(_search_provider_declarations(), start=1):
+        validate_spec_manifest(spec, manifest)
+        provider_id = spec.provider_id
+        if manifest.id != provider_id or provider_id in declared:
+            raise RuntimeError(f"invalid Search provider declaration: {provider_id}")
+        search_adapters = tuple(
+            adapter.id for adapter in manifest.adapters if adapter.capability == "search"
+        )
+        if len(search_adapters) != 1 or search_adapters[0] != spec.adapter_id:
+            raise RuntimeError(f"Search adapter declaration mismatch: {provider_id}")
+        declared[provider_id] = (spec.domain, search_adapters[0])
+        declaration_order[provider_id] = order
+
+    defaults_by_domain: dict[str, tuple[SearchProviderSelection, ...]] = {}
+    configured_default_ids: set[str] = set()
+    for domain, provider_ids in config.search_defaults.items():
+        selections: list[SearchProviderSelection] = []
+        for priority, provider_id in enumerate(provider_ids, start=1):
+            declaration = declared.get(provider_id)
+            if declaration is None:
+                raise RuntimeError(f"unknown Search default provider: {provider_id}")
+            provider_domain, adapter_id = declaration
+            if provider_domain != domain:
+                raise RuntimeError(
+                    f"Search default provider {provider_id} belongs to {provider_domain}, not {domain}"
+                )
+            selections.append(
+                SearchProviderSelection(
+                    provider=ProviderRef(id=provider_id, kind="search"),
+                    adapter_id=adapter_id,
+                    yaml_priority=priority,
+                )
+            )
+            configured_default_ids.add(provider_id)
+        defaults_by_domain[domain] = tuple(selections)
+
+    explicit_only = tuple(
+        SearchProviderSelection(
+            provider=ProviderRef(id=provider_id, kind="search"),
+            adapter_id=adapter_id,
+            yaml_priority=declaration_order[provider_id],
+        )
+        for provider_id, (_domain, adapter_id) in declared.items()
+        if provider_id not in configured_default_ids
+    )
+    return OrderedSearchProviderSelector(
+        defaults_by_domain,
+        explicit_selections=explicit_only,
+    )
 
 
 def _self_hosted_base_url(config: SouWenConfig, provider_id: str) -> str:
@@ -2097,228 +2170,8 @@ def build_target_runtime(config: SouWenConfig) -> TargetRuntime:
         )
     )
 
-    search = SearchModuleService(
-        manager,
-        OrderedSearchProviderSelector(
-            {
-                "paper": (
-                    SearchProviderSelection(
-                        provider=ProviderRef(id="openalex", kind="search"),
-                        adapter_id="openalex-search",
-                        yaml_priority=1,
-                    ),
-                    SearchProviderSelection(
-                        provider=ProviderRef(id="eric", kind="search"),
-                        adapter_id="eric-search",
-                        yaml_priority=2,
-                    ),
-                    *(
-                        SearchProviderSelection(
-                            provider=ProviderRef(id=manifest.id, kind="search"),
-                            adapter_id=manifest.adapters[0].id,
-                            yaml_priority=priority,
-                        )
-                        for priority, (
-                            manifest,
-                            _spec,
-                            _provider_type,
-                            _client_factory,
-                        ) in enumerate(
-                            (
-                                binding
-                                for binding in _BATCH_ONE_SEARCH_BINDINGS
-                                if binding[1].domain == "paper"
-                            ),
-                            start=3,
-                        )
-                    ),
-                    *(
-                        SearchProviderSelection(
-                            provider=ProviderRef(id=manifest.id, kind="search"),
-                            adapter_id=manifest.adapters[0].id,
-                            yaml_priority=priority,
-                        )
-                        for priority, (
-                            manifest,
-                            _spec,
-                            _provider_type,
-                            _client_factory,
-                        ) in enumerate(
-                            (
-                                binding
-                                for binding in _BATCH_TWO_SEARCH_BINDINGS
-                                if binding[1].domain == "paper"
-                            ),
-                            start=100,
-                        )
-                    ),
-                ),
-                "patent": tuple(
-                    SearchProviderSelection(
-                        provider=ProviderRef(id=manifest.id, kind="search"),
-                        adapter_id=manifest.adapters[0].id,
-                        yaml_priority=priority,
-                    )
-                    for priority, (
-                        manifest,
-                        _spec,
-                        _provider_type,
-                        _client_factory,
-                    ) in enumerate(
-                        (
-                            binding
-                            for binding in (
-                                *_BATCH_ONE_SEARCH_BINDINGS,
-                                *_BATCH_TWO_SEARCH_BINDINGS,
-                            )
-                            if binding[1].domain == "patent"
-                        ),
-                        start=1,
-                    )
-                ),
-                **{
-                    domain: tuple(
-                        SearchProviderSelection(
-                            provider=ProviderRef(id=manifest.id, kind="search"),
-                            adapter_id=manifest.adapters[0].id,
-                            yaml_priority=priority,
-                        )
-                        for priority, (
-                            manifest,
-                            _spec,
-                            _provider_type,
-                            _client_factory,
-                        ) in enumerate(
-                            (
-                                binding
-                                for binding in _BATCH_FOUR_SEARCH_BINDINGS
-                                if binding[1].domain == domain
-                                and binding[0].id in _DEFAULT_PROVIDER_IDS
-                            ),
-                            start=1,
-                        )
-                    )
-                    for domain in ("book", "research_output")
-                },
-                **{
-                    domain: tuple(
-                        SearchProviderSelection(
-                            provider=ProviderRef(id=manifest.id, kind="search"),
-                            adapter_id=manifest.adapters[0].id,
-                            yaml_priority=priority,
-                        )
-                        for priority, (
-                            manifest,
-                            spec,
-                            _provider_type,
-                            _provider_id,
-                        ) in enumerate(
-                            (
-                                binding
-                                for binding in _BATCH_FIVE_SEARCH_BINDINGS
-                                if binding[1].domain == domain
-                                and binding[0].id in _DEFAULT_PROVIDER_IDS
-                            ),
-                            start=1,
-                        )
-                    )
-                    for domain in ("web", "news", "images", "videos")
-                },
-            },
-            explicit_selections=(
-                SearchProviderSelection(
-                    provider=ProviderRef(id="patentsview", kind="search"),
-                    adapter_id="patentsview-search",
-                    yaml_priority=1,
-                ),
-                *(
-                    SearchProviderSelection(
-                        provider=ProviderRef(id=manifest.id, kind="search"),
-                        adapter_id=manifest.adapters[0].id,
-                        yaml_priority=priority,
-                    )
-                    for priority, (
-                        manifest,
-                        _spec,
-                        _provider_type,
-                        _client_factory,
-                    ) in enumerate(_BATCH_THREE_SEARCH_ONLY_BINDINGS, start=100)
-                ),
-                *(
-                    SearchProviderSelection(
-                        provider=ProviderRef(id=manifest.id, kind="search"),
-                        adapter_id=next(
-                            adapter.id
-                            for adapter in manifest.adapters
-                            if adapter.capability == "search"
-                        ),
-                        yaml_priority=priority,
-                    )
-                    for priority, (
-                        manifest,
-                        _search_spec,
-                        _fetch_spec,
-                        _search_type,
-                        _fetch_type,
-                        _client_factory,
-                    ) in enumerate(_BATCH_THREE_MULTI_BINDINGS, start=200)
-                ),
-                *(
-                    SearchProviderSelection(
-                        provider=ProviderRef(id=manifest.id, kind="search"),
-                        adapter_id=manifest.adapters[0].id,
-                        yaml_priority=priority,
-                    )
-                    for priority, (
-                        manifest,
-                        _spec,
-                        _provider_type,
-                        _client_factory,
-                    ) in enumerate(
-                        (
-                            binding
-                            for binding in _BATCH_FOUR_SEARCH_BINDINGS
-                            if binding[0].id not in _DEFAULT_PROVIDER_IDS
-                        ),
-                        start=300,
-                    )
-                ),
-                *(
-                    SearchProviderSelection(
-                        provider=ProviderRef(id=manifest.id, kind="search"),
-                        adapter_id=manifest.adapters[0].id,
-                        yaml_priority=priority,
-                    )
-                    for priority, (
-                        manifest,
-                        _spec,
-                        _provider_type,
-                        _provider_id,
-                    ) in enumerate(
-                        (
-                            binding
-                            for binding in _BATCH_FIVE_SEARCH_BINDINGS
-                            if binding[0].id not in _DEFAULT_PROVIDER_IDS
-                        ),
-                        start=400,
-                    )
-                ),
-                *(
-                    SearchProviderSelection(
-                        provider=ProviderRef(id=manifest.id, kind="search"),
-                        adapter_id=manifest.adapters[0].id,
-                        yaml_priority=priority,
-                    )
-                    for priority, (
-                        manifest,
-                        _spec,
-                        _provider_type,
-                        _provider_id,
-                    ) in enumerate(_BATCH_SIX_SEARCH_BINDINGS, start=500)
-                ),
-            ),
-        ),
-    )
+    search_selector = _build_search_selector(config)
+    search = SearchModuleService(manager, search_selector)
     enabled_llm = config.enabled_uniapi_ark_source_ids()
     llm_search: Any = (
         LLMSearchModuleService(manager, enabled_llm[0])
@@ -2352,7 +2205,10 @@ def build_target_runtime(config: SouWenConfig) -> TargetRuntime:
         },
         browser_executor=browser_client,
     )
-    required_adapters = {"openalex-search", "builtin-fetch"}
+    paper_primary = search_selector.select_default(
+        SearchRequest(query="readiness", domains=("paper",))
+    )[0]
+    required_adapters = {paper_primary.adapter_id, "builtin-fetch"}
 
     async def readiness() -> ReadinessSnapshot:
         eligible = set(manager.eligible_adapter_ids)
@@ -2375,6 +2231,7 @@ def build_target_runtime(config: SouWenConfig) -> TargetRuntime:
         ready = providers_ready and browser_ready
         components = {
             "api": "ready",
+            "crossref": "ready" if "crossref-search" in eligible else "not_ready",
             "openalex": "ready" if "openalex-search" in eligible else "not_ready",
             "builtin_fetch": "ready" if "builtin-fetch" in eligible else "not_ready",
             "llm_search": (
@@ -2382,6 +2239,9 @@ def build_target_runtime(config: SouWenConfig) -> TargetRuntime:
             ),
             "browser_worker": browser_status,
         }
+        components[paper_primary.provider.id] = (
+            "ready" if paper_primary.adapter_id in eligible else "not_ready"
+        )
         return ReadinessSnapshot(
             ready=ready,
             components=components,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,15 +12,20 @@
 - ``TestProxyValidation``：代理 URL 校验与安全性
 """
 
+from typing import get_args
+
 import pytest
 
 from souwen.config import (
+    DEFAULT_SEARCH_PROVIDERS,
     LLMSearchGatewayConfig,
+    SEARCH_DOMAINS,
     SouWenConfig,
     SourceChannelConfig,
     get_config,
     reload_config,
 )
+from souwen.platform.provider_spi import SearchDomain
 
 
 @pytest.fixture(autouse=True)
@@ -118,6 +123,40 @@ class TestDefaults:
         """proxy_pool 默认空列表（不启用代理池）。"""
         cfg = SouWenConfig()
         assert cfg.proxy_pool == []
+
+    def test_search_defaults_cover_every_canonical_domain(self):
+        cfg = SouWenConfig()
+
+        assert SEARCH_DOMAINS == get_args(SearchDomain)
+        assert tuple(cfg.search_defaults) == SEARCH_DOMAINS
+        assert cfg.search_defaults == DEFAULT_SEARCH_PROVIDERS
+        assert cfg.search_defaults["paper"][0] == "crossref"
+
+    @pytest.mark.parametrize(
+        ("search_defaults", "message"),
+        [
+            ({"paper": ["crossref"]}, "exactly cover"),
+            (
+                {**DEFAULT_SEARCH_PROVIDERS, "unknown": ["fixture"]},
+                "exactly cover",
+            ),
+            (
+                {**DEFAULT_SEARCH_PROVIDERS, "paper": []},
+                "at least one provider",
+            ),
+            (
+                {**DEFAULT_SEARCH_PROVIDERS, "paper": ["crossref", "crossref"]},
+                "must be unique",
+            ),
+            (
+                {**DEFAULT_SEARCH_PROVIDERS, "paper": ["not valid"]},
+                "invalid provider ID",
+            ),
+        ],
+    )
+    def test_invalid_search_defaults_are_rejected(self, search_defaults, message):
+        with pytest.raises(ValueError, match=message):
+            SouWenConfig(search_defaults=search_defaults)
 
     def test_uniapi_ark_sources_are_opt_in_and_mutually_exclusive(self):
         deepseek = "uniapi_ark_annotations_deepseek_v3_2_251201"

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -163,6 +163,21 @@ class TestYamlLoading:
         assert cfg.llm_search_gateways["uniapi"].api_key == "yaml-secret"
         assert cfg.llm_search_gateways["uniapi"].base_url == "https://gateway.example.com/v1"
 
+    def test_loads_search_defaults_as_one_nested_policy_table(self, tmp_path):
+        defaults = SouWenConfig().search_defaults
+        configured = {domain: list(providers) for domain, providers in defaults.items()}
+        configured["paper"] = ["crossref", "openalex"]
+        yaml_lines = ["search_defaults:"]
+        yaml_lines.extend(
+            f"  {domain}: [{', '.join(providers)}]" for domain, providers in configured.items()
+        )
+        (tmp_path / "souwen.yaml").write_text("\n".join(yaml_lines) + "\n", encoding="utf-8")
+
+        cfg = reload_config()
+
+        assert cfg.search_defaults["paper"] == ("crossref", "openalex")
+        assert tuple(cfg.search_defaults) == tuple(defaults)
+
     def test_yaml_gateway_exact_env_references_are_resolved_without_literal_fallback(
         self, monkeypatch, tmp_path
     ):

--- a/tests/test_delivery_api_v2.py
+++ b/tests/test_delivery_api_v2.py
@@ -31,6 +31,7 @@ from souwen.platform.provider_spi import (
     ProviderError,
     ProviderErrorCode,
     Provenance,
+    SearchRequest,
     SearchMeta,
     Usage,
 )
@@ -483,6 +484,60 @@ async def test_runtime_catalog_keeps_uniapi_missing_fields_safe_and_nonblocking(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("paper_defaults", "disabled_provider", "expected_primary"),
+    (
+        (("crossref", "openalex"), "openalex", "crossref"),
+        (("openalex", "crossref"), "crossref", "openalex"),
+        (("eric", "crossref"), "crossref", "eric"),
+    ),
+)
+async def test_readiness_requires_the_configured_paper_primary_not_a_disabled_alternative(
+    monkeypatch,
+    paper_defaults,
+    disabled_provider,
+    expected_primary,
+) -> None:
+    monkeypatch.delenv("SOUWEN_BROWSER_WORKER_TOKEN", raising=False)
+    search_defaults = SouWenConfig().search_defaults
+    search_defaults["paper"] = paper_defaults
+    runtime = build_target_runtime(
+        SouWenConfig(
+            search_defaults=search_defaults,
+            sources={disabled_provider: {"enabled": False}},
+        )
+    )
+
+    selection = runtime.services.search._selector.select_default(
+        SearchRequest(query="readiness", domains=("paper",))
+    )[0]
+    snapshot = await runtime.services.readiness()
+
+    assert selection.provider.id == expected_primary
+    assert snapshot.ready is True
+    assert snapshot.components[expected_primary] == "ready"
+    assert snapshot.components[disabled_provider] == "not_ready"
+
+
+@pytest.mark.asyncio
+async def test_readiness_names_an_unavailable_nonstandard_paper_primary(monkeypatch) -> None:
+    monkeypatch.delenv("SOUWEN_BROWSER_WORKER_TOKEN", raising=False)
+    search_defaults = SouWenConfig().search_defaults
+    search_defaults["paper"] = ("eric", "crossref")
+    runtime = build_target_runtime(
+        SouWenConfig(
+            search_defaults=search_defaults,
+            sources={"eric": {"enabled": False}},
+        )
+    )
+
+    snapshot = await runtime.services.readiness()
+
+    assert snapshot.ready is False
+    assert snapshot.components["eric"] == "not_ready"
+
+
+@pytest.mark.asyncio
 async def test_enabled_browser_worker_is_required_for_target_readiness(monkeypatch) -> None:
     class _Worker:
         def __init__(self, *, fail: bool) -> None:
@@ -527,6 +582,39 @@ def test_composition_root_requires_the_shared_browser_inventory_digest(monkeypat
         runtime.browser_client._expected_inventory_digest
         == BROWSER_WORKER_PROVIDER_INVENTORY_DIGEST
     )
+
+
+def test_target_runtime_has_one_default_provider_for_every_public_search_domain(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("SOUWEN_BROWSER_WORKER_TOKEN", raising=False)
+    runtime = build_target_runtime(SouWenConfig())
+    selector = runtime.services.search._selector
+
+    expected = {
+        "paper": "crossref",
+        "book": "open_library",
+        "research_output": "datacite",
+        "patent": "google_patents",
+        "web": "bing",
+        "news": "duckduckgo_news",
+        "images": "duckduckgo_images",
+        "videos": "bilibili",
+        "social": "reddit",
+        "office": "feishu_drive",
+        "developer": "github",
+        "cn_tech": "linuxdo",
+        "knowledge": "wikipedia",
+    }
+
+    selected = {
+        domain: selector.select_default(SearchRequest(query="default", domains=(domain,)))[
+            0
+        ].provider.id
+        for domain in expected
+    }
+
+    assert selected == expected
 
 
 @pytest.mark.asyncio

--- a/tests/test_eric_provider_v2.py
+++ b/tests/test_eric_provider_v2.py
@@ -117,6 +117,27 @@ def _openalex_response() -> SearchResponse:
     )
 
 
+def _crossref_response() -> SearchResponse:
+    return SearchResponse(
+        query="machine learning",
+        source="crossref",
+        total_results=1,
+        page=1,
+        per_page=10,
+        results=[
+            PaperResult(
+                source="crossref",
+                title="Crossref default",
+                authors=[Author(name="Default Author")],
+                doi="10.1000/default",
+                year=2024,
+                source_url="https://doi.org/10.1000/default",
+                raw={"type": "journal-article"},
+            )
+        ],
+    )
+
+
 def _request(**overrides: object) -> SearchRequest:
     values: dict[str, object] = {
         "query": "machine learning",
@@ -708,22 +729,22 @@ def test_delivery_routes_use_lazy_explicit_eric_transport_and_safe_catalog(monke
 
 
 @pytest.mark.asyncio
-async def test_disabled_eric_keeps_openalex_default_and_never_constructs_eric(monkeypatch) -> None:
+async def test_disabled_eric_keeps_crossref_default_and_never_constructs_eric(monkeypatch) -> None:
     eric_transport_constructions = 0
-    openalex_calls = 0
+    crossref_calls = 0
 
     class _Http:
         async def close(self) -> None:
             return None
 
-    class RuntimeOpenAlexClient:
+    class RuntimeCrossrefClient:
         def __init__(self, *_args, **_kwargs) -> None:
             self._client = _Http()
 
         async def search(self, *_args, **_kwargs):
-            nonlocal openalex_calls
-            openalex_calls += 1
-            return _openalex_response()
+            nonlocal crossref_calls
+            crossref_calls += 1
+            return _crossref_response()
 
     def forbidden_eric_transport(**_options):
         nonlocal eric_transport_constructions
@@ -731,7 +752,7 @@ async def test_disabled_eric_keeps_openalex_default_and_never_constructs_eric(mo
         raise AssertionError("disabled ERIC must not construct transport")
 
     monkeypatch.delenv("SOUWEN_BROWSER_WORKER_TOKEN", raising=False)
-    monkeypatch.setattr("souwen.server.v2_runtime.OpenAlexClient", RuntimeOpenAlexClient)
+    monkeypatch.setattr("souwen.server.v2_runtime.CrossrefClient", RuntimeCrossrefClient)
     monkeypatch.setattr("souwen.server.v2_runtime.HttpTransport", forbidden_eric_transport)
     runtime = build_target_runtime(SouWenConfig(sources={"eric": {"enabled": False}}))
 
@@ -741,8 +762,8 @@ async def test_disabled_eric_keeps_openalex_default_and_never_constructs_eric(mo
     assert "eric-search" not in runtime.manager.eligible_adapter_ids
 
     default_page = await runtime.services.search.search(_request(), _context(), _execution())
-    assert default_page.meta.requested == ("openalex",)
-    assert default_page.items[0].id == "doi:10.1000/fallback"
+    assert default_page.meta.requested == ("crossref",)
+    assert default_page.items[0].id == "doi:10.1000/default"
 
     with pytest.raises(ProviderError) as exc_info:
         await runtime.services.search.search(
@@ -751,7 +772,7 @@ async def test_disabled_eric_keeps_openalex_default_and_never_constructs_eric(mo
             _execution(),
         )
     assert exc_info.value.code is ProviderErrorCode.PROVIDER_UNAVAILABLE
-    assert openalex_calls == 1
+    assert crossref_calls == 1
     assert eric_transport_constructions == 0
     await runtime.close()
 

--- a/tests/test_fetch_module_v2.py
+++ b/tests/test_fetch_module_v2.py
@@ -24,6 +24,9 @@ class _Manager:
     async def execute(self, adapter_id, request, request_context, execution):
         if "blocked" in str(request.target):
             raise ProviderError(ProviderErrorCode.POLICY_BLOCKED, provider_id=adapter_id)
+        provider_id = (
+            adapter_id if adapter_id == "builtin-fetch" else adapter_id.removesuffix("-fetch")
+        )
         content = (
             "short" if "short" in str(request.target) else "long enough canonical content " * 4
         )
@@ -38,7 +41,7 @@ class _Manager:
                 truncated=False,
                 quality="low" if len(content) <= 63 else "high",
             ),
-            provenance=(Provenance(provider=adapter_id, outcome="success"),),
+            provenance=(Provenance(provider=provider_id, outcome="success"),),
         )
 
 
@@ -99,19 +102,217 @@ async def test_module_keeps_order_and_marks_low_or_failed_items_partial() -> Non
 
 
 @pytest.mark.asyncio
-async def test_module_rejects_request_side_provider_or_fanout_override() -> None:
+async def test_module_rejects_unknown_or_non_fetch_provider_override() -> None:
     service = FetchModuleService(_Manager())
     context = RequestContext(request_id="fetch-module-v2")
     for request in (
-        FetchRequest(targets=("https://example.com",), strategy="fanout"),
         FetchRequest(
             targets=("https://example.com",),
             providers=(ProviderRef(id="other", kind="fetch"),),
+        ),
+        FetchRequest(
+            targets=("https://example.com",),
+            providers=(ProviderRef(id="other", kind="search"),),
         ),
     ):
         with pytest.raises(ProviderError) as caught:
             await service.fetch(request, context, ExecutionContext.with_timeout(5))
         assert caught.value.code is ProviderErrorCode.INVALID_REQUEST
+
+
+@pytest.mark.asyncio
+async def test_module_fanout_returns_one_outcome_per_target_and_provider() -> None:
+    manager = _RecordingManager()
+    service = FetchModuleService(
+        manager,
+        provider_adapter_ids={"other": "other-fetch"},
+    )
+
+    batch = await service.fetch(
+        FetchRequest(
+            targets=("https://example.com/one", "https://example.com/two"),
+            providers=(
+                ProviderRef(id="builtin-fetch", kind="fetch"),
+                ProviderRef(id="other", kind="fetch"),
+            ),
+            strategy="fanout",
+        ),
+        RequestContext(request_id="fetch-fanout"),
+        ExecutionContext.with_timeout(5),
+    )
+
+    assert manager.adapter_ids == [
+        "builtin-fetch",
+        "other-fetch",
+        "builtin-fetch",
+        "other-fetch",
+    ]
+    assert [str(item.target) for item in batch.items] == [
+        "https://example.com/one",
+        "https://example.com/one",
+        "https://example.com/two",
+        "https://example.com/two",
+    ]
+    assert [item.provenance[0].provider for item in batch.items] == [
+        "builtin-fetch",
+        "other",
+        "builtin-fetch",
+        "other",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_module_fallback_advances_after_failure_and_stops_after_success() -> None:
+    class Manager(_RecordingManager):
+        async def execute(self, adapter_id, request, request_context, execution):
+            self.adapter_ids.append(adapter_id)
+            if adapter_id == "first-fetch":
+                raise ProviderError(ProviderErrorCode.PROVIDER_UNAVAILABLE)
+            return await _Manager.execute(self, adapter_id, request, request_context, execution)
+
+    manager = Manager()
+    service = FetchModuleService(
+        manager,
+        provider_adapter_ids={
+            "first": "first-fetch",
+            "second": "second-fetch",
+            "third": "third-fetch",
+        },
+    )
+
+    batch = await service.fetch(
+        FetchRequest(
+            targets=("https://example.com/one",),
+            providers=(
+                ProviderRef(id="first", kind="fetch"),
+                ProviderRef(id="second", kind="fetch"),
+                ProviderRef(id="third", kind="fetch"),
+            ),
+            strategy="fallback",
+        ),
+        RequestContext(request_id="fetch-fallback"),
+        ExecutionContext.with_timeout(5),
+    )
+
+    assert manager.adapter_ids == ["first-fetch", "second-fetch"]
+    assert batch.items[0].status == "success"
+    assert [item.provider for item in batch.items[0].provenance] == [
+        "first",
+        "second",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fanout_failure_uses_public_provider_identity() -> None:
+    class Manager(_RecordingManager):
+        async def execute(self, adapter_id, request, request_context, execution):
+            self.adapter_ids.append(adapter_id)
+            if adapter_id == "newspaper-fetch":
+                raise ProviderError(
+                    ProviderErrorCode.RATE_LIMITED,
+                    provider_id="newspaper",
+                    retry_after_seconds=11,
+                )
+            return await _Manager.execute(self, adapter_id, request, request_context, execution)
+
+    batch = await FetchModuleService(
+        Manager(),
+        provider_adapter_ids={
+            "newspaper": "newspaper-fetch",
+            "other": "other-fetch",
+        },
+    ).fetch(
+        FetchRequest(
+            targets=("https://example.com/one",),
+            providers=(
+                ProviderRef(id="newspaper", kind="fetch"),
+                ProviderRef(id="other", kind="fetch"),
+            ),
+            strategy="fanout",
+        ),
+        RequestContext(request_id="fetch-public-provider-id"),
+        ExecutionContext.with_timeout(5),
+    )
+
+    failed = batch.items[0]
+    assert failed.status == "failed"
+    assert failed.provenance[0].provider == "newspaper"
+    assert failed.error.provider == "newspaper"
+    assert batch.items[1].status == "success"
+    assert batch.meta.partial is True
+
+
+@pytest.mark.asyncio
+async def test_single_provider_failure_preserves_public_identity_and_retry_metadata() -> None:
+    class Manager:
+        async def execute(self, adapter_id, request, request_context, execution):
+            raise ProviderError(
+                ProviderErrorCode.RATE_LIMITED,
+                provider_id="newspaper",
+                retry_after_seconds=17,
+            )
+
+    service = FetchModuleService(
+        Manager(),
+        provider_adapter_ids={"newspaper": "newspaper-fetch"},
+    )
+
+    with pytest.raises(ProviderError) as caught:
+        await service.fetch(
+            FetchRequest(
+                targets=("https://example.com/one",),
+                providers=(ProviderRef(id="newspaper", kind="fetch"),),
+            ),
+            RequestContext(request_id="fetch-public-provider-error"),
+            ExecutionContext.with_timeout(5),
+        )
+
+    assert caught.value.code is ProviderErrorCode.RATE_LIMITED
+    assert caught.value.provider_id == "newspaper"
+    assert caught.value.retry_after_seconds == 17
+
+
+@pytest.mark.asyncio
+async def test_fallback_keeps_low_quality_candidate_after_fatal_later_attempt() -> None:
+    class Manager(_RecordingManager):
+        async def execute(self, adapter_id, request, request_context, execution):
+            self.adapter_ids.append(adapter_id)
+            if adapter_id == "second-fetch":
+                raise ProviderError(
+                    ProviderErrorCode.POLICY_BLOCKED,
+                    provider_id="second",
+                )
+            return await _Manager.execute(self, adapter_id, request, request_context, execution)
+
+    manager = Manager()
+    batch = await FetchModuleService(
+        manager,
+        provider_adapter_ids={
+            "first": "first-fetch",
+            "second": "second-fetch",
+            "third": "third-fetch",
+        },
+    ).fetch(
+        FetchRequest(
+            targets=("https://example.com/short",),
+            providers=(
+                ProviderRef(id="first", kind="fetch"),
+                ProviderRef(id="second", kind="fetch"),
+                ProviderRef(id="third", kind="fetch"),
+            ),
+            strategy="fallback",
+        ),
+        RequestContext(request_id="fetch-low-quality-fatal"),
+        ExecutionContext.with_timeout(5),
+    )
+
+    assert manager.adapter_ids == ["first-fetch", "second-fetch"]
+    assert batch.items[0].status == "success"
+    assert batch.items[0].content == "short"
+    assert batch.items[0].content_metadata.quality == "low"
+    assert [item.provider for item in batch.items[0].provenance] == ["first", "second"]
+    assert [item.outcome for item in batch.items[0].provenance] == ["success", "failed"]
+    assert batch.meta.partial is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_hf_space_smoke.py
+++ b/tests/test_hf_space_smoke.py
@@ -332,7 +332,7 @@ def test_missing_required_llm_provider_is_reported_as_a_failed_check(monkeypatch
             "capabilities": ["search"],
         },
         {
-            "provider": "builtin",
+            "provider": "builtin-fetch",
             "availability": "available",
             "capabilities": ["fetch"],
         },
@@ -344,9 +344,13 @@ def test_missing_required_llm_provider_is_reported_as_a_failed_check(monkeypatch
 
         def json(self, path, **_kwargs):
             if path == "/api/v1/search":
-                return 200, {}, {"items": []}
+                return 200, {}, {"items": [], "meta": {"requested": ["crossref"]}}
             if path == "/api/v1/fetch":
-                return 200, {}, {"items": [{"status": "success", "content": "fixture"}]}
+                return (
+                    200,
+                    {},
+                    {"items": [{"status": "success", "content": "Example Domain fixture"}]},
+                )
             raise AssertionError(path)
 
     monkeypatch.setattr(smoke, "Client", Client)
@@ -361,10 +365,12 @@ def test_missing_required_llm_provider_is_reported_as_a_failed_check(monkeypatch
 
     payload = json.loads(report.read_text(encoding="utf-8"))
     checks = {item["name"]: item for item in payload["checks"]}
+    assert checks["search_default_live"]["outcome"] == "PASS"
     assert checks["search_live"]["outcome"] == "PASS"
     assert checks["llm_search_live"]["outcome"] == "FAIL"
     assert checks["llm_search_live"]["detail"] == "no available llm_search provider"
     assert checks["fetch_live"]["outcome"] == "PASS"
+    assert checks["fetch_readable_live"]["outcome"] == "PASS"
 
 
 def test_search_live_uses_bounded_provider_fallback(monkeypatch, tmp_path) -> None:
@@ -391,6 +397,8 @@ def test_search_live_uses_bounded_provider_fallback(monkeypatch, tmp_path) -> No
         ]
     )
     calls: list[str] = []
+    default_payloads: list[dict] = []
+    fetch_strategies: list[str] = []
 
     class Client:
         def __init__(self, *_args, **_kwargs):
@@ -398,15 +406,24 @@ def test_search_live_uses_bounded_provider_fallback(monkeypatch, tmp_path) -> No
 
         def json(self, path, **kwargs):
             if path == "/api/v1/search":
+                if "providers" not in kwargs["payload"]:
+                    default_payloads.append(kwargs["payload"])
+                    calls.append("default")
+                    return 200, {}, {"items": [], "meta": {"requested": ["crossref"]}}
                 provider = kwargs["payload"]["providers"][0]["id"]
                 calls.append(provider)
-                if provider == "openalex":
+                if provider == "crossref":
                     return 503, {}, {"error": {"code": "upstream_unavailable"}}
                 return 200, {}, {"items": []}
             if path == "/api/v1/llm-search":
                 return 200, {}, {"evidence": [], "usage": {}}
             if path == "/api/v1/fetch":
-                return 200, {}, {"items": [{"status": "success", "content": "fixture"}]}
+                fetch_strategies.append(kwargs["payload"]["strategy"])
+                return (
+                    200,
+                    {},
+                    {"items": [{"status": "success", "content": "Example Domain fixture"}]},
+                )
             raise AssertionError(path)
 
     monkeypatch.setattr(smoke, "Client", Client)
@@ -414,8 +431,17 @@ def test_search_live_uses_bounded_provider_fallback(monkeypatch, tmp_path) -> No
     report = tmp_path / "capability.json"
 
     assert smoke.main(["--mode", "capability", "--json-report", str(report)]) == 0
-    assert calls == ["openalex", "crossref"]
+    assert calls == ["default", "crossref", "openalex"]
+    assert default_payloads == [
+        {
+            "query": "retrieval augmented generation",
+            "domains": ["paper"],
+            "page": {"limit": 3},
+        }
+    ]
+    assert fetch_strategies == ["fallback", "fanout"]
     checks = {
         item["name"]: item for item in json.loads(report.read_text(encoding="utf-8"))["checks"]
     }
-    assert checks["search_live"]["detail"] == "crossref: 0 results"
+    assert checks["search_default_live"]["detail"] == "crossref: 0 results"
+    assert checks["search_live"]["detail"] == "openalex: 0 results"

--- a/tests/test_search_module_v2.py
+++ b/tests/test_search_module_v2.py
@@ -391,6 +391,29 @@ async def test_all_failures_raise_typed_canonical_provider_error() -> None:
 
 
 @pytest.mark.asyncio
+async def test_single_provider_failure_preserves_public_retry_metadata() -> None:
+    context = _context()
+    primary = _selection("crossref")
+    upstream = ProviderError(
+        ProviderErrorCode.RATE_LIMITED,
+        provider_id="crossref",
+        retry_after_seconds=17,
+    )
+    manager = _Manager({primary.adapter_id: upstream})
+
+    with pytest.raises(ProviderError) as caught:
+        await SearchModuleService(manager, _Selector(default=(primary,))).search(
+            SearchRequest(query="query", domains=("paper",)),
+            context,
+            _execution(),
+        )
+
+    assert caught.value.code is ProviderErrorCode.RATE_LIMITED
+    assert caught.value.provider_id == "crossref"
+    assert caught.value.retry_after_seconds == 17
+
+
+@pytest.mark.asyncio
 async def test_default_selection_count_and_cancel_or_deadline_stop_before_manager_call() -> None:
     context = _context()
     first = _selection("first")

--- a/tests/test_typescript_sdk_generator.py
+++ b/tests/test_typescript_sdk_generator.py
@@ -32,6 +32,10 @@ def test_generated_typescript_sdk_is_current_and_records_exact_artifact() -> Non
         )
     assert "This is a Panel/Vite client" in source
     assert "import.meta.env.VITE_ALLOWED_API_HOSTS" in source
+    search_domains = document["components"]["schemas"]["SearchRequest"]["properties"]["domains"][
+        "items"
+    ]["enum"]
+    assert f"export const SEARCH_DOMAINS = {json.dumps(search_domains)} as const" in source
     for operation_id in gen_typescript_sdk.EXPECTED_OPERATIONS:
         assert f"  {operation_id}: {{" in source
 

--- a/tests/test_web/test_ssrf_binding.py
+++ b/tests/test_web/test_ssrf_binding.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import gzip
 import socket
 import sys
+import zlib
 from types import ModuleType, SimpleNamespace
 from typing import Any
 
@@ -294,6 +296,254 @@ async def test_proxy_client_receives_only_ip_literal_connect_target(monkeypatch)
     assert request_kwargs["headers"]["Host"] == "example.com"
     assert request_kwargs["extensions"] == {"sni_hostname": "example.com"}
     assert request_kwargs["follow_redirects"] is False
+
+
+@pytest.mark.asyncio
+async def test_safe_httpx_only_advertises_builtin_content_decoders(monkeypatch):
+    """IP-pinned HTTPX requests must not advertise optional Brotli support."""
+
+    target, reason = resolve_fetch_target("https://example.com/compressed")
+    assert target is not None, reason
+    html = "<html><body>decoded content</body></html>"
+    accepted_encodings: list[str] = []
+
+    class CompressedStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            yield gzip.compress(html.encode())
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        accepted_encodings.append(request.headers["accept-encoding"])
+        return httpx.Response(
+            200,
+            headers={"content-encoding": "gzip", "content-type": "text/html"},
+            stream=CompressedStream(),
+        )
+
+    scraper = BaseScraper(
+        min_delay=0,
+        max_delay=0,
+        max_retries=1,
+        use_curl_cffi=False,
+        follow_redirects=False,
+    )
+    _patch_safe_client_transport(monkeypatch, handler)
+
+    async with scraper:
+        response = await scraper._do_resolved_request(
+            "GET",
+            target,
+            None,
+            {
+                "Host": target.host_header,
+                "Accept-Encoding": "gzip, deflate, br",
+            },
+            _max_response_bytes=4096,
+        )
+
+    assert accepted_encodings == ["gzip, deflate"]
+    assert response.text == html
+    assert "content-encoding" not in response.headers
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("raw_deflate", (False, True))
+async def test_safe_httpx_decodes_zlib_and_raw_deflate_streams(monkeypatch, raw_deflate):
+    target, reason = resolve_fetch_target("https://example.com/deflate")
+    assert target is not None, reason
+    content = b"deflate content"
+    if raw_deflate:
+        compressor = zlib.compressobj(wbits=-zlib.MAX_WBITS)
+        encoded = compressor.compress(content) + compressor.flush()
+    else:
+        encoded = zlib.compress(content)
+
+    class DeflateStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            for index in range(len(encoded)):
+                yield encoded[index : index + 1]
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-encoding": "deflate", "content-type": "text/plain"},
+            stream=DeflateStream(),
+        )
+
+    scraper = BaseScraper(
+        min_delay=0,
+        max_delay=0,
+        max_retries=1,
+        use_curl_cffi=False,
+        follow_redirects=False,
+    )
+    _patch_safe_client_transport(monkeypatch, handler)
+
+    async with scraper:
+        response = await scraper._do_resolved_request(
+            "GET",
+            target,
+            None,
+            {"Host": target.host_header},
+            _max_response_bytes=1024,
+        )
+
+    assert response.content == content
+    assert "content-encoding" not in response.headers
+
+
+@pytest.mark.asyncio
+async def test_safe_httpx_stops_streaming_after_decompressed_byte_limit(monkeypatch):
+    """The target Fetch cap must stop a compressed stream before full buffering."""
+
+    target, reason = resolve_fetch_target("https://example.com/compression-bomb")
+    assert target is not None, reason
+    compressed = gzip.compress(b"x" * (1024 * 1024))
+
+    class CountingStream(httpx.AsyncByteStream):
+        def __init__(self) -> None:
+            self.chunks = [compressed[index : index + 1] for index in range(len(compressed))]
+            self.yielded = 0
+            self.closed = False
+
+        async def __aiter__(self):
+            for chunk in self.chunks:
+                self.yielded += 1
+                yield chunk
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+    stream = CountingStream()
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-encoding": "gzip", "content-type": "text/plain"},
+            stream=stream,
+        )
+
+    scraper = BaseScraper(
+        min_delay=0,
+        max_delay=0,
+        max_retries=1,
+        use_curl_cffi=False,
+        follow_redirects=False,
+    )
+    _patch_safe_client_transport(monkeypatch, handler)
+
+    async with scraper:
+        response = await scraper._do_resolved_request(
+            "GET",
+            target,
+            None,
+            {"Host": target.host_header},
+            _max_response_bytes=1024,
+        )
+
+    assert response.extensions["souwen_response_too_large"] is True
+    assert response.extensions["souwen_response_size_lower_bound"] == 1025
+    assert response.content == b""
+    assert stream.yielded < len(stream.chunks)
+    assert stream.closed is True
+
+
+@pytest.mark.asyncio
+async def test_safe_httpx_applies_one_limit_across_concatenated_gzip_members(monkeypatch):
+    target, reason = resolve_fetch_target("https://example.com/concatenated-gzip")
+    assert target is not None, reason
+    first = gzip.compress(b"first member")
+    second = gzip.compress(b"x" * 2048)
+
+    class ConcatenatedStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            yield first
+            yield second[:3]
+            yield second[3:]
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-encoding": "gzip", "content-type": "text/plain"},
+            stream=ConcatenatedStream(),
+        )
+
+    scraper = BaseScraper(
+        min_delay=0,
+        max_delay=0,
+        max_retries=1,
+        use_curl_cffi=False,
+        follow_redirects=False,
+    )
+    _patch_safe_client_transport(monkeypatch, handler)
+
+    async with scraper:
+        response = await scraper._do_resolved_request(
+            "GET",
+            target,
+            None,
+            {"Host": target.host_header},
+            _max_response_bytes=1024,
+        )
+
+    assert response.extensions["souwen_response_too_large"] is True
+    assert response.extensions["souwen_response_size_lower_bound"] == 1025
+    assert response.content == b""
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("encoding", "payload"),
+    (
+        ("gzip", gzip.compress(b"truncated gzip")[:-4]),
+        ("deflate", zlib.compress(b"truncated zlib deflate")[:-2]),
+        (
+            "deflate",
+            (
+                lambda compressor: (
+                    compressor.compress(b"truncated raw deflate") + compressor.flush()
+                )[:-1]
+            )(zlib.compressobj(wbits=-zlib.MAX_WBITS)),
+        ),
+        ("deflate", zlib.compress(b"complete deflate") + b"trailing"),
+    ),
+)
+async def test_safe_httpx_rejects_incomplete_or_trailing_compressed_streams(
+    monkeypatch,
+    encoding,
+    payload,
+):
+    target, reason = resolve_fetch_target("https://example.com/invalid-compressed-stream")
+    assert target is not None, reason
+
+    class InvalidStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            yield payload
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-encoding": encoding, "content-type": "text/plain"},
+            stream=InvalidStream(),
+        )
+
+    scraper = BaseScraper(
+        min_delay=0,
+        max_delay=0,
+        max_retries=1,
+        use_curl_cffi=False,
+        follow_redirects=False,
+    )
+    _patch_safe_client_transport(monkeypatch, handler)
+
+    async with scraper:
+        with pytest.raises(httpx.DecodingError):
+            await scraper._do_resolved_request(
+                "GET",
+                target,
+                None,
+                {"Host": target.host_header},
+                _max_response_bytes=1024,
+            )
 
 
 @pytest.mark.asyncio

--- a/tools/gen_typescript_sdk.py
+++ b/tools/gen_typescript_sdk.py
@@ -15,7 +15,7 @@ from typing import Any
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_ARTIFACT = REPOSITORY_ROOT / "contracts/openapi/souwen-openapi-2.0.0rc4.json"
 DEFAULT_OUTPUT = REPOSITORY_ROOT / "panel/src/core/sdk/index.ts"
-GENERATOR_VERSION = 1
+GENERATOR_VERSION = 2
 EXPECTED_VERSION = "2.0.0rc4"
 EXPECTED_API_MAJOR = 2
 EXPECTED_OPERATIONS = {
@@ -298,6 +298,23 @@ def _render_dtos(document: dict[str, Any]) -> list[str]:
     return lines
 
 
+def _search_domains(document: dict[str, Any]) -> list[str]:
+    try:
+        values = document["components"]["schemas"]["SearchRequest"]["properties"]["domains"][
+            "items"
+        ]["enum"]
+    except (KeyError, TypeError) as exc:
+        raise GenerationError("SearchRequest.domains must expose one enum") from exc
+    if (
+        not isinstance(values, list)
+        or not values
+        or any(not isinstance(value, str) or not value for value in values)
+        or len(values) != len(set(values))
+    ):
+        raise GenerationError("SearchRequest.domains enum must contain unique strings")
+    return values
+
+
 def _render(document: dict[str, Any], artifact_payload: bytes) -> str:
     artifact_sha = hashlib.sha256(artifact_payload).hexdigest()
     operation_lines = []
@@ -319,6 +336,8 @@ def _render(document: dict[str, Any], artifact_payload: bytes) -> str:
             f"export const SUPPORTED_API_MAJOR = {document['x-souwen-api-major']} as const",
             f"export const OPENAPI_SHA256 = {artifact_sha!r} as const",
             "export const DEFAULT_TIMEOUT_MS = 125_000",
+            f"export const SEARCH_DOMAINS = {json.dumps(_search_domains(document))} as const",
+            "export type SearchDomain = typeof SEARCH_DOMAINS[number]",
             "",
             *dto_lines,
             "export interface OperationBinding<Request, Response> {",


### PR DESCRIPTION
## 结果与交付边界

本 PR 修复 current-main 在线预览验收暴露的 Search 默认路径、Fetch 冻结契约、压缩响应安全边界和 Panel 状态表达问题，使代码、生成 SDK、Panel、HFS smoke 与文档描述一致。

当前状态仅为 PR 已创建：尚未合并、尚未部署。合并后将使用独立 deployment profile 部署唯一 canonical Space `BlueSkyXN/SouWen`；不移动 `v2.0.0rc4` tag，不发布新的 GitHub Release。

## 主要变更

- 新增完整 `search_defaults` 配置，精确覆盖 13 个 canonical domain；默认 `paper` primary 改为 `crossref`，运行时通过 manifest/spec 校验 Provider、capability、domain 与 adapter，并按实际 primary 计算 readiness。
- 实现 frozen RC4 `FetchRequest.strategy` 的 `fallback` 与 `fanout` 语义，固定结果顺序、partial、public Provider identity、retry metadata 和 Browser Worker 边界，并新增 SPEC-04。
- IP-pinned HTTPX 只广告 `gzip, deflate`，按 raw stream 增量解码并在解压后 `10 MiB + 1 byte` 处停止；覆盖 gzip 多 member、截断流、trailing data、zlib/raw deflate 和 chunk-boundary 行为。
- Panel 的 Search domain 从 frozen OpenAPI 生成，默认请求不再手填 Provider；LLM Search 正确处理 evidence-only 成功；Fetch UI 固定 `fallback`；Settings 区分 gateway 声明与实际 Provider availability。
- HFS capability smoke 新增默认 Search、显式 Search、single-provider fanout 和公开正文可读性检查；API、配置、SDK、外观与在线预览文档同步更新。

## 兼容性与风险边界

- canonical OpenAPI artifact、Python SDK wire contract 和 `v2.0.0rc4` tag 保持不变；TypeScript SDK 仅增加由 OpenAPI enum 生成的 `SEARCH_DOMAINS`/`SearchDomain`。
- 省略 `SearchRequest.providers` 的 `paper` 请求会从 OpenAlex 切换到 Crossref，这是有意且已记录的用户可见行为变化；仍只选择一个 primary，不增加隐式 sequential fallback。
- `fanout` 是 RC4 schema 已公开但此前未实现的行为；Panel 不暴露 fanout 控件，显式 SDK/API caller 才会触发多 Provider 执行。
- HFS registry 采用 v2.1 draft schema；公开正式标准仍是 HFS v2.0。generic `hf_space_sync.py` 对本项目继续 fail closed，不用于真实 push/pull/prune。

## 验证

- `pytest tests/ -q --tb=short`：`2771 passed, 2 skipped`
- `cd panel && npm test`：`7 files / 51 tests passed`
- `cd panel && npm run build:local && npm run check:artifact`：PASS，嵌入 artifact byte-identical
- `ruff check src tests scripts tools`：PASS
- `ruff format --check src tests scripts tools`：PASS
- `python3 scripts/ci/run_profile.py --profile sdk-contract`：PASS
- `python3 scripts/ci/run_profile.py --profile server-contract`：PASS
- OpenAPI、Python SDK、TypeScript SDK、Provider docs generators `--check`：PASS
- Markdown links：`66 files / 160 links / 0 issues`
- HFS v2.1 draft checker（含本地事实源元数据）：`0 ERROR / 0 WARN`
- `python3 -m build`：wheel 与 sdist 构建成功
- `git diff --check`：PASS

## Review focus

1. `src/souwen/common_runtime/provider_support/scraper/base.py` 的流式解码完整性与 hard cap。
2. `src/souwen/modules/fetch/application/orchestration.py` 的 fallback/fanout、public identity 与 partial 语义。
3. `src/souwen/server/v2_runtime.py` 的 13-domain selector 与动态 readiness primary。
4. Panel 请求 payload、generated `SEARCH_DOMAINS` 和 live smoke 的契约一致性。
