### PR TITLE
fix(release): 加固 RC5 HFS Provider 预检与暂停恢复

### DIFF
--- a/.github/workflows/deploy-hf-space.yml
+++ b/.github/workflows/deploy-hf-space.yml
@@ -19,6 +19,36 @@ on:
         description: "显式执行 HFS promotion 与验收"
         required: true
         type: boolean
+      recovery_from_run_id:
+        description: "显式 paused forward-recovery 所依据的失败 Release run ID"
+        required: false
+        default: ""
+        type: string
+      expected_paused_space_sha:
+        description: "Recovery 前必须保持的 paused Space wrapper SHA"
+        required: false
+        default: ""
+        type: string
+      expected_paused_source_sha:
+        description: "Recovery 前 paused wrapper 必须唯一 pin 的 source SHA"
+        required: false
+        default: ""
+        type: string
+      expected_failed_candidate_sha:
+        description: "Recovery 来源 run 的失败 candidate SHA"
+        required: false
+        default: ""
+        type: string
+      expected_prior_space_sha:
+        description: "失败 transaction 的直接 parent wrapper SHA"
+        required: false
+        default: ""
+        type: string
+      expected_prior_source_sha:
+        description: "Transaction parent wrapper 必须唯一 pin 的 SouWen source SHA"
+        required: false
+        default: ""
+        type: string
     outputs:
       space_commit_sha:
         description: "Space repository commit verified by runtime.raw.sha"
@@ -56,12 +86,15 @@ on:
       - "souwen.example.yaml"
       - "entrypoint.sh"
       - "scripts/ci/**"
+      - "scripts/hf_space_llm_preflight.py"
+      - "scripts/hf_space_recovery_contract.py"
       - "scripts/hf_space_smoke.py"
       - "scripts/fixtures/hf-space-fetch-probe.html"
       - "scripts/fixtures/hf-space-browser-probe.html"
       - "scripts/warp-init.sh"
       - "cloud/hfs/**"
       - ".github/workflows/deploy-hf-space.yml"
+      - ".github/workflows/recover-hf-space.yml"
       - ".github/workflows/build-pyinstaller-server.yml"
   workflow_dispatch:
 
@@ -95,18 +128,37 @@ jobs:
           EXPECTED_VERSION: ${{ inputs.version }}
           VERIFIER_SHA: ${{ inputs.verifier_sha }}
           DEPLOY_HFS: ${{ inputs.deploy_hfs }}
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          DISPATCH_ACTOR: ${{ github.actor }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
           WORKFLOW_REF: ${{ github.ref }}
           WORKFLOW_SHA: ${{ github.workflow_sha }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           python3 -I - <<'PY'
+          import json
           import os
           import re
           import subprocess
           import tomllib
+          from urllib.request import Request, urlopen
 
           candidate = os.environ["CANDIDATE_SHA"]
           version = os.environ["EXPECTED_VERSION"]
           verifier = os.environ["VERIFIER_SHA"]
+          owner = os.environ["REPOSITORY_OWNER"]
+          if os.environ["RUN_ATTEMPT"] != "1":
+              raise SystemExit("reusable HF Space CD reruns are not allowed")
+          if any(
+              actor.casefold() != owner.casefold()
+              for actor in (
+                  os.environ["DISPATCH_ACTOR"],
+                  os.environ["TRIGGERING_ACTOR"],
+              )
+          ):
+              raise SystemExit("HF promotion requires repository-owner dispatch")
           if re.fullmatch(r"[0-9a-f]{40}", candidate) is None:
               raise SystemExit("candidate_sha must be exactly 40 lowercase hexadecimal characters")
           if re.fullmatch(r"[0-9a-f]{40}", verifier) is None:
@@ -115,8 +167,23 @@ jobs:
               raise SystemExit("reusable HF Space CD requires deploy_hfs=true")
           if os.environ["WORKFLOW_REF"] != "refs/heads/main":
               raise SystemExit("HF promotion requires a control-plane workflow from main")
-          if verifier != os.environ["WORKFLOW_SHA"]:
-              raise SystemExit("verifier_sha must equal the caller workflow SHA")
+          request = Request(
+              f"https://api.github.com/repos/{os.environ['REPOSITORY']}/git/ref/heads/main",
+              headers={
+                  "Accept": "application/vnd.github+json",
+                  "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
+                  "X-GitHub-Api-Version": "2022-11-28",
+              },
+          )
+          with urlopen(request, timeout=30) as response:
+              main_ref = json.load(response)
+          origin_main = str((main_ref.get("object") or {}).get("sha") or "")
+          if re.fullmatch(r"[0-9a-f]{40}", origin_main) is None:
+              raise SystemExit("cannot prove current GitHub main SHA")
+          if candidate != origin_main:
+              raise SystemExit("HF promotion candidate must equal current GitHub main")
+          if verifier != os.environ["WORKFLOW_SHA"] or verifier != origin_main:
+              raise SystemExit("verifier_sha and workflow SHA must equal current GitHub main")
           head = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
           if head != candidate:
               raise SystemExit(f"checkout mismatch: expected {candidate}, got {head}")
@@ -155,12 +222,14 @@ jobs:
 
   delivery-contracts:
     name: SDK and Server contracts
+    needs: detect-changes
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.candidate_sha || github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
 
       - uses: actions/setup-python@v7
         with:
@@ -194,6 +263,7 @@ jobs:
 
   docker-hfs:
     name: HF Space Docker surface smoke
+    needs: detect-changes
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
@@ -205,6 +275,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.candidate_sha || github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
 
       - name: Resolve source ref for HFS Dockerfile clone
         id: source
@@ -314,7 +385,7 @@ jobs:
     environment:
       name: hf
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     outputs:
       version: ${{ steps.project.outputs.version }}
       space_commit_sha: ${{ steps.sync.outputs.space_commit_sha }}
@@ -324,6 +395,7 @@ jobs:
       prior_runtime_commit_sha: ${{ steps.prior.outputs.prior_runtime_commit_sha }}
       prior_souwen_ref: ${{ steps.prior.outputs.prior_souwen_ref }}
       prior_runtime_stage: ${{ steps.prior.outputs.prior_runtime_stage }}
+      sync_parent_sha: ${{ steps.prior.outputs.sync_parent_sha }}
     steps:
       - name: Require HFS deployment secrets
         env:
@@ -356,8 +428,10 @@ jobs:
           python-version: "3.11"
           cache: pip
 
-      - name: Install Hugging Face Hub client
-        run: python -m pip install "huggingface_hub>=1.8,<2" "PyYAML>=6,<7"
+      - name: Install HFS deployment clients
+        run: |
+          python -m pip install "huggingface_hub>=1.8,<2" "PyYAML>=6,<7"
+          python -m pip install -e ".[server,tls,web,robots,scraper]"
 
       - name: Validate required HFS LLM Search configuration
         env:
@@ -388,15 +462,19 @@ jobs:
               raise SystemExit("HFS promotion requires llm_search_gateways.uniapi")
           api_key = uniapi.get("api_key")
           base_url = uniapi.get("base_url")
-          env_reference = re.compile(r"^\$\{[A-Z_][A-Z0-9_]*\}$")
+          env_reference = re.compile(r"^\$\{([A-Z_][A-Z0-9_]*)\}$")
           if not isinstance(api_key, str) or not api_key.strip():
               raise SystemExit("HFS promotion requires a UniAPI API key or exact env reference")
           if not isinstance(base_url, str) or not base_url.strip():
-              raise SystemExit("HFS promotion requires a UniAPI base URL or exact env reference")
-          if not env_reference.fullmatch(base_url.strip()):
-              parsed = urlsplit(base_url.strip())
-              if parsed.scheme not in {"http", "https"} or not parsed.hostname:
-                  raise SystemExit("HFS UniAPI base URL must be HTTP(S) or an exact env reference")
+              raise SystemExit("HFS promotion requires a literal UniAPI base URL")
+          api_key_reference = env_reference.fullmatch(api_key.strip())
+          if api_key_reference is not None and api_key_reference.group(1) != "UNIAPI_API_KEY":
+              raise SystemExit("HFS UniAPI API key uses an unmanaged environment reference")
+          if env_reference.fullmatch(base_url.strip()) is not None:
+              raise SystemExit("HFS UniAPI base URL must not use an environment reference")
+          parsed = urlsplit(base_url.strip())
+          if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+              raise SystemExit("HFS UniAPI base URL must be a literal HTTP(S) URL")
 
           sources = config.get("sources")
           source_ids = (
@@ -431,17 +509,67 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_SPACE_ID: BlueSkyXN/SouWen
+          CANDIDATE_SHA: ${{ inputs.candidate_sha || github.event.pull_request.head.sha || github.sha }}
+          RECOVERY_FROM_RUN_ID: ${{ inputs.recovery_from_run_id }}
+          EXPECTED_PAUSED_SPACE_SHA: ${{ inputs.expected_paused_space_sha }}
+          EXPECTED_PAUSED_SOURCE_SHA: ${{ inputs.expected_paused_source_sha }}
+          EXPECTED_FAILED_CANDIDATE_SHA: ${{ inputs.expected_failed_candidate_sha }}
+          EXPECTED_PRIOR_SPACE_SHA: ${{ inputs.expected_prior_space_sha }}
+          EXPECTED_PRIOR_SOURCE_SHA: ${{ inputs.expected_prior_source_sha }}
         run: |
           python -I - <<'PY'
           import os
           import re
+          import sys
           import time
           from pathlib import Path
 
           from huggingface_hub import HfApi, hf_hub_download
 
+          sys.path.insert(0, os.getcwd())
+          from scripts.hf_space_recovery_contract import (  # noqa: E402
+              RecoveryContractError,
+              validate_recovery_topology,
+          )
+
           api = HfApi(token=os.environ["HF_TOKEN"])
           space_id = os.environ["HF_SPACE_ID"]
+          candidate_sha = os.environ["CANDIDATE_SHA"]
+          recovery_fields = {
+              "recovery_from_run_id": os.environ.get("RECOVERY_FROM_RUN_ID", ""),
+              "expected_paused_space_sha": os.environ.get("EXPECTED_PAUSED_SPACE_SHA", ""),
+              "expected_paused_source_sha": os.environ.get(
+                  "EXPECTED_PAUSED_SOURCE_SHA", ""
+              ),
+              "expected_failed_candidate_sha": os.environ.get(
+                  "EXPECTED_FAILED_CANDIDATE_SHA", ""
+              ),
+              "expected_prior_space_sha": os.environ.get("EXPECTED_PRIOR_SPACE_SHA", ""),
+              "expected_prior_source_sha": os.environ.get("EXPECTED_PRIOR_SOURCE_SHA", ""),
+          }
+          populated_recovery_fields = {
+              name for name, value in recovery_fields.items() if value
+          }
+          if populated_recovery_fields and len(populated_recovery_fields) != len(
+              recovery_fields
+          ):
+              raise SystemExit("recovery inputs must be either all empty or all populated")
+          recovery = bool(populated_recovery_fields)
+          if recovery:
+              if not recovery_fields["recovery_from_run_id"].isdigit():
+                  raise SystemExit("recovery_from_run_id must be numeric")
+              for name in (
+                  "expected_paused_space_sha",
+                  "expected_paused_source_sha",
+                  "expected_failed_candidate_sha",
+                  "expected_prior_space_sha",
+                  "expected_prior_source_sha",
+              ):
+                  if re.fullmatch(r"[0-9a-f]{40}", recovery_fields[name]) is None:
+                      raise SystemExit(f"{name} must be an immutable 40-character SHA")
+          if re.fullmatch(r"[0-9a-f]{40}", candidate_sha) is None:
+              raise SystemExit("candidate_sha must be an immutable 40-character SHA")
+
           target_info = api.repo_info(repo_id=space_id, repo_type="space")
           if target_info.private is not True:
               raise SystemExit(
@@ -451,74 +579,152 @@ jobs:
           if re.fullmatch(r"[0-9a-f]{40}", prior_space_sha) is None:
               raise SystemExit("target Space does not expose an immutable 40-character commit")
 
-          deadline = time.monotonic() + 900
-          while True:
+          def source_pin(revision: str) -> str:
+              dockerfile = Path(
+                  hf_hub_download(
+                      repo_id=space_id,
+                      repo_type="space",
+                      filename="Dockerfile",
+                      revision=revision,
+                      token=os.environ["HF_TOKEN"],
+                      force_download=True,
+                  )
+              ).read_text(encoding="utf-8")
+              matches = re.findall(
+                  r"^ARG SOUWEN_REF=([0-9a-f]{40})$", dockerfile, re.MULTILINE
+              )
+              if len(matches) != 1:
+                  raise SystemExit(
+                      "target Space Dockerfile must contain exactly one immutable SOUWEN_REF "
+                      "before automatic promotion or operator-led recovery is allowed"
+                  )
+              return matches[0]
+
+          if recovery:
               runtime = api.get_space_runtime(repo_id=space_id)
               stage = str(getattr(runtime.stage, "value", runtime.stage))
-              runtime_sha = str(runtime.raw.get("sha") or "")
-              current_repo_sha = str(
-                  api.repo_info(repo_id=space_id, repo_type="space").sha
-              )
-              if current_repo_sha != prior_space_sha:
+              if stage.upper() != "PAUSED":
                   raise SystemExit(
-                      "Space repository changed while capturing the rollback point: "
-                      f"expected={prior_space_sha}, current={current_repo_sha}"
+                      "paused recovery requires the target Space to remain PAUSED: "
+                      f"stage={stage}"
+                  )
+              expected_paused_sha = recovery_fields["expected_paused_space_sha"]
+              current_pin = source_pin(prior_space_sha)
+              expected_prior_space = recovery_fields["expected_prior_space_sha"]
+              prior_pin = source_pin(expected_prior_space)
+              expected_prior_source = recovery_fields["expected_prior_source_sha"]
+              if prior_pin != expected_prior_source:
+                  raise SystemExit(
+                      "paused recovery prior source pin mismatch: "
+                      f"expected={expected_prior_source}, current={prior_pin}"
                   )
 
-              stage_upper = stage.upper()
-              stable = stage_upper.endswith("RUNNING") or stage_upper.endswith("SLEEPING")
-              if stable and runtime_sha == prior_space_sha:
-                  break
-              if any(
-                  marker in stage_upper
-                  for marker in (
-                      "PAUSED",
-                      "BUILD_ERROR",
-                      "RUNTIME_ERROR",
-                      "CONFIG_ERROR",
-                      "NO_APP_FILE",
-                      "STOPPED",
+              direct_parent_sha = None
+              if prior_space_sha != expected_prior_space:
+                  commits = api.list_repo_commits(
+                      repo_id=space_id,
+                      repo_type="space",
+                      revision=prior_space_sha,
                   )
-              ):
-                  raise SystemExit(
-                      "refusing to mutate a Space without a stable rollback runtime: "
-                      f"stage={stage}, repo_sha={prior_space_sha}, runtime_sha={runtime_sha}"
+                  if (
+                      len(commits) < 2
+                      or str(commits[0].commit_id) != prior_space_sha
+                  ):
+                      raise SystemExit(
+                          "paused recovery could not prove the paused wrapper ancestry"
+                      )
+                  direct_parent_sha = str(commits[1].commit_id)
+              try:
+                  topology = validate_recovery_topology(
+                      paused_space_sha=prior_space_sha,
+                      paused_source_sha=current_pin,
+                      expected_paused_space_sha=expected_paused_sha,
+                      expected_paused_source_sha=recovery_fields[
+                          "expected_paused_source_sha"
+                      ],
+                      failed_candidate_sha=recovery_fields[
+                          "expected_failed_candidate_sha"
+                      ],
+                      prior_space_sha=expected_prior_space,
+                      prior_source_sha=expected_prior_source,
+                      direct_parent_sha=direct_parent_sha,
                   )
-              if time.monotonic() >= deadline:
-                  raise SystemExit(
-                      "cannot establish rollback point before promotion: "
-                      f"stage={stage}, repo_sha={prior_space_sha}, runtime_sha={runtime_sha}"
-                  )
+              except RecoveryContractError as exc:
+                  raise SystemExit(str(exc)) from exc
+              rollback_space_sha = expected_prior_space
+              # Wrapper ancestry is not a runtime readback while the current Space is PAUSED.
+              rollback_runtime_sha = ""
+              rollback_source_sha = expected_prior_source
+              rollback_stage = ""
+              sync_parent_sha = topology.sync_parent_sha
               print(
-                  f"rollback-point stage={stage}, repo_sha={prior_space_sha}, "
-                  f"runtime_sha={runtime_sha}"
+                  f"validated paused forward recovery mode={topology.mode}, "
+                  f"parent={sync_parent_sha}, paused_source={current_pin}, "
+                  f"candidate={candidate_sha}"
               )
-              time.sleep(20)
+          else:
+              deadline = time.monotonic() + 900
+              while True:
+                  runtime = api.get_space_runtime(repo_id=space_id)
+                  stage = str(getattr(runtime.stage, "value", runtime.stage))
+                  runtime_sha = str(runtime.raw.get("sha") or "")
+                  current_repo_sha = str(
+                      api.repo_info(repo_id=space_id, repo_type="space").sha
+                  )
+                  if current_repo_sha != prior_space_sha:
+                      raise SystemExit(
+                          "Space repository changed while capturing the rollback point: "
+                          f"expected={prior_space_sha}, current={current_repo_sha}"
+                      )
 
-          dockerfile = Path(
-              hf_hub_download(
-                  repo_id=space_id,
-                  repo_type="space",
-                  filename="Dockerfile",
-                  revision=prior_space_sha,
-                  token=os.environ["HF_TOKEN"],
-                  force_download=True,
-              )
-          ).read_text(encoding="utf-8")
-          matches = re.findall(r"^ARG SOUWEN_REF=([0-9a-f]{40})$", dockerfile, re.MULTILINE)
-          if len(matches) != 1:
-              raise SystemExit(
-                  "target Space Dockerfile must contain exactly one immutable SOUWEN_REF "
-                  "before automatic promotion or operator-led recovery is allowed"
-              )
+                  stage_upper = stage.upper()
+                  stable = stage_upper.endswith("RUNNING") or stage_upper.endswith("SLEEPING")
+                  if stable and runtime_sha == prior_space_sha:
+                      break
+                  if any(
+                      marker in stage_upper
+                      for marker in (
+                          "PAUSED",
+                          "BUILD_ERROR",
+                          "RUNTIME_ERROR",
+                          "CONFIG_ERROR",
+                          "NO_APP_FILE",
+                          "STOPPED",
+                      )
+                  ):
+                      raise SystemExit(
+                          "refusing to mutate a Space without a stable rollback runtime: "
+                          f"stage={stage}, repo_sha={prior_space_sha}, "
+                          f"runtime_sha={runtime_sha}"
+                      )
+                  if time.monotonic() >= deadline:
+                      raise SystemExit(
+                          "cannot establish rollback point before promotion: "
+                          f"stage={stage}, repo_sha={prior_space_sha}, "
+                          f"runtime_sha={runtime_sha}"
+                      )
+                  print(
+                      f"rollback-point stage={stage}, repo_sha={prior_space_sha}, "
+                      f"runtime_sha={runtime_sha}"
+                  )
+                  time.sleep(20)
+
+              rollback_source_sha = source_pin(prior_space_sha)
+              rollback_space_sha = prior_space_sha
+              rollback_runtime_sha = runtime_sha
+              rollback_stage = stage
+              sync_parent_sha = prior_space_sha
+
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
-              output.write(f"prior_space_commit_sha={prior_space_sha}\n")
-              output.write(f"prior_runtime_commit_sha={runtime_sha}\n")
-              output.write(f"prior_souwen_ref={matches[0]}\n")
-              output.write(f"prior_runtime_stage={stage}\n")
+              output.write(f"prior_space_commit_sha={rollback_space_sha}\n")
+              output.write(f"prior_runtime_commit_sha={rollback_runtime_sha}\n")
+              output.write(f"prior_souwen_ref={rollback_source_sha}\n")
+              output.write(f"prior_runtime_stage={rollback_stage}\n")
+              output.write(f"sync_parent_sha={sync_parent_sha}\n")
           print(
-              f"captured rollback point space={prior_space_sha}, "
-              f"runtime={runtime_sha}, stage={stage}, source={matches[0]}"
+              f"captured transaction context space={rollback_space_sha}, "
+              f"runtime={rollback_runtime_sha}, stage={rollback_stage}, "
+              f"source={rollback_source_sha}, parent={sync_parent_sha}"
           )
           PY
 
@@ -565,6 +771,115 @@ jobs:
               )
           print("Managed Space Secret name preflight passed")
           PY
+
+      - name: Probe selected HFS LLM Search Provider before mutation
+        env:
+          SOUWEN_CONFIG_B64: ${{ secrets.SOUWEN_CONFIG_B64 }}
+          UNIAPI_API_KEY: ${{ secrets.UNIAPI_API_KEY }}
+        run: python scripts/hf_space_llm_preflight.py --request-timeout 60
+
+      - name: Recheck absent recovery tag and Release before mutation
+        if: ${{ inputs.recovery_from_run_id != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          python -I - <<'PY'
+          import json
+          import os
+          from urllib.error import HTTPError
+          from urllib.request import Request, urlopen
+
+          token = os.environ["GH_TOKEN"]
+          repository = os.environ["REPOSITORY"]
+          tag = f"v{os.environ['VERSION']}"
+
+          def require_absent(path: str, label: str) -> None:
+              request = Request(
+                  f"https://api.github.com{path}",
+                  headers={
+                      "Accept": "application/vnd.github+json",
+                      "Authorization": f"Bearer {token}",
+                      "X-GitHub-Api-Version": "2022-11-28",
+                  },
+              )
+              try:
+                  with urlopen(request, timeout=30) as response:
+                      json.load(response)
+              except HTTPError as exc:
+                  if exc.code == 404:
+                      return
+                  raise SystemExit(f"cannot prove absent {label}") from exc
+              raise SystemExit(f"paused recovery requires absent {label}")
+
+          require_absent(f"/repos/{repository}/git/ref/tags/{tag}", f"tag {tag}")
+          require_absent(f"/repos/{repository}/releases/tags/{tag}", f"Release {tag}")
+          print(f"confirmed absent recovery tag and Release for {tag}")
+          PY
+
+      - name: Write immutable HFS transaction intent
+        env:
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+          CANDIDATE_SHA: ${{ inputs.candidate_sha || github.event.pull_request.head.sha || github.sha }}
+          VERSION: ${{ inputs.version }}
+          RECOVERY_FROM_RUN_ID: ${{ inputs.recovery_from_run_id }}
+          EXPECTED_PAUSED_SPACE_SHA: ${{ inputs.expected_paused_space_sha }}
+          EXPECTED_PAUSED_SOURCE_SHA: ${{ inputs.expected_paused_source_sha }}
+          EXPECTED_FAILED_CANDIDATE_SHA: ${{ inputs.expected_failed_candidate_sha }}
+          EXPECTED_PRIOR_SPACE_SHA: ${{ inputs.expected_prior_space_sha }}
+          EXPECTED_PRIOR_SOURCE_SHA: ${{ inputs.expected_prior_source_sha }}
+          PRIOR_SPACE_SHA: ${{ steps.prior.outputs.prior_space_commit_sha }}
+          PRIOR_SOURCE_SHA: ${{ steps.prior.outputs.prior_souwen_ref }}
+          SYNC_PARENT_SHA: ${{ steps.prior.outputs.sync_parent_sha }}
+        run: |
+          python3 -I - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          intent = {
+              "schema": "souwen-hfs-transaction-intent-v1",
+              "run_id": os.environ["RUN_ID"],
+              "run_attempt": int(os.environ["RUN_ATTEMPT"]),
+              "workflow_sha": os.environ["WORKFLOW_SHA"],
+              "candidate_sha": os.environ["CANDIDATE_SHA"],
+              "version": os.environ["VERSION"],
+              "transaction_kind": (
+                  "recovery" if os.environ["RECOVERY_FROM_RUN_ID"] else "release"
+              ),
+              "recovery_from_run_id": os.environ["RECOVERY_FROM_RUN_ID"],
+              "expected_paused_space_sha": os.environ["EXPECTED_PAUSED_SPACE_SHA"],
+              "expected_paused_source_sha": os.environ["EXPECTED_PAUSED_SOURCE_SHA"],
+              "expected_failed_candidate_sha": os.environ[
+                  "EXPECTED_FAILED_CANDIDATE_SHA"
+              ],
+              "expected_prior_space_sha": os.environ["EXPECTED_PRIOR_SPACE_SHA"],
+              "expected_prior_source_sha": os.environ["EXPECTED_PRIOR_SOURCE_SHA"],
+              "prior_space_sha": os.environ["PRIOR_SPACE_SHA"],
+              "prior_source_sha": os.environ["PRIOR_SOURCE_SHA"],
+              "sync_parent_sha": os.environ["SYNC_PARENT_SHA"],
+          }
+          Path("hfs-transaction-intent.json").write_text(
+              json.dumps(intent, sort_keys=True, separators=(",", ":")) + "\n",
+              encoding="utf-8",
+          )
+          print(
+              "recorded immutable HFS transaction intent for "
+              f"run={intent['run_id']}, attempt={intent['run_attempt']}"
+          )
+          PY
+
+      - name: Upload immutable HFS transaction intent before mutation
+        uses: actions/upload-artifact@v7
+        with:
+          name: >-
+            hfs-transaction-intent-${{ github.run_id }}-attempt-${{ github.run_attempt }}
+          path: hfs-transaction-intent.json
+          if-no-files-found: error
+          retention-days: 90
 
       - name: Mark settings mutation phase
         id: settings_mutation
@@ -632,7 +947,7 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_SPACE_ID: BlueSkyXN/SouWen
           CANDIDATE_SHA: ${{ inputs.candidate_sha || github.event.pull_request.head.sha || github.sha }}
-          PRIOR_SPACE_SHA: ${{ steps.prior.outputs.prior_space_commit_sha }}
+          PRIOR_SPACE_SHA: ${{ steps.prior.outputs.sync_parent_sha }}
         run: |
           python -I - <<'PY'
           import os
@@ -774,13 +1089,23 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_SPACE_ID: BlueSkyXN/SouWen
+          RECOVERY_FROM_RUN_ID: ${{ inputs.recovery_from_run_id }}
         run: |
           python -I - <<'PY'
           import os
+
           from huggingface_hub import HfApi
 
           api = HfApi(token=os.environ["HF_TOKEN"])
           space_id = os.environ["HF_SPACE_ID"]
+          recovery = bool(os.environ.get("RECOVERY_FROM_RUN_ID"))
+          if recovery:
+              current = api.get_space_runtime(repo_id=space_id)
+              stage = str(getattr(current.stage, "value", current.stage))
+              if stage.upper() != "PAUSED":
+                  raise SystemExit(
+                      f"paused recovery must start from PAUSED; current stage={stage}"
+                  )
           runtime = api.restart_space(
               repo_id=space_id,
               factory_reboot=True,
@@ -1050,3 +1375,88 @@ jobs:
           else:
               raise SystemExit(f"Space pause could not be verified; last stage={last_stage}")
           PY
+
+  transaction-receipt:
+    name: Record HFS transaction outcome
+    needs: [sync-hfs-wrapper, rebuild-space, post-deploy-smoke, contain-space, pause-space]
+    if: ${{ always() && inputs.deploy_hfs }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Write machine-readable transaction outcome
+        env:
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+          VERSION: ${{ inputs.version }}
+          RECOVERY_FROM_RUN_ID: ${{ inputs.recovery_from_run_id }}
+          EXPECTED_PAUSED_SPACE_SHA: ${{ inputs.expected_paused_space_sha }}
+          EXPECTED_PAUSED_SOURCE_SHA: ${{ inputs.expected_paused_source_sha }}
+          EXPECTED_FAILED_CANDIDATE_SHA: ${{ inputs.expected_failed_candidate_sha }}
+          EXPECTED_PRIOR_SPACE_SHA: ${{ inputs.expected_prior_space_sha }}
+          EXPECTED_PRIOR_SOURCE_SHA: ${{ inputs.expected_prior_source_sha }}
+          PRIOR_SPACE_SHA: ${{ needs.sync-hfs-wrapper.outputs.prior_space_commit_sha }}
+          PRIOR_SOURCE_SHA: ${{ needs.sync-hfs-wrapper.outputs.prior_souwen_ref }}
+          SYNC_PARENT_SHA: ${{ needs.sync-hfs-wrapper.outputs.sync_parent_sha }}
+          SPACE_COMMIT_SHA: ${{ needs.sync-hfs-wrapper.outputs.space_commit_sha }}
+          SETTINGS_MUTATION_STARTED: ${{ needs.sync-hfs-wrapper.outputs.settings_mutation_started }}
+          SYNC_RESULT: ${{ needs.sync-hfs-wrapper.result }}
+          REBUILD_RESULT: ${{ needs.rebuild-space.result }}
+          POST_DEPLOY_RESULT: ${{ needs.post-deploy-smoke.result }}
+          CONTAIN_RESULT: ${{ needs.contain-space.result }}
+          PAUSE_RESULT: ${{ needs.pause-space.result }}
+        run: |
+          python3 -I - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          outcome = {
+              "schema": "souwen-hfs-transaction-outcome-v1",
+              "run_id": os.environ["RUN_ID"],
+              "run_attempt": int(os.environ["RUN_ATTEMPT"]),
+              "workflow_sha": os.environ["WORKFLOW_SHA"],
+              "candidate_sha": os.environ["CANDIDATE_SHA"],
+              "version": os.environ["VERSION"],
+              "transaction_kind": (
+                  "recovery" if os.environ["RECOVERY_FROM_RUN_ID"] else "release"
+              ),
+              "recovery_from_run_id": os.environ["RECOVERY_FROM_RUN_ID"],
+              "expected_paused_space_sha": os.environ["EXPECTED_PAUSED_SPACE_SHA"],
+              "expected_paused_source_sha": os.environ["EXPECTED_PAUSED_SOURCE_SHA"],
+              "expected_failed_candidate_sha": os.environ[
+                  "EXPECTED_FAILED_CANDIDATE_SHA"
+              ],
+              "expected_prior_space_sha": os.environ["EXPECTED_PRIOR_SPACE_SHA"],
+              "expected_prior_source_sha": os.environ["EXPECTED_PRIOR_SOURCE_SHA"],
+              "prior_space_sha": os.environ["PRIOR_SPACE_SHA"],
+              "prior_source_sha": os.environ["PRIOR_SOURCE_SHA"],
+              "sync_parent_sha": os.environ["SYNC_PARENT_SHA"],
+              "space_commit_sha": os.environ["SPACE_COMMIT_SHA"],
+              "settings_mutation_started": (
+                  os.environ["SETTINGS_MUTATION_STARTED"] == "true"
+              ),
+              "sync_result": os.environ["SYNC_RESULT"],
+              "rebuild_result": os.environ["REBUILD_RESULT"],
+              "post_deploy_result": os.environ["POST_DEPLOY_RESULT"],
+              "contain_result": os.environ["CONTAIN_RESULT"],
+              "pause_result": os.environ["PAUSE_RESULT"],
+          }
+          Path("hfs-transaction-outcome.json").write_text(
+              json.dumps(outcome, sort_keys=True, separators=(",", ":")) + "\n",
+              encoding="utf-8",
+          )
+          print(
+              "recorded HFS transaction outcome for "
+              f"run={outcome['run_id']}, kind={outcome['transaction_kind']}"
+          )
+          PY
+
+      - name: Upload HFS transaction outcome
+        uses: actions/upload-artifact@v7
+        with:
+          name: hfs-transaction-outcome-${{ github.run_id }}-attempt-${{ github.run_attempt }}
+          path: hfs-transaction-outcome.json
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/recover-hf-space.yml
+++ b/.github/workflows/recover-hf-space.yml
@@ -1,0 +1,313 @@
+name: Recover paused HF Space
+
+run-name: >-
+  Recover HFS parent=${{ inputs.expected_paused_space_sha }}
+  source=${{ inputs.expected_paused_source_sha }}
+  from=${{ inputs.recovery_from_run_id }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate_sha:
+        description: "Current main SHA to install after paused forward recovery"
+        required: true
+        type: string
+      version:
+        description: "Exact candidate version"
+        required: true
+        type: string
+      recovery_from_run_id:
+        description: "Failed release-candidate run whose containment paused the Space"
+        required: true
+        type: string
+      expected_paused_space_sha:
+        description: "Current paused Space wrapper SHA"
+        required: true
+        type: string
+      expected_paused_source_sha:
+        description: "Source SHA pinned by the current paused wrapper"
+        required: true
+        type: string
+      expected_failed_candidate_sha:
+        description: "Candidate SHA of the failed release or recovery run"
+        required: true
+        type: string
+      expected_prior_space_sha:
+        description: "Direct transaction-parent wrapper SHA"
+        required: true
+        type: string
+      expected_prior_source_sha:
+        description: "Source SHA pinned by the transaction-parent wrapper"
+        required: true
+        type: string
+
+concurrency:
+  # Match release-candidate.yml so recovery cannot race later assemble/publish jobs.
+  group: souwen-release-hfs-transaction
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  validate:
+    name: Validate paused recovery provenance
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      candidate_sha: ${{ steps.contract.outputs.candidate_sha }}
+      version: ${{ steps.contract.outputs.version }}
+      verifier_sha: ${{ steps.contract.outputs.verifier_sha }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.candidate_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate owner, current main, failed run, and containment evidence
+        id: contract
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+          VERSION: ${{ inputs.version }}
+          RECOVERY_FROM_RUN_ID: ${{ inputs.recovery_from_run_id }}
+          EXPECTED_PAUSED_SPACE_SHA: ${{ inputs.expected_paused_space_sha }}
+          EXPECTED_PAUSED_SOURCE_SHA: ${{ inputs.expected_paused_source_sha }}
+          EXPECTED_FAILED_CANDIDATE_SHA: ${{ inputs.expected_failed_candidate_sha }}
+          EXPECTED_PRIOR_SPACE_SHA: ${{ inputs.expected_prior_space_sha }}
+          EXPECTED_PRIOR_SOURCE_SHA: ${{ inputs.expected_prior_source_sha }}
+          DISPATCH_ACTOR: ${{ github.actor }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+          REPOSITORY: ${{ github.repository }}
+          WORKFLOW_REF: ${{ github.ref }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+        run: |
+          python3 -I - <<'PY'
+          import json
+          import io
+          import os
+          import re
+          import subprocess
+          import sys
+          import tomllib
+          import zipfile
+          from urllib.error import HTTPError
+          from urllib.request import HTTPRedirectHandler, Request, build_opener, urlopen
+
+          candidate = os.environ["CANDIDATE_SHA"]
+          version = os.environ["VERSION"]
+          run_id = os.environ["RECOVERY_FROM_RUN_ID"]
+          expected_failed_candidate = os.environ["EXPECTED_FAILED_CANDIDATE_SHA"]
+          owner = os.environ["REPOSITORY_OWNER"]
+          repository = os.environ["REPOSITORY"]
+          workflow_sha = os.environ["WORKFLOW_SHA"]
+
+          if os.environ["RUN_ATTEMPT"] != "1":
+              raise SystemExit("paused recovery workflow reruns are not allowed")
+
+          if any(
+              actor.casefold() != owner.casefold()
+              for actor in (
+                  os.environ["DISPATCH_ACTOR"],
+                  os.environ["TRIGGERING_ACTOR"],
+              )
+          ):
+              raise SystemExit("paused recovery requires repository-owner dispatch")
+          if os.environ["WORKFLOW_REF"] != "refs/heads/main":
+              raise SystemExit("paused recovery must run from main")
+          if not run_id.isdigit():
+              raise SystemExit("recovery_from_run_id must be numeric")
+          for name in (
+              "CANDIDATE_SHA",
+              "EXPECTED_PAUSED_SPACE_SHA",
+              "EXPECTED_PAUSED_SOURCE_SHA",
+              "EXPECTED_FAILED_CANDIDATE_SHA",
+              "EXPECTED_PRIOR_SPACE_SHA",
+              "EXPECTED_PRIOR_SOURCE_SHA",
+          ):
+              if re.fullmatch(r"[0-9a-f]{40}", os.environ[name]) is None:
+                  raise SystemExit(f"{name} must be exactly 40 lowercase hexadecimal characters")
+
+          subprocess.run(["git", "fetch", "--no-tags", "origin", "main"], check=True)
+          origin_main = subprocess.check_output(
+              ["git", "rev-parse", "refs/remotes/origin/main"], text=True
+          ).strip()
+          checkout = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+          if candidate != origin_main or checkout != candidate or workflow_sha != origin_main:
+              raise SystemExit("recovery candidate must equal the current origin/main")
+          with open("pyproject.toml", "rb") as file:
+              project_version = tomllib.load(file)["project"]["version"]
+          if version != "2.0.0rc5" or project_version != version:
+              raise SystemExit("paused recovery version does not match the RC5 candidate")
+
+          # Candidate-controlled modules are safe to import only after owner/current-main gates.
+          sys.path.insert(0, os.getcwd())
+          from scripts.hf_space_recovery_contract import (  # noqa: E402
+              RecoveryContractError,
+              validate_source_run_provenance,
+          )
+
+          token = os.environ["GH_TOKEN"]
+
+          def api_json(path: str):
+              request = Request(
+                  f"https://api.github.com{path}",
+                  headers={
+                      "Accept": "application/vnd.github+json",
+                      "Authorization": f"Bearer {token}",
+                      "X-GitHub-Api-Version": "2022-11-28",
+                  },
+              )
+              with urlopen(request, timeout=30) as response:
+                  return json.load(response)
+
+          def require_absent(path: str, label: str) -> None:
+              try:
+                  api_json(path)
+              except HTTPError as exc:
+                  if exc.code == 404:
+                      return
+                  raise SystemExit(f"cannot prove absent {label}") from exc
+              raise SystemExit(f"paused recovery requires absent {label}")
+
+          class NoRedirect(HTTPRedirectHandler):
+              def redirect_request(self, req, fp, code, msg, headers, newurl):
+                  return None
+
+          def load_transaction_intent():
+              artifact_name = f"hfs-transaction-intent-{run_id}-attempt-1"
+              payload = api_json(
+                  f"/repos/{repository}/actions/runs/{run_id}/artifacts"
+                  f"?name={artifact_name}"
+              )
+              artifacts = payload.get("artifacts", [])
+              if not artifacts:
+                  return None
+              if len(artifacts) != 1:
+                  raise SystemExit("failed transaction intent inventory mismatch")
+              artifact = artifacts[0]
+              if (
+                  artifact.get("name") != artifact_name
+                  or artifact.get("expired") is not False
+                  or str((artifact.get("workflow_run") or {}).get("id")) != run_id
+              ):
+                  raise SystemExit("failed transaction intent metadata mismatch")
+
+              request = Request(
+                  artifact["archive_download_url"],
+                  headers={
+                      "Accept": "application/vnd.github+json",
+                      "Authorization": f"Bearer {token}",
+                      "X-GitHub-Api-Version": "2022-11-28",
+                  },
+              )
+              try:
+                  build_opener(NoRedirect()).open(request, timeout=30)
+              except HTTPError as exc:
+                  if exc.code != 302 or not exc.headers.get("Location", "").startswith(
+                      "https://"
+                  ):
+                      raise SystemExit("failed transaction intent download mismatch") from exc
+                  download_url = exc.headers["Location"]
+              else:
+                  raise SystemExit("failed transaction intent download did not redirect")
+
+              with urlopen(Request(download_url), timeout=30) as response:
+                  archive = response.read(1_000_001)
+              if len(archive) > 1_000_000:
+                  raise SystemExit("failed transaction intent archive is oversized")
+              with zipfile.ZipFile(io.BytesIO(archive)) as bundle:
+                  entries = bundle.infolist()
+                  if (
+                      len(entries) != 1
+                      or entries[0].filename != "hfs-transaction-intent.json"
+                      or entries[0].file_size > 65_536
+                  ):
+                      raise SystemExit("failed transaction intent archive mismatch")
+                  intent = json.loads(bundle.read(entries[0]).decode("utf-8"))
+              if not isinstance(intent, dict):
+                  raise SystemExit("failed transaction intent schema mismatch")
+              return intent
+
+          tag = f"v{version}"
+          require_absent(f"/repos/{repository}/git/ref/tags/{tag}", f"tag {tag}")
+          require_absent(f"/repos/{repository}/releases/tags/{tag}", f"Release {tag}")
+
+          run = api_json(f"/repos/{repository}/actions/runs/{run_id}")
+          jobs = api_json(f"/repos/{repository}/actions/runs/{run_id}/jobs?per_page=100")
+          if jobs.get("total_count", 0) > 100:
+              raise SystemExit("failed release run job inventory exceeds the recovery verifier")
+          try:
+              source_kind = validate_source_run_provenance(
+                  run_id=run_id,
+                  run=run,
+                  jobs=jobs.get("jobs", []),
+                  owner=owner,
+                  failed_candidate_sha=expected_failed_candidate,
+                  paused_space_sha=os.environ["EXPECTED_PAUSED_SPACE_SHA"],
+                  paused_source_sha=os.environ["EXPECTED_PAUSED_SOURCE_SHA"],
+                  prior_space_sha=os.environ["EXPECTED_PRIOR_SPACE_SHA"],
+                  prior_source_sha=os.environ["EXPECTED_PRIOR_SOURCE_SHA"],
+                  intent=load_transaction_intent(),
+              )
+          except RecoveryContractError as exc:
+              raise SystemExit(str(exc)) from exc
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"candidate_sha={candidate}\n")
+              output.write(f"version={version}\n")
+              output.write(f"verifier_sha={workflow_sha}\n")
+          print(
+              f"validated paused recovery candidate={candidate}, source_kind={source_kind}, "
+              f"failed_run={run_id}, failed_candidate={expected_failed_candidate}"
+          )
+          PY
+
+  recover:
+    name: Forward-recover exact paused HF Space
+    needs: validate
+    uses: ./.github/workflows/deploy-hf-space.yml
+    with:
+      candidate_sha: ${{ needs.validate.outputs.candidate_sha }}
+      version: ${{ needs.validate.outputs.version }}
+      verifier_sha: ${{ needs.validate.outputs.verifier_sha }}
+      deploy_hfs: true
+      recovery_from_run_id: ${{ inputs.recovery_from_run_id }}
+      expected_paused_space_sha: ${{ inputs.expected_paused_space_sha }}
+      expected_paused_source_sha: ${{ inputs.expected_paused_source_sha }}
+      expected_failed_candidate_sha: ${{ inputs.expected_failed_candidate_sha }}
+      expected_prior_space_sha: ${{ inputs.expected_prior_space_sha }}
+      expected_prior_source_sha: ${{ inputs.expected_prior_source_sha }}
+    secrets: inherit
+
+  verify:
+    name: Verify recovery outputs
+    needs: [validate, recover]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require exact successful recovery output
+        env:
+          CANDIDATE_SHA: ${{ needs.validate.outputs.candidate_sha }}
+          VERSION: ${{ needs.validate.outputs.version }}
+          SPACE_COMMIT_SHA: ${{ needs.recover.outputs.space_commit_sha }}
+          PROMOTED_VERSION: ${{ needs.recover.outputs.version }}
+        run: |
+          python3 -I - <<'PY'
+          import os
+          import re
+
+          if re.fullmatch(r"[0-9a-f]{40}", os.environ["SPACE_COMMIT_SHA"]) is None:
+              raise SystemExit("paused recovery did not return an immutable Space commit")
+          if os.environ["PROMOTED_VERSION"] != os.environ["VERSION"]:
+              raise SystemExit("paused recovery version readback mismatch")
+          print(
+              "paused recovery completed for "
+              f"candidate={os.environ['CANDIDATE_SHA']}, "
+              f"space={os.environ['SPACE_COMMIT_SHA']}"
+          )
+          PY

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -34,7 +34,8 @@ on:
         type: boolean
 
 concurrency:
-  group: release-candidate-${{ inputs.candidate_sha }}
+  # Serialize external deploy/publish runs with recovery; pure evidence runs stay per-candidate.
+  group: ${{ (inputs.deploy_hfs || inputs.publish) && 'souwen-release-hfs-transaction' || format('release-candidate-evidence-{0}', inputs.candidate_sha) }}
   cancel-in-progress: false
 
 permissions:
@@ -73,6 +74,7 @@ jobs:
           REPOSITORY_OWNER: ${{ github.repository_owner }}
           WORKFLOW_REF: ${{ github.ref }}
           WORKFLOW_SHA: ${{ github.workflow_sha }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           python3 -I - <<'PY'
           import os
@@ -88,6 +90,8 @@ jobs:
           deploy_hfs = os.environ['DEPLOY_HFS']
           dispatch_actor = os.environ['DISPATCH_ACTOR']
           triggering_actor = os.environ['TRIGGERING_ACTOR']
+          if os.environ['RUN_ATTEMPT'] != '1':
+              raise SystemExit('release candidate workflow reruns are not allowed')
           repository_owner = os.environ['REPOSITORY_OWNER']
           workflow_ref = os.environ['WORKFLOW_REF']
           workflow_sha = os.environ['WORKFLOW_SHA']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,18 @@
   commit version source、根 `.env` env 事实源，以及 `SOUWEN_CONFIG_B64` 对应的 gitignored 原始
   YAML 事实源；settings ownership 精确收敛到三个 workflow-managed Space Secrets 和一个
   provenance Variable。Secret 值 write-only，失败后不再用“旧 wrapper + 新/部分 settings”
-  自动恢复，而是 fail closed pause，等待使用获批 Secret source 人工恢复。
+  自动恢复，而是 fail closed pause，等待使用获批 Secret source 受控恢复。
+- HFS promotion 在任何 settings mutation 前通过 exact candidate 的 production runtime assembly 对
+  配置中唯一启用的 LLM Search Provider 执行 single-attempt live evidence gate；429、不可用或无
+  structured evidence 均在写入前失败，不 retry、不自动换 model，也不会 pause 原健康 Space。对已经
+  containment 的 `PAUSED` transaction，新增 owner-only `recover-hf-space.yml`，精确绑定失败 run、
+  paused/prior wrapper 与 source SHA，覆盖 settings-only、direct-parent wrapper advance 和 validated
+  recovery retry，完成 settings 重写、单次 factory reboot 和完整 smoke。Recovery 与 central release
+  共用覆盖 assemble/publish 的全局 concurrency，并在 validate 与 mutation 前双重证明 RC5 tag/Release
+  absent；新 transaction 在 mutation 前先持久化 machine intent，结合 primary/retry containment 与 live
+  paused topology 绑定恢复状态，post outcome 仅作补充证据。Release/recovery 禁止 rerun，intent 上线前
+  的已知 RC5 failed run 仅接受一次性 exact-SHA legacy contract。Recovery 本身不创建 tag/Release，
+  正式发布仍必须重新运行 central release workflow。
 - HFS surface smoke 增加 authenticated admin config/ping/doctor 正向检查，并对 config 中未脱敏的
   credential-shaped string fail closed。
 - 修正 Docker 文档：应用配置只读挂载到 `/app/souwen.yaml`，`/app/data` 专用于 WARP/runtime

--- a/docs/hf-space-cd.md
+++ b/docs/hf-space-cd.md
@@ -93,7 +93,7 @@ application token 必须走独立的 `X-SouWen-Token`；即使当前 preview sur
 | `HF_TOKEN` | 写 Space repo、restart/pause runtime | 仅 HFS 管理 API；需要 write 权限 |
 | `HF_SPACE_READ_TOKEN` | 兼容可能启用的 private edge | `Authorization: Bearer ...`；目标权限只需 READ |
 | `SOUWEN_SMOKE_BEARER_TOKEN` | SouWen 应用 admin password | `X-SouWen-Token: ...` |
-| `SOUWEN_CONFIG_B64` | 与 Space 同源的 RC5 配置；promotion 前验证 exact 一个 LLM Search Provider 与 gateway 结构 | 仅 workflow 内存预检；`${VAR}` 是否解析由 post-deploy live smoke 证明 |
+| `SOUWEN_CONFIG_B64` | 与 Space 同源的 RC5 配置；promotion 前验证 exact 一个 LLM Search Provider、gateway 结构与一次 single-attempt live evidence | 仅 workflow 内存/临时文件预检；不输出配置值，post-deploy 仍重新验证 HFS runtime |
 | `UNIAPI_API_KEY` | RC5 UniAPI gateway credential | workflow 将其写入同名 Space Secret；只回读 Secret 名称，不读取或记录值 |
 
 SouWen 仍以标准 `Authorization: Bearer <password>` 作为普通部署的首选应用鉴权。只有上游
@@ -133,26 +133,33 @@ SHA。
 2. 记录 `prior_space_commit_sha`、`prior_runtime_commit_sha`、`prior_souwen_ref`。旧部署没有
    immutable source pin 时，在写入前停止，不能回退到 floating `main`；同时记录
    `prior_runtime_stage` 供 manifest 和恢复审计。
-3. rollback point 稳定后，workflow 先在独立 preflight 中只读 Secret 名称并拒绝任何未登记名称；
-   preflight 失败时没有 settings mutation，也不得暂停原健康 Space。preflight 完成后、第一次写入前，
-   workflow 写出 `settings_mutation_started=true` 事务标记，再将 `SOUWEN_SMOKE_BEARER_TOKEN` 映射为
-   Space `SOUWEN_ADMIN_PASSWORD`，并同步 `SOUWEN_CONFIG_B64`、`UNIAPI_API_KEY`。写入后名称集合必须
-   精确等于 `hfs-dev.toml` 中的三个受管名称；不删除未知 Secret，也不输出值、长度、hash 或前缀。
+3. rollback point 稳定后，workflow 先只读 Secret 名称并拒绝任何未登记名称，再从 exact candidate
+   生产 runtime assembly 对 `SOUWEN_CONFIG_B64` **显式选中的唯一 LLM Search Provider**执行一次
+   `max_results_per_provider=1`、single-attempt live request。它不 retry、不遍历第二个 Provider、不自动
+   切换 model，也不输出 gateway、credential 或 raw upstream body。配置 loader 运行在隔离环境中：
+   gateway `api_key` 只允许 literal 或 exact `${UNIAPI_API_KEY}`，`base_url` 必须是 literal HTTP(S)
+   URL；GitHub runner 的其他 token、`HOME` 或 `SOUWEN_*` 不能参与解析。这是获授权 promotion 的一次付费
+   pre-mutation gate；任一失败都发生在 mutation marker 前，因此原健康 Space 保持不变且不 pause。
+   两个 preflight 完成后、第一次写入前，workflow 才写出 `settings_mutation_started=true` 事务标记，
+   将 `SOUWEN_SMOKE_BEARER_TOKEN` 映射为 Space `SOUWEN_ADMIN_PASSWORD`，并同步
+   `SOUWEN_CONFIG_B64`、`UNIAPI_API_KEY`。写入后名称集合必须精确等于 `hfs-dev.toml` 中的三个受管
+   名称；不删除未知 Secret，也不输出值、长度、hash 或前缀。
 4. 只同步受管的四个 wrapper 文件；diff 固定读取 prior revision，`create_commit` 使用
    `parent_commit=<prior_space_commit_sha>` 防止外部 writer 造成 TOCTOU。取得新 commit 后，
    transaction 写入并立即 readback `SOUWEN_WRAPPER_SHA=<space_commit_sha>` Space variable。
 5. Factory rebuild，等待 Space repo SHA 与 runtime SHA 等于新的 wrapper commit。
 6. 使用 trusted verifier 完成 surface、target capability、edge/application auth 与 candidate/source/
    wrapper SHA smoke。Required checks 固定覆盖 Search、LLM Search 与 immutable Fetch；readiness
-   另行证明 Browser Worker ready 且 source SHA 一致。普通 CI 不做付费 LLM Search live call，
-   只有显式 HFS promotion 的 capability smoke 才执行。
+   另行证明 Browser Worker ready 且 source SHA 一致。Pre-mutation provider gate 不能替代 HFS egress、
+   application assembly 或 post-deploy capability smoke。普通 PR/main CI 不做付费 LLM Search live call；
+   只有显式 HFS promotion 或 paused recovery 才执行。
 
 Space Secret 是 write-only：workflow 能读回名称，不能捕获旧值。因此
 `settings_mutation_started=true` 一旦完成，
 任何 sync/rebuild/post-smoke 失败都不能安全地自动恢复成“旧 wrapper + 旧 settings”。失败路径必须：
 
 - 调用 `pause_space` 并验证 `PAUSED`，避免旧代码与新/部分 settings 组合继续对外运行；
-- 保留 prior repo/runtime/source snapshot 和失败 run，供人工恢复使用；
+- 保留 prior repo/runtime/source snapshot 和失败 run，供受控 operator recovery 使用；
 - 从获批的安全 Secret source 恢复相互匹配的 settings，再选择 prior 或 corrected wrapper，factory
   rebuild 后重新执行完整 surface/capability/provenance smoke；
 - 保持原 promotion 为失败，暂停成功不能把失败验收伪装为 PASS。
@@ -161,6 +168,32 @@ Space Secret 是 write-only：workflow 能读回名称，不能捕获旧值。�
 无法解决 write-only prior values 缺失。GitHub Actions cancel、runner 丢失或平台故障也不能保证
 containment job 一定启动，因此失败通知仍是人工 hard stop：先只读核对 Space repo/runtime/source
 与 settings names，再决定恢复，未完成恢复前保持 paused。
+
+需要从已知失败 transaction 前向恢复时，只能从 current `main` 手工 dispatch
+`.github/workflows/recover-hf-space.yml`。该 workflow 不是发布入口；它要求 repository owner 同时是
+actor/triggering actor，并精确绑定 source run ID、paused wrapper/source SHA、failed candidate SHA、prior
+wrapper/source SHA；validate 与 mutation marker 前都会 fail-close 证明目标 RC tag/Release 尚不存在。
+Source run 可以是 containment 成功且 publish skipped 的 failed release，也可以是 validate 成功、完整
+transaction run-name receipt 匹配且再次 containment 的 failed recovery。Reusable workflow 在 mutation
+marker **之前**先上传 `souwen-hfs-transaction-intent-v1`，绑定 run/attempt、candidate、prior/current
+wrapper、source pin 与 inputs；intent 上传失败时不得写 Secret。Primary 或 retry containment 后另上传
+outcome evidence，但 recovery 只依赖 mutation 前已持久化的 intent、Actions jobs provenance 与 live paused
+topology，因此 outcome runner/upload 失败不会锁死恢复入口。所有 release/recovery source 和当前 dispatch
+都只接受 `run_attempt=1`，禁止 rerun 复用 run ID。历史 run `30545216223` 早于 intent，只允许代码中一次性
+固定的 exact run/candidate/paused/prior SHA contract，不能泛化为其他 legacy run。
+Reusable HFS workflow 验证 Space 仍为 private/`PAUSED`，并只接受两个状态：Secret 写入后 wrapper 尚未
+前移的 `settings-only` 拓扑，或 paused wrapper **直接**继承 prior wrapper 且 pin failed candidate 的
+`wrapper-advanced` 拓扑。随后从获批 GitHub `hf` environment Secret source 重写完整 settings，以当前
+paused wrapper 为并发保护 parent 创建新 candidate wrapper，并直接执行一次 factory reboot，再完成完整
+surface/capability/provenance smoke；任一步失败仍会重新 pause，且可用新失败 recovery receipt 再次前向
+恢复。`release-candidate.yml` 与 recovery 使用同一全局 concurrency group，锁覆盖标准 run 的 HFS、
+assemble 与 publish 全阶段，避免旧 evidence 与新 runtime 交叉发布。Recovery 成功只恢复到稳定 runtime，
+不生成 tag/Release，也不能替代之后新的标准 `release-candidate.yml` publish run。
+
+Recovery 的 `prior_space_commit_sha`/`prior_souwen_ref` 仅表示已验证的 transaction-parent ancestry；当前
+Space 为 `PAUSED` 时无法把该 parent 冒充 runtime readback，因此 `prior_runtime_commit_sha` 与
+`prior_runtime_stage` 明确留空。只有普通 promotion 从稳定 `RUNNING`/`SLEEPING` 捕获的值才属于 prior
+runtime evidence。
 
 ## 必测入口
 

--- a/docs/internal/development-branching.md
+++ b/docs/internal/development-branching.md
@@ -106,8 +106,14 @@ Since 2026-07-26 both workflows run in two lanes (owner-approved CI slimming):
 
 External smoke, HF Space local preflight, the RC5 Server bundle builder, and
 secret-backed checks keep their dedicated reusable/manual/schedule entrypoints.
-They should not be folded into every ordinary PR. Remote HFS promotion and
-GitHub publication are coordinated only by `release-candidate.yml`.
+They should not be folded into every ordinary PR. Normal remote HFS promotion and
+GitHub publication are coordinated only by `release-candidate.yml`. The owner-only
+`recover-hf-space.yml` entrypoint may only forward-recover an exact, previously contained
+`PAUSED` transaction; it cannot publish and does not replace a fresh central release run.
+External transaction runs (`deploy_hfs=true` or `publish=true`) share
+`souwen-release-hfs-transaction` concurrency for the complete caller run, so recovery cannot overlap a
+standard run's HFS evidence, assembly, or publication phase. Pure local evidence runs retain a
+per-candidate group and therefore cannot delay an urgent paused recovery.
 
 `build-pyinstaller-server.yml` builds the RC5 release inventory: exactly four
 target-native PyInstaller Server bundles. The old legacy PyInstaller and Nuitka
@@ -127,7 +133,7 @@ it from the current `main` workflow revision with an exact 40-character
    candidate may be a descendant of current `origin/main`; this run has no
    external release/deploy write. It generates the immutable OpenAPI artifact,
    exactly four Server bundles and their target-native smoke evidence.
-3. Accept **RC-ready** only when all 15 always-required gates pass on the exact
+3. Accept **RC-ready** only when all 13 always-required gates pass on the exact
    candidate and the evidence bundle inventory/checksums agree.
 4. Merge the approved candidate. Before any HFS write, require
    `candidate_sha == origin/main`, protected `hf`/`release` environments, a private

--- a/docs/internal/rc-readiness-gates.md
+++ b/docs/internal/rc-readiness-gates.md
@@ -214,10 +214,22 @@ RC-ready run 可以验证从 current main 派生的 candidate；任何 secret-be
 - Surface/capability smoke 必须从 trusted `verifier_sha` 执行，不能把 app admin token 暴露给
   candidate checkout。它还必须正向检查 authenticated admin config/ping/doctor，并验证 config
   的 credential-shaped string 已脱敏。
-- Space Secret 值 write-only；Secret name/schema preflight 必须在 mutation marker 前完成，失败时
-  不得 pause 原健康 Space。`settings_mutation_started=true` 必须在第一次写调用前由已完成 step 写出；
-  此后的任一 sync/rebuild/post-smoke 失败必须 pause Space 并验证 `PAUSED`，再从获批 Secret source
-  人工恢复匹配的 settings/wrapper，原 promotion 仍为 FAIL。
+- Space Secret 值 write-only；Secret name/schema preflight 与 exact selected LLM Provider 的 single-attempt
+  live preflight 必须在 mutation marker 前完成，失败时不得 pause 原健康 Space。Provider preflight 不
+  retry、不自动切换 model，且不能替代 post-deploy capability smoke。`settings_mutation_started=true`
+  必须在第一次写调用前由已完成 step 写出；此后的任一 sync/rebuild/post-smoke 失败必须 pause Space
+  并验证 `PAUSED`。如需前向恢复，只能由 owner 从 current `main` 使用精确绑定 failed run、paused/
+  prior wrapper 与 source SHA 的 `recover-hf-space.yml` 重写获批 settings、factory rebuild 并重跑完整
+  smoke。Recovery 同时覆盖 wrapper 尚未前移和 direct-parent wrapper 已前移两种 paused 拓扑；失败的
+  release/recovery 只有在 mutation 前成功上传的 `souwen-hfs-transaction-intent-v1`、primary 或 retry
+  containment jobs 与 live paused topology 均可证明时才可作为下一次 recovery source；post-transaction
+  outcome artifact 只补充证据，不是恢复可用性的单点。两个入口与 source run 都只接受 attempt 1，禁止
+  rerun 复用 run ID。Intent 机制上线前的历史 RC5 failed run 只允许一次性 hard-coded exact SHA
+  contract，不接受 operator 自报的任意 legacy state。
+  Recovery validate 与 mutation marker 前还必须分别证明目标 tag/Release absent；无法读回或发现 partial
+  state 时停止，不得消耗该 RC 版本。
+  Recovery 与 central release caller 共用覆盖 assemble/publish 的全局 concurrency；原 promotion 仍为
+  FAIL，recovery 也不能发布或替代新的 central release run。
 
 **Evidence**：批准记录引用、prior/promoted Space SHA、source SHA、factory rebuild run、
 surface/capability report、edge/application auth/admin-open assertion；失败路径另保存 containment

--- a/scripts/hf_space_llm_preflight.py
+++ b/scripts/hf_space_llm_preflight.py
@@ -1,0 +1,241 @@
+"""Fail-closed live gate for the explicitly selected HFS LLM Search Provider."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import binascii
+from collections.abc import Callable, Mapping, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+import math
+import os
+from pathlib import Path
+import re
+import sys
+import tempfile
+from typing import Any
+from urllib.parse import urlsplit
+
+import yaml
+
+from souwen.config import SouWenConfig, get_config, reload_config
+from souwen.platform.provider_spi import (
+    ExecutionContext,
+    LLMSearchRequest,
+    ProviderError,
+    ProviderRef,
+    RequestContext,
+)
+from souwen.server.v2_runtime import build_target_runtime
+
+
+DEFAULT_TIMEOUT_SECONDS = 60.0
+_QUERY = "What is retrieval augmented generation?"
+_EXACT_ENV_REFERENCE = re.compile(r"^\$\{([A-Z_][A-Z0-9_]*)\}$")
+_MANAGED_ENV_REFERENCE = ("uniapi", "api_key", "UNIAPI_API_KEY")
+
+
+class PreflightFailure(RuntimeError):
+    """A bounded failure that contains no gateway, credential, or raw upstream detail."""
+
+
+@dataclass(frozen=True, slots=True)
+class PreflightReceipt:
+    provider_id: str
+    evidence_count: int
+
+
+@contextmanager
+def _isolated_environment(values: Mapping[str, str]):
+    previous = dict(os.environ)
+    try:
+        os.environ.clear()
+        os.environ.update(values)
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(previous)
+
+
+def _decode_and_validate_config(encoded: str) -> str:
+    try:
+        decoded = base64.b64decode(encoded, validate=True).decode("utf-8")
+        raw = yaml.safe_load(decoded)
+    except (binascii.Error, UnicodeDecodeError, yaml.YAMLError) as exc:
+        raise PreflightFailure("invalid HFS LLM Search configuration") from exc
+    if not isinstance(raw, dict):
+        raise PreflightFailure("invalid HFS LLM Search configuration")
+
+    gateways = raw.get("llm_search_gateways")
+    uniapi = gateways.get("uniapi") if isinstance(gateways, dict) else None
+    if not isinstance(uniapi, dict):
+        raise PreflightFailure("invalid HFS LLM Search configuration")
+
+    for gateway_name, gateway in gateways.items():
+        if not isinstance(gateway, dict):
+            continue
+        for field_name in ("api_key", "base_url"):
+            value = gateway.get(field_name)
+            match = _EXACT_ENV_REFERENCE.fullmatch(value) if isinstance(value, str) else None
+            if match is None:
+                continue
+            reference = (gateway_name, field_name, match.group(1))
+            if reference != _MANAGED_ENV_REFERENCE:
+                raise PreflightFailure(
+                    "HFS LLM Search configuration contains an unmanaged environment reference"
+                )
+
+    base_url = uniapi.get("base_url")
+    parsed = urlsplit(base_url.strip()) if isinstance(base_url, str) else None
+    if (
+        parsed is None
+        or parsed.scheme not in {"http", "https"}
+        or not parsed.hostname
+        or _EXACT_ENV_REFERENCE.fullmatch(base_url.strip()) is not None
+    ):
+        raise PreflightFailure("HFS LLM Search configuration requires a literal HTTP(S) base URL")
+    return decoded
+
+
+def load_preflight_config(encoded: str, api_key: str) -> SouWenConfig:
+    """Load the exact deployment YAML through the production config loader."""
+    decoded = _decode_and_validate_config(encoded)
+    if not api_key:
+        raise PreflightFailure("invalid HFS LLM Search configuration")
+
+    original_cwd = Path.cwd()
+    try:
+        with tempfile.TemporaryDirectory(prefix="souwen-hfs-llm-preflight-") as tmpdir:
+            config_path = Path(tmpdir) / "souwen.yaml"
+            config_path.write_text(decoded, encoding="utf-8")
+            config_path.chmod(0o600)
+            os.chdir(tmpdir)
+            with _isolated_environment(
+                {
+                    "HOME": tmpdir,
+                    "UNIAPI_API_KEY": api_key,
+                }
+            ):
+                get_config.cache_clear()
+                return reload_config()
+    except PreflightFailure:
+        raise
+    except Exception as exc:  # noqa: BLE001 - raw config errors must not escape to CI logs.
+        raise PreflightFailure("invalid HFS LLM Search configuration") from exc
+    finally:
+        os.chdir(original_cwd)
+        get_config.cache_clear()
+
+
+async def run_preflight(
+    config: SouWenConfig,
+    *,
+    runtime_factory: Callable[[SouWenConfig], Any] | None = None,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> PreflightReceipt:
+    """Execute one exact-provider production request without retry or model fallback."""
+    if not math.isfinite(timeout_seconds) or timeout_seconds <= 0:
+        raise PreflightFailure("HFS LLM Search preflight timeout must be positive")
+    selected = config.enabled_uniapi_ark_source_ids()
+    if len(selected) != 1:
+        raise PreflightFailure(
+            "HFS LLM Search preflight requires exactly one explicitly selected Provider"
+        )
+    provider_id = selected[0]
+    factory = runtime_factory or build_target_runtime
+    runtime = None
+    result = None
+    failure: BaseException | None = None
+    try:
+        runtime = factory(config)
+        result = await runtime.services.llm_search.search(
+            LLMSearchRequest(
+                query=_QUERY,
+                providers=(ProviderRef(id=provider_id, kind="llm_search"),),
+                strategy="single",
+                max_results_per_provider=1,
+            ),
+            RequestContext(request_id="hfs-llm-provider-preflight"),
+            ExecutionContext.with_timeout(timeout_seconds),
+        )
+    except asyncio.CancelledError:
+        failure = PreflightFailure(
+            f"selected LLM Search Provider {provider_id} failed: provider_unavailable"
+        )
+    except ProviderError as exc:
+        retry_after = ""
+        if exc.retry_after_seconds is not None:
+            retry_after = f", retry_after={exc.retry_after_seconds:g}"
+        failure = PreflightFailure(
+            f"selected LLM Search Provider {provider_id} failed: {exc.code.value}{retry_after}"
+        )
+    except Exception:  # noqa: BLE001 - never expose transport/config exception text.
+        failure = PreflightFailure(
+            f"selected LLM Search Provider {provider_id} failed: provider_unavailable"
+        )
+
+    if runtime is not None:
+        try:
+            await runtime.close()
+        except asyncio.CancelledError:
+            if failure is None:
+                failure = PreflightFailure("HFS LLM Search preflight runtime cleanup failed")
+        except Exception:  # noqa: BLE001 - cleanup errors must remain credential-safe.
+            if failure is None:
+                failure = PreflightFailure("HFS LLM Search preflight runtime cleanup failed")
+
+    if failure is not None:
+        raise failure
+    evidence = getattr(result, "evidence", ())
+    if not isinstance(evidence, (tuple, list)) or not evidence:
+        raise PreflightFailure(
+            f"selected LLM Search Provider {provider_id} failed: invalid_upstream_response"
+        )
+    return PreflightReceipt(provider_id=provider_id, evidence_count=len(evidence))
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Probe the one HFS-configured LLM Search Provider before any Space mutation."
+    )
+    parser.add_argument(
+        "--request-timeout",
+        type=float,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help="Single provider-call timeout in seconds (default: 60).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    encoded = os.environ.get("SOUWEN_CONFIG_B64", "")
+    api_key = os.environ.get("UNIAPI_API_KEY", "")
+    if not encoded or not api_key:
+        print("ERROR: HFS LLM Search preflight requires configured secrets", file=sys.stderr)
+        return 1
+    try:
+        config = load_preflight_config(encoded, api_key)
+        receipt = asyncio.run(
+            run_preflight(
+                config,
+                timeout_seconds=args.request_timeout,
+            )
+        )
+    except PreflightFailure as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    except Exception:  # noqa: BLE001 - never expose unexpected runtime/config exception text.
+        print("ERROR: HFS LLM Search preflight failed safely", file=sys.stderr)
+        return 1
+    print(
+        "HFS LLM Search preflight passed: "
+        f"provider={receipt.provider_id}, evidence={receipt.evidence_count}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hf_space_recovery_contract.py
+++ b/scripts/hf_space_recovery_contract.py
@@ -1,0 +1,237 @@
+"""Pure fail-closed contracts shared by the HFS recovery workflows and tests."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+import re
+from typing import Any
+
+
+RELEASE_WORKFLOW_PATH = ".github/workflows/release-candidate.yml"
+RECOVERY_WORKFLOW_PATH = ".github/workflows/recover-hf-space.yml"
+_LEGACY_RELEASE_RECEIPTS = {
+    "30545216223": {
+        "candidate_sha": "13d42552283146a8d18a6c9c64ba16124dc20908",
+        "paused_space_sha": "04f02981aa8d3b7fe16c3ace9a5787fa700d7b20",
+        "paused_source_sha": "13d42552283146a8d18a6c9c64ba16124dc20908",
+        "prior_space_sha": "95c479db55a31fe7b9dde93afc9183c8ec9c47c4",
+        "prior_source_sha": "8f65556df8593dee67662e95be3e29c6a2aec044",
+    }
+}
+
+
+class RecoveryContractError(RuntimeError):
+    """The supplied transaction evidence does not identify one recoverable state."""
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryTopology:
+    mode: str
+    sync_parent_sha: str
+
+
+def validate_recovery_topology(
+    *,
+    paused_space_sha: str,
+    paused_source_sha: str,
+    expected_paused_space_sha: str,
+    expected_paused_source_sha: str,
+    failed_candidate_sha: str,
+    prior_space_sha: str,
+    prior_source_sha: str,
+    direct_parent_sha: str | None,
+) -> RecoveryTopology:
+    """Accept only settings-only or one-direct-wrapper-advance paused states."""
+    if paused_space_sha != expected_paused_space_sha:
+        raise RecoveryContractError("paused recovery Space SHA mismatch")
+    if paused_source_sha != expected_paused_source_sha:
+        raise RecoveryContractError("paused recovery source pin mismatch")
+
+    if paused_space_sha == prior_space_sha:
+        if paused_source_sha != prior_source_sha:
+            raise RecoveryContractError(
+                "settings-only recovery must retain the exact prior source pin"
+            )
+        return RecoveryTopology(mode="settings-only", sync_parent_sha=paused_space_sha)
+
+    if paused_source_sha != failed_candidate_sha:
+        raise RecoveryContractError(
+            "wrapper-advanced recovery must pin the failed transaction candidate"
+        )
+    if direct_parent_sha != prior_space_sha:
+        raise RecoveryContractError(
+            "wrapper-advanced recovery must descend directly from the expected prior wrapper"
+        )
+    return RecoveryTopology(mode="wrapper-advanced", sync_parent_sha=paused_space_sha)
+
+
+def _unique_job_conclusion(
+    jobs: Sequence[Mapping[str, Any]],
+    suffix: str,
+    *,
+    required: bool = True,
+) -> str | None:
+    matches = [
+        job.get("conclusion")
+        for job in jobs
+        if isinstance(job.get("name"), str) and job["name"].endswith(suffix)
+    ]
+    if len(matches) != 1:
+        if not required and not matches:
+            return None
+        raise RecoveryContractError("failed transaction job inventory mismatch")
+    conclusion = matches[0]
+    return conclusion if isinstance(conclusion, str) else None
+
+
+def validate_source_run_provenance(
+    *,
+    run_id: str,
+    run: Mapping[str, Any],
+    jobs: Sequence[Mapping[str, Any]],
+    owner: str,
+    failed_candidate_sha: str,
+    paused_space_sha: str,
+    paused_source_sha: str,
+    prior_space_sha: str,
+    prior_source_sha: str,
+    intent: Mapping[str, Any] | None,
+) -> str:
+    """Validate a failed release or a validated, contained recovery retry receipt."""
+    expected = {
+        "status": "completed",
+        "conclusion": "failure",
+        "event": "workflow_dispatch",
+        "head_sha": failed_candidate_sha,
+        "run_attempt": 1,
+    }
+    if any(run.get(name) != value for name, value in expected.items()):
+        raise RecoveryContractError("failed transaction run provenance mismatch")
+    if any(
+        not isinstance(run.get(name), Mapping)
+        or str(run[name].get("login", "")).casefold() != owner.casefold()
+        for name in ("actor", "triggering_actor")
+    ):
+        raise RecoveryContractError("failed transaction actor provenance mismatch")
+
+    path = run.get("path")
+    containment = _unique_job_conclusion(jobs, "Pause Space after failed settings-aware promotion")
+    retry_containment = _unique_job_conclusion(
+        jobs,
+        "Retry containment when the first pause cannot be proven",
+    )
+    containment_proven = (containment == "success" and retry_containment == "skipped") or (
+        containment in {"failure", "cancelled"} and retry_containment == "success"
+    )
+    if not containment_proven:
+        raise RecoveryContractError("failed transaction containment mismatch")
+
+    if path == RELEASE_WORKFLOW_PATH:
+        publication = _unique_job_conclusion(jobs, "Publish GitHub Release")
+        if publication != "skipped":
+            raise RecoveryContractError("failed release publication state mismatch")
+        legacy = _LEGACY_RELEASE_RECEIPTS.get(run_id)
+        if legacy is not None:
+            supplied = {
+                "candidate_sha": failed_candidate_sha,
+                "paused_space_sha": paused_space_sha,
+                "paused_source_sha": paused_source_sha,
+                "prior_space_sha": prior_space_sha,
+                "prior_source_sha": prior_source_sha,
+            }
+            if supplied != legacy:
+                raise RecoveryContractError("legacy failed release receipt mismatch")
+            return "legacy-release"
+        _validate_machine_intent(
+            intent=intent,
+            run_id=run_id,
+            kind="release",
+            failed_candidate_sha=failed_candidate_sha,
+            paused_space_sha=paused_space_sha,
+            paused_source_sha=paused_source_sha,
+            prior_space_sha=prior_space_sha,
+            prior_source_sha=prior_source_sha,
+        )
+        return "release"
+
+    if path == RECOVERY_WORKFLOW_PATH:
+        validation = _unique_job_conclusion(jobs, "Validate paused recovery provenance")
+        verification = _unique_job_conclusion(jobs, "Verify recovery outputs")
+        publication = _unique_job_conclusion(
+            jobs,
+            "Publish GitHub Release",
+            required=False,
+        )
+        expected_title = re.compile(
+            rf"^Recover HFS parent={re.escape(prior_space_sha)} "
+            rf"source={re.escape(prior_source_sha)} from=[0-9]+$"
+        )
+        if (
+            validation != "success"
+            or verification != "skipped"
+            or publication is not None
+            or expected_title.fullmatch(str(run.get("display_title", ""))) is None
+        ):
+            raise RecoveryContractError("failed recovery transaction receipt mismatch")
+        _validate_machine_intent(
+            intent=intent,
+            run_id=run_id,
+            kind="recovery",
+            failed_candidate_sha=failed_candidate_sha,
+            paused_space_sha=paused_space_sha,
+            paused_source_sha=paused_source_sha,
+            prior_space_sha=prior_space_sha,
+            prior_source_sha=prior_source_sha,
+        )
+        return "recovery"
+
+    raise RecoveryContractError("unsupported recovery source workflow")
+
+
+def _validate_machine_intent(
+    *,
+    intent: Mapping[str, Any] | None,
+    run_id: str,
+    kind: str,
+    failed_candidate_sha: str,
+    paused_space_sha: str,
+    paused_source_sha: str,
+    prior_space_sha: str,
+    prior_source_sha: str,
+) -> None:
+    if intent is None:
+        raise RecoveryContractError("failed transaction machine intent is required")
+    expected = {
+        "schema": "souwen-hfs-transaction-intent-v1",
+        "run_id": run_id,
+        "run_attempt": 1,
+        "workflow_sha": failed_candidate_sha,
+        "candidate_sha": failed_candidate_sha,
+        "version": "2.0.0rc5",
+        "transaction_kind": kind,
+    }
+    if any(intent.get(name) != value for name, value in expected.items()):
+        raise RecoveryContractError("failed transaction machine intent mismatch")
+
+    if kind == "release":
+        if (
+            intent.get("prior_space_sha") != prior_space_sha
+            or intent.get("prior_source_sha") != prior_source_sha
+            or intent.get("sync_parent_sha") != prior_space_sha
+            or intent.get("recovery_from_run_id") != ""
+        ):
+            raise RecoveryContractError("failed release machine intent mismatch")
+    elif (
+        intent.get("expected_paused_space_sha") != prior_space_sha
+        or intent.get("expected_paused_source_sha") != prior_source_sha
+        or intent.get("sync_parent_sha") != prior_space_sha
+        or not str(intent.get("recovery_from_run_id", "")).isdigit()
+    ):
+        raise RecoveryContractError("failed recovery machine intent mismatch")
+
+    if paused_space_sha == prior_space_sha:
+        if paused_source_sha != prior_source_sha:
+            raise RecoveryContractError("settings-only machine intent mismatch")
+    elif paused_source_sha != failed_candidate_sha:
+        raise RecoveryContractError("wrapper-advanced machine intent mismatch")

--- a/tests/test_hf_space_llm_preflight.py
+++ b/tests/test_hf_space_llm_preflight.py
@@ -1,0 +1,252 @@
+"""Deterministic tests for the pre-mutation HFS LLM Search live gate."""
+
+from __future__ import annotations
+
+import base64
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+from scripts import hf_space_llm_preflight as preflight
+from souwen.platform.provider_spi import ProviderError, ProviderErrorCode
+
+
+DEEPSEEK_ID = "uniapi_ark_annotations_deepseek_v3_2_251201"
+DOUBAO_ID = "uniapi_ark_annotations_doubao_seed_2_0_lite_260428"
+
+
+def _encoded_config(
+    *,
+    deepseek: bool,
+    doubao: bool,
+    api_key: str = "${UNIAPI_API_KEY}",
+    base_url: str = "https://gateway.example.invalid/v1",
+) -> str:
+    payload = {
+        "llm_search_gateways": {
+            "uniapi": {
+                "api_key": api_key,
+                "base_url": base_url,
+            }
+        },
+        "sources": {
+            DEEPSEEK_ID: {"enabled": deepseek},
+            DOUBAO_ID: {"enabled": doubao},
+        },
+    }
+    return base64.b64encode(yaml.safe_dump(payload).encode()).decode()
+
+
+def test_load_preflight_config_resolves_exact_gateway_references_without_env_leak(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("UNIAPI_API_KEY", raising=False)
+    monkeypatch.setenv("ACTIONS_RUNTIME_TOKEN", "runner-token-canary")
+    monkeypatch.setenv(
+        "SOUWEN_LLM_SEARCH_GATEWAYS",
+        '{"uniapi":{"api_key":"runner-override","base_url":"https://override.invalid"}}',
+    )
+
+    config = preflight.load_preflight_config(
+        _encoded_config(deepseek=False, doubao=True),
+        "secret-canary",
+    )
+
+    assert config.enabled_uniapi_ark_source_ids() == (DOUBAO_ID,)
+    gateway = config.get_llm_search_gateway("uniapi")
+    assert gateway.api_key == "secret-canary"
+    assert gateway.base_url == "https://gateway.example.invalid/v1"
+    assert "UNIAPI_API_KEY" not in preflight.os.environ
+    assert preflight.os.environ["ACTIONS_RUNTIME_TOKEN"] == "runner-token-canary"
+    assert "runner-override" not in repr(gateway)
+
+    with pytest.raises(preflight.PreflightFailure, match="configuration"):
+        preflight.load_preflight_config(
+            _encoded_config(deepseek=True, doubao=True),
+            "secret-canary",
+        )
+
+
+@pytest.mark.parametrize(
+    ("api_key", "base_url"),
+    [
+        ("${ACTIONS_RUNTIME_TOKEN}", "https://gateway.example.invalid/v1"),
+        ("${HOME}", "https://gateway.example.invalid/v1"),
+        ("${UNIAPI_API_KEY}", "${ACTIONS_RUNTIME_URL}"),
+    ],
+)
+def test_load_preflight_config_rejects_unmanaged_runner_environment_references(
+    monkeypatch: pytest.MonkeyPatch,
+    api_key: str,
+    base_url: str,
+) -> None:
+    monkeypatch.setenv("ACTIONS_RUNTIME_TOKEN", "runner-token-canary")
+    monkeypatch.setenv("ACTIONS_RUNTIME_URL", "https://runner-canary.invalid")
+
+    with pytest.raises(preflight.PreflightFailure) as exc_info:
+        preflight.load_preflight_config(
+            _encoded_config(
+                deepseek=False,
+                doubao=True,
+                api_key=api_key,
+                base_url=base_url,
+            ),
+            "managed-api-key",
+        )
+
+    assert "runner-token-canary" not in str(exc_info.value)
+    assert "runner-canary" not in str(exc_info.value)
+
+
+class _Service:
+    def __init__(self, *, error: ProviderError | None = None) -> None:
+        self.error = error
+        self.calls = []
+
+    async def search(self, request, context, execution):
+        self.calls.append((request, context, execution))
+        if self.error is not None:
+            raise self.error
+        return SimpleNamespace(evidence=(object(),))
+
+
+class _CancelledService(_Service):
+    async def search(self, request, context, execution):
+        self.calls.append((request, context, execution))
+        raise preflight.asyncio.CancelledError
+
+
+class _Runtime:
+    def __init__(self, service: _Service) -> None:
+        self.services = SimpleNamespace(llm_search=service)
+        self.close_count = 0
+
+    async def close(self) -> None:
+        self.close_count += 1
+
+
+class _Config:
+    def __init__(self, selected: tuple[str, ...]) -> None:
+        self.selected = selected
+
+    def enabled_uniapi_ark_source_ids(self) -> tuple[str, ...]:
+        return self.selected
+
+
+@pytest.mark.asyncio
+async def test_preflight_uses_only_explicit_provider_and_closes_runtime() -> None:
+    service = _Service()
+    runtime = _Runtime(service)
+
+    receipt = await preflight.run_preflight(
+        _Config((DOUBAO_ID,)),
+        runtime_factory=lambda _config: runtime,
+        timeout_seconds=7,
+    )
+
+    assert receipt.provider_id == DOUBAO_ID
+    assert receipt.evidence_count == 1
+    assert runtime.close_count == 1
+    assert len(service.calls) == 1
+    request, context, execution = service.calls[0]
+    assert request.query == "What is retrieval augmented generation?"
+    assert [(provider.id, provider.kind) for provider in request.providers] == [
+        (DOUBAO_ID, "llm_search")
+    ]
+    assert request.strategy == "single"
+    assert request.max_results_per_provider == 1
+    assert context.request_id == "hfs-llm-provider-preflight"
+    assert 0 < execution.remaining_seconds <= 7
+
+
+@pytest.mark.asyncio
+async def test_preflight_rate_limit_is_safe_single_attempt_without_model_fallback() -> None:
+    service = _Service(
+        error=ProviderError(
+            ProviderErrorCode.RATE_LIMITED,
+            provider_id=DEEPSEEK_ID,
+            retry_after_seconds=1,
+        )
+    )
+    runtime = _Runtime(service)
+
+    with pytest.raises(preflight.PreflightFailure) as exc_info:
+        await preflight.run_preflight(
+            _Config((DEEPSEEK_ID,)),
+            runtime_factory=lambda _config: runtime,
+            timeout_seconds=5,
+        )
+
+    detail = str(exc_info.value)
+    assert len(service.calls) == 1
+    assert service.calls[0][0].providers[0].id == DEEPSEEK_ID
+    assert DOUBAO_ID not in detail
+    assert DEEPSEEK_ID in detail
+    assert "rate_limited" in detail
+    assert "retry_after=1" in detail
+    assert runtime.close_count == 1
+
+
+@pytest.mark.asyncio
+async def test_preflight_sanitizes_provider_cancellation_and_closes_runtime() -> None:
+    service = _CancelledService()
+    runtime = _Runtime(service)
+
+    with pytest.raises(preflight.PreflightFailure, match="provider_unavailable"):
+        await preflight.run_preflight(
+            _Config((DOUBAO_ID,)),
+            runtime_factory=lambda _config: runtime,
+        )
+
+    assert len(service.calls) == 1
+    assert runtime.close_count == 1
+
+
+@pytest.mark.asyncio
+async def test_preflight_rejects_zero_or_multiple_selected_providers_before_runtime() -> None:
+    calls = 0
+
+    def factory(_config):
+        nonlocal calls
+        calls += 1
+        raise AssertionError("runtime must not be built")
+
+    for selected in ((), (DEEPSEEK_ID, DOUBAO_ID)):
+        with pytest.raises(preflight.PreflightFailure, match="exactly one"):
+            await preflight.run_preflight(_Config(selected), runtime_factory=factory)
+    assert calls == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error", [ValueError("secret-canary"), RuntimeError("secret-canary")])
+async def test_preflight_sanitizes_runtime_assembly_failures(error: Exception) -> None:
+    def factory(_config):
+        raise error
+
+    with pytest.raises(preflight.PreflightFailure) as exc_info:
+        await preflight.run_preflight(
+            _Config((DOUBAO_ID,)),
+            runtime_factory=factory,
+        )
+
+    assert "secret-canary" not in str(exc_info.value)
+    assert "provider_unavailable" in str(exc_info.value)
+
+
+def test_main_sanitizes_unexpected_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    async def unexpected_failure(*_args, **_kwargs):
+        raise RuntimeError("cli-secret-canary")
+
+    monkeypatch.setenv("SOUWEN_CONFIG_B64", "encoded")
+    monkeypatch.setenv("UNIAPI_API_KEY", "api-key")
+    monkeypatch.setattr(preflight, "load_preflight_config", lambda *_args: _Config((DOUBAO_ID,)))
+    monkeypatch.setattr(preflight, "run_preflight", unexpected_failure)
+
+    assert preflight.main([]) == 1
+    captured = capsys.readouterr()
+    assert "cli-secret-canary" not in captured.err
+    assert "failed safely" in captured.err

--- a/tests/test_hf_space_recovery_contract.py
+++ b/tests/test_hf_space_recovery_contract.py
@@ -1,0 +1,253 @@
+"""Deterministic transition tests for Action-only HFS paused recovery."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.hf_space_recovery_contract import (
+    RECOVERY_WORKFLOW_PATH,
+    RELEASE_WORKFLOW_PATH,
+    RecoveryContractError,
+    validate_recovery_topology,
+    validate_source_run_provenance,
+)
+
+
+FAILED = "1" * 40
+PAUSED = "2" * 40
+PRIOR = "3" * 40
+PRIOR_SOURCE = "4" * 40
+
+
+def test_recovery_topology_accepts_settings_only_pause_before_wrapper_sync() -> None:
+    topology = validate_recovery_topology(
+        paused_space_sha=PRIOR,
+        paused_source_sha=PRIOR_SOURCE,
+        expected_paused_space_sha=PRIOR,
+        expected_paused_source_sha=PRIOR_SOURCE,
+        failed_candidate_sha=FAILED,
+        prior_space_sha=PRIOR,
+        prior_source_sha=PRIOR_SOURCE,
+        direct_parent_sha=None,
+    )
+
+    assert topology.mode == "settings-only"
+    assert topology.sync_parent_sha == PRIOR
+
+
+def test_recovery_topology_accepts_one_direct_wrapper_advance_and_retry() -> None:
+    topology = validate_recovery_topology(
+        paused_space_sha=PAUSED,
+        paused_source_sha=FAILED,
+        expected_paused_space_sha=PAUSED,
+        expected_paused_source_sha=FAILED,
+        failed_candidate_sha=FAILED,
+        prior_space_sha=PRIOR,
+        prior_source_sha=PRIOR_SOURCE,
+        direct_parent_sha=PRIOR,
+    )
+
+    assert topology.mode == "wrapper-advanced"
+    assert topology.sync_parent_sha == PAUSED
+
+
+@pytest.mark.parametrize(
+    ("changes", "message"),
+    [
+        (
+            {
+                "paused_source_sha": PRIOR_SOURCE,
+                "expected_paused_source_sha": PRIOR_SOURCE,
+            },
+            "failed transaction candidate",
+        ),
+        ({"direct_parent_sha": "5" * 40}, "descend directly"),
+        ({"expected_paused_source_sha": "6" * 40}, "source pin mismatch"),
+    ],
+)
+def test_recovery_topology_rejects_ambiguous_or_unbound_wrapper_state(
+    changes: dict[str, str], message: str
+) -> None:
+    values = {
+        "paused_space_sha": PAUSED,
+        "paused_source_sha": FAILED,
+        "expected_paused_space_sha": PAUSED,
+        "expected_paused_source_sha": FAILED,
+        "failed_candidate_sha": FAILED,
+        "prior_space_sha": PRIOR,
+        "prior_source_sha": PRIOR_SOURCE,
+        "direct_parent_sha": PRIOR,
+    }
+    values.update(changes)
+
+    with pytest.raises(RecoveryContractError, match=message):
+        validate_recovery_topology(**values)
+
+
+def _run(path: str, *, display_title: str = "", head_sha: str = FAILED) -> dict:
+    return {
+        "status": "completed",
+        "conclusion": "failure",
+        "event": "workflow_dispatch",
+        "path": path,
+        "head_sha": head_sha,
+        "run_attempt": 1,
+        "actor": {"login": "BlueSkyXN"},
+        "triggering_actor": {"login": "BlueSkyXN"},
+        "display_title": display_title,
+    }
+
+
+def _job(name: str, conclusion: str) -> dict[str, str]:
+    return {"name": name, "conclusion": conclusion}
+
+
+def _containment_jobs(*, primary: str = "success", retry: str = "skipped") -> list[dict[str, str]]:
+    return [
+        _job("Pause Space after failed settings-aware promotion", primary),
+        _job("Retry containment when the first pause cannot be proven", retry),
+    ]
+
+
+def _intent(kind: str, run_id: str) -> dict:
+    return {
+        "schema": "souwen-hfs-transaction-intent-v1",
+        "run_id": run_id,
+        "run_attempt": 1,
+        "workflow_sha": FAILED,
+        "candidate_sha": FAILED,
+        "version": "2.0.0rc5",
+        "transaction_kind": kind,
+        "recovery_from_run_id": "123" if kind == "recovery" else "",
+        "expected_paused_space_sha": PRIOR if kind == "recovery" else "",
+        "expected_paused_source_sha": PRIOR_SOURCE if kind == "recovery" else "",
+        "prior_space_sha": PRIOR,
+        "prior_source_sha": PRIOR_SOURCE,
+        "sync_parent_sha": PRIOR,
+    }
+
+
+def test_release_failure_is_a_valid_contained_recovery_source() -> None:
+    run_id = "40000000000"
+    kind = validate_source_run_provenance(
+        run_id=run_id,
+        run=_run(RELEASE_WORKFLOW_PATH),
+        jobs=[*_containment_jobs(), _job("Publish GitHub Release", "skipped")],
+        owner="BlueSkyXN",
+        failed_candidate_sha=FAILED,
+        paused_space_sha=PAUSED,
+        paused_source_sha=FAILED,
+        prior_space_sha=PRIOR,
+        prior_source_sha=PRIOR_SOURCE,
+        intent=_intent("release", run_id),
+    )
+
+    assert kind == "release"
+
+
+def test_failed_recovery_receipt_is_a_valid_retry_source() -> None:
+    run_id = "40000000001"
+    title = f"Recover HFS parent={PRIOR} source={PRIOR_SOURCE} from=123456"
+    kind = validate_source_run_provenance(
+        run_id=run_id,
+        run=_run(RECOVERY_WORKFLOW_PATH, display_title=title),
+        jobs=[
+            _job("Validate paused recovery provenance", "success"),
+            *_containment_jobs(),
+            _job("Verify recovery outputs", "skipped"),
+        ],
+        owner="blueskyxn",
+        failed_candidate_sha=FAILED,
+        paused_space_sha=PAUSED,
+        paused_source_sha=FAILED,
+        prior_space_sha=PRIOR,
+        prior_source_sha=PRIOR_SOURCE,
+        intent=_intent("recovery", run_id),
+    )
+
+    assert kind == "recovery"
+
+
+def test_retry_containment_is_an_equivalent_action_verified_pause() -> None:
+    run_id = "40000000002"
+    kind = validate_source_run_provenance(
+        run_id=run_id,
+        run=_run(RELEASE_WORKFLOW_PATH),
+        jobs=[
+            *_containment_jobs(primary="failure", retry="success"),
+            _job("Publish GitHub Release", "skipped"),
+        ],
+        owner="BlueSkyXN",
+        failed_candidate_sha=FAILED,
+        paused_space_sha=PAUSED,
+        paused_source_sha=FAILED,
+        prior_space_sha=PRIOR,
+        prior_source_sha=PRIOR_SOURCE,
+        intent=_intent("release", run_id),
+    )
+
+    assert kind == "release"
+
+
+def test_known_rc5_failure_uses_one_exact_legacy_receipt() -> None:
+    candidate = "13d42552283146a8d18a6c9c64ba16124dc20908"
+    kind = validate_source_run_provenance(
+        run_id="30545216223",
+        run=_run(RELEASE_WORKFLOW_PATH, head_sha=candidate),
+        jobs=[*_containment_jobs(), _job("Publish GitHub Release", "skipped")],
+        owner="BlueSkyXN",
+        failed_candidate_sha=candidate,
+        paused_space_sha="04f02981aa8d3b7fe16c3ace9a5787fa700d7b20",
+        paused_source_sha=candidate,
+        prior_space_sha="95c479db55a31fe7b9dde93afc9183c8ec9c47c4",
+        prior_source_sha="8f65556df8593dee67662e95be3e29c6a2aec044",
+        intent=None,
+    )
+
+    assert kind == "legacy-release"
+
+
+def test_source_run_rerun_attempt_is_rejected() -> None:
+    run = _run(RELEASE_WORKFLOW_PATH)
+    run["run_attempt"] = 2
+
+    with pytest.raises(RecoveryContractError, match="run provenance"):
+        validate_source_run_provenance(
+            run_id="40000000004",
+            run=run,
+            jobs=[*_containment_jobs(), _job("Publish GitHub Release", "skipped")],
+            owner="BlueSkyXN",
+            failed_candidate_sha=FAILED,
+            paused_space_sha=PAUSED,
+            paused_source_sha=FAILED,
+            prior_space_sha=PRIOR,
+            prior_source_sha=PRIOR_SOURCE,
+            intent=_intent("release", "40000000004"),
+        )
+
+
+@pytest.mark.parametrize(
+    ("path", "title"),
+    [
+        (RECOVERY_WORKFLOW_PATH, "Recover HFS parent=wrong source=wrong from=1"),
+        (".github/workflows/other.yml", ""),
+    ],
+)
+def test_recovery_source_rejects_unbound_or_unsupported_transaction(path: str, title: str) -> None:
+    with pytest.raises(RecoveryContractError):
+        validate_source_run_provenance(
+            run_id="40000000003",
+            run=_run(path, display_title=title),
+            jobs=[
+                _job("Validate paused recovery provenance", "success"),
+                *_containment_jobs(),
+                _job("Verify recovery outputs", "skipped"),
+            ],
+            owner="BlueSkyXN",
+            failed_candidate_sha=FAILED,
+            paused_space_sha=PAUSED,
+            paused_source_sha=FAILED,
+            prior_space_sha=PRIOR,
+            prior_source_sha=PRIOR_SOURCE,
+            intent=_intent("recovery", "40000000003"),
+        )

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -738,6 +738,7 @@ def test_hfs_deployment_does_not_keep_a_retired_cli_binary_smoke() -> None:
 def test_hfs_required_fetch_fixture_change_triggers_workflow() -> None:
     text = _workflow("deploy-hf-space.yml")
 
+    assert '- "scripts/hf_space_llm_preflight.py"' in text
     assert '- "scripts/hf_space_smoke.py"' in text
     assert '- "scripts/fixtures/hf-space-fetch-probe.html"' in text
     assert '- "scripts/fixtures/hf-space-browser-probe.html"' in text
@@ -764,13 +765,16 @@ def test_hfs_m1_requires_target_supervisor_and_internal_worker_evidence() -> Non
     )
 
 
-def test_only_hfs_reusable_call_inherits_secrets() -> None:
+def test_only_release_and_paused_recovery_hfs_calls_inherit_secrets() -> None:
     inherited = {
         path.name: path.read_text(encoding="utf-8").count("secrets: inherit")
         for path in WORKFLOW_DIR.glob("*.yml")
         if "secrets: inherit" in path.read_text(encoding="utf-8")
     }
-    assert inherited == {"release-candidate.yml": 1}
+    assert inherited == {
+        "recover-hf-space.yml": 1,
+        "release-candidate.yml": 1,
+    }
 
 
 def test_release_candidate_aggregates_all_release_gates() -> None:
@@ -1109,6 +1113,19 @@ def test_hfs_reusable_promotion_is_candidate_pinned_and_live_verified() -> None:
     assert "unauth_status" in text
     assert "github.event_name == 'workflow_call'" not in text
     assert "if: ${{ inputs.deploy_hfs }}" in text
+    assert "HF promotion requires repository-owner dispatch" in contract_step
+    assert "HF promotion candidate must equal current GitHub main" in contract_step
+    assert "verifier_sha and workflow SHA must equal current GitHub main" in contract_step
+    assert "reusable HF Space CD reruns are not allowed" in contract_step
+    assert "https://api.github.com/repos/{os.environ['REPOSITORY']}/git/ref/heads/main" in (
+        contract_step
+    )
+    delivery = _job(text, "delivery-contracts", "docker-hfs")
+    docker = _job(text, "docker-hfs", "sync-hfs-wrapper")
+    assert "needs: detect-changes" in delivery
+    assert "needs: detect-changes" in docker
+    assert "persist-credentials: false" in delivery
+    assert "persist-credentials: false" in docker
     assert 'write_output(True, "release-candidate")' in text
     assert "inputs.deploy_hfs && 'promotion'" in text
     assert "cancel-in-progress: ${{ !inputs.deploy_hfs }}" in text
@@ -1142,7 +1159,10 @@ def test_hfs_reusable_promotion_is_candidate_pinned_and_live_verified() -> None:
     assert "${!name}" in secret_gate
     assert "name: Validate required HFS LLM Search configuration" in text
     assert "HFS promotion requires exactly one enabled LLM Search Provider" in text
-    assert 'env_reference = re.compile(r"^\\$\\{[A-Z_][A-Z0-9_]*\\}$")' in text
+    assert 'env_reference = re.compile(r"^\\$\\{([A-Z_][A-Z0-9_]*)\\}$")' in text
+    assert "HFS UniAPI API key uses an unmanaged environment reference" in text
+    assert "HFS UniAPI base URL must not use an environment reference" in text
+    assert '      - ".github/workflows/recover-hf-space.yml"' in text
 
     settings_preflight = text.split("- name: Preflight managed HFS Space Secret names", maxsplit=1)[
         1
@@ -1196,11 +1216,36 @@ def test_hfs_settings_preflight_finishes_before_the_containment_marker_and_first
     text = _workflow("deploy-hf-space.yml")
     sync = _job(text, "sync-hfs-wrapper", "rebuild-space")
 
+    provider_preflight = sync.index(
+        "- name: Probe selected HFS LLM Search Provider before mutation"
+    )
+    release_absence = sync.index("- name: Recheck absent recovery tag and Release before mutation")
+    write_intent = sync.index("- name: Write immutable HFS transaction intent")
+    upload_intent = sync.index("- name: Upload immutable HFS transaction intent before mutation")
     preflight = sync.index("- name: Preflight managed HFS Space Secret names")
     marker = sync.index("- name: Mark settings mutation phase")
     first_write = sync.index("api.add_space_secret(")
 
-    assert preflight < marker < first_write
+    assert (
+        preflight
+        < provider_preflight
+        < release_absence
+        < write_intent
+        < upload_intent
+        < marker
+        < first_write
+    )
+    provider_block = sync[provider_preflight:marker]
+    assert "SOUWEN_CONFIG_B64: ${{ secrets.SOUWEN_CONFIG_B64 }}" in provider_block
+    assert "UNIAPI_API_KEY: ${{ secrets.UNIAPI_API_KEY }}" in provider_block
+    assert "python scripts/hf_space_llm_preflight.py" in provider_block
+    assert "paused recovery requires absent" in provider_block
+    assert '"schema": "souwen-hfs-transaction-intent-v1"' in provider_block
+    assert (
+        "hfs-transaction-intent-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
+        in provider_block
+    )
+    assert "|| true" not in provider_block
     assert "id: settings_mutation" in sync[marker:first_write]
     assert "settings_mutation_started=true" in sync[marker:first_write]
     assert (
@@ -1217,6 +1262,124 @@ def test_hfs_containment_requires_a_completed_settings_mutation_marker() -> None
     assert "needs.sync-hfs-wrapper.result != 'success'" in containment
     assert "needs.rebuild-space.result != 'success'" in containment
     assert "needs.post-deploy-smoke.result != 'success'" in containment
+
+
+def test_hfs_paused_recovery_is_owner_exact_state_and_action_driven() -> None:
+    recovery = _workflow("recover-hf-space.yml")
+    deploy = _workflow("deploy-hf-space.yml")
+
+    assert "workflow_dispatch:" in recovery
+    for input_name in (
+        "candidate_sha",
+        "version",
+        "recovery_from_run_id",
+        "expected_paused_space_sha",
+        "expected_paused_source_sha",
+        "expected_failed_candidate_sha",
+        "expected_prior_space_sha",
+        "expected_prior_source_sha",
+    ):
+        assert f"      {input_name}:" in recovery
+    assert "actions: read" in recovery
+    assert "contents: read" in recovery
+    assert "DISPATCH_ACTOR: ${{ github.actor }}" in recovery
+    assert "TRIGGERING_ACTOR: ${{ github.triggering_actor }}" in recovery
+    assert "REPOSITORY_OWNER: ${{ github.repository_owner }}" in recovery
+    assert "paused recovery requires repository-owner dispatch" in recovery
+    assert "paused recovery workflow reruns are not allowed" in recovery
+    assert "recovery candidate must equal the current origin/main" in recovery
+    assert "failed release run job inventory exceeds the recovery verifier" in recovery
+    assert "validate_source_run_provenance" in recovery
+    assert "load_transaction_intent" in recovery
+    assert 'artifact_name = f"hfs-transaction-intent-{run_id}-attempt-1"' in recovery
+    assert "build_opener(NoRedirect())" in recovery
+    assert "urlopen(Request(download_url)" in recovery
+    assert "source_kind=" in recovery
+    assert "uses: ./.github/workflows/deploy-hf-space.yml" in recovery
+    assert "secrets: inherit" in recovery
+    assert "publish:" not in recovery
+    for forbidden in (
+        "contents: write",
+        "actions: write",
+        "id-token: write",
+        "git tag",
+        "gh release",
+    ):
+        assert forbidden not in recovery
+
+    workflow_call = deploy.split("  workflow_call:", maxsplit=1)[1].split(
+        "  pull_request:", maxsplit=1
+    )[0]
+    for input_name in (
+        "recovery_from_run_id",
+        "expected_paused_space_sha",
+        "expected_paused_source_sha",
+        "expected_failed_candidate_sha",
+        "expected_prior_space_sha",
+        "expected_prior_source_sha",
+    ):
+        assert f"      {input_name}:" in workflow_call
+
+    sync = _job(deploy, "sync-hfs-wrapper", "rebuild-space")
+    assert "recovery inputs must be either all empty or all populated" in sync
+    assert "paused recovery requires the target Space to remain PAUSED" in sync
+    assert "paused recovery prior source pin mismatch" in sync
+    assert "validate_recovery_topology" in sync
+    assert "api.list_repo_commits(" in sync
+    assert "sync_parent_sha" in sync
+    assert 'rollback_runtime_sha = ""' in sync
+    assert 'rollback_stage = ""' in sync
+    assert "RECOVERY_FROM_PAUSED_" not in sync
+
+    rebuild = _job(deploy, "rebuild-space", "post-deploy-smoke")
+    factory_restart = (
+        "api.restart_space(\n              repo_id=space_id,\n              factory_reboot=True,"
+    )
+    assert "api.restart_space(repo_id=space_id)" not in rebuild
+    assert factory_restart in rebuild
+    assert rebuild.count("api.restart_space(") == 1
+    assert rebuild.count("time.monotonic() + 900") == 1
+    assert "paused recovery must start from PAUSED" in rebuild
+    assert "timeout-minutes: 25" in rebuild
+
+    release = _workflow("release-candidate.yml")
+    assert "release candidate workflow reruns are not allowed" in release
+    assert "'souwen-release-hfs-transaction'" in release
+    assert "release-candidate-evidence-{0}" in release
+    assert "group: souwen-release-hfs-transaction" in recovery
+    assert "cancel-in-progress: false" in release
+    assert "cancel-in-progress: false" in recovery
+
+    validate_block = _job(recovery, "validate", "recover")
+    owner_gate = validate_block.index("paused recovery requires repository-owner dispatch")
+    current_main_gate = validate_block.index(
+        "recovery candidate must equal the current origin/main"
+    )
+    helper_import = validate_block.index("from scripts.hf_space_recovery_contract import")
+    source_run_api = validate_block.index(
+        'run = api_json(f"/repos/{repository}/actions/runs/{run_id}")'
+    )
+    assert owner_gate < current_main_gate < helper_import < source_run_api
+
+    receipt = deploy.split("  transaction-receipt:", maxsplit=1)[1]
+    assert (
+        "needs: [sync-hfs-wrapper, rebuild-space, post-deploy-smoke, contain-space, pause-space]"
+    ) in receipt
+    assert "if: ${{ always() && inputs.deploy_hfs }}" in receipt
+    assert '"schema": "souwen-hfs-transaction-outcome-v1"' in receipt
+    assert '"settings_mutation_started"' in receipt
+    assert (
+        "hfs-transaction-outcome-${{ github.run_id }}-attempt-${{ github.run_attempt }}" in receipt
+    )
+    assert "actions/upload-artifact@v7" in receipt
+
+
+def test_hfs_sync_budget_covers_stable_snapshot_install_and_live_preflight() -> None:
+    sync = _job(_workflow("deploy-hf-space.yml"), "sync-hfs-wrapper", "rebuild-space")
+
+    assert "timeout-minutes: 30" in sync
+    assert "time.monotonic() + 900" in sync
+    assert "--request-timeout 60" in sync
 
 
 def test_hfs_rebuild_job_avoids_checkout_and_dependency_cache() -> None:

--- a/tests/test_uniapi_ark_provider_v2.py
+++ b/tests/test_uniapi_ark_provider_v2.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import pytest
 
+from souwen.common_runtime.transport.errors import RateLimitError
 from souwen.platform.provider_spi import (
     ExecutionContext,
     LLMSearchRequest,
@@ -65,6 +66,20 @@ class _Transport:
 class _BlockingTransport(_Transport):
     async def post(self, *args, **kwargs):
         await asyncio.Event().wait()
+
+
+class _RateLimitedTransport(_Transport):
+    async def post(self, url, json=None, data=None, headers=None, retry_policy="default"):
+        self.calls.append(
+            {
+                "url": url,
+                "json": json,
+                "data": data,
+                "headers": headers,
+                "retry_policy": retry_policy,
+            }
+        )
+        raise RateLimitError("private upstream detail", retry_after=1)
 
 
 def _payload(
@@ -241,6 +256,32 @@ async def test_v1_gateway_base_url_does_not_duplicate_the_version_path() -> None
     )
 
     assert transport.calls[0]["url"] == "responses"
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_is_safe_and_single_attempt_for_operator_control() -> None:
+    transport = _RateLimitedTransport({})
+    provider = UniApiArkAnnotationsDeepSeekProvider(
+        {"enabled": True},
+        {
+            "UNIAPI_API_KEY": "fixture-secret",
+            "UNIAPI_BASE_URL": "https://gateway.example.test/v1",
+        },
+        transport=transport,
+    )
+
+    with pytest.raises(ProviderError) as exc_info:
+        await provider.search(
+            _request(DEEPSEEK_ADAPTER_ID, max_results=1),
+            RequestContext(request_id="provider-v2-rate-limit"),
+            ExecutionContext.with_timeout(5),
+        )
+
+    assert exc_info.value.code is ProviderErrorCode.RATE_LIMITED
+    assert exc_info.value.retry_after_seconds == 1
+    assert "private upstream detail" not in str(exc_info.value)
+    assert len(transport.calls) == 1
+    assert transport.calls[0]["retry_policy"] == "single_attempt"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 结果与边界

在任何 HF Space settings mutation 之前，对配置中唯一显式启用的 LLM Search Provider 执行 single-attempt live gate；为已经 containment 的 `PAUSED` transaction 增加 owner-only、Action-only 的前向恢复入口。

本 PR 只提交代码、测试、文档与 GitHub Actions contract；**尚未执行真实 HFS recovery、Secret 更新、tag 或 Release 发布**。远端恢复与正式 `v2.0.0rc5` 发布必须在本 PR exact-head checks 全绿并合并后，由两个独立的新 Actions run 完成。

## 问题

上一轮 RC5 发布的本地/构建/资产门禁通过，但 selected DeepSeek Provider live smoke 返回上游 RPM 429。直接在运行时隐藏切换到另一个模型会破坏 operator control；同时，Space Secret write-only 使 mutation 后失败不能安全自动回滚到“旧代码 + 旧 settings”。

原恢复设计的审查还发现：runner environment 越权解析、runtime assembly 异常泄露、settings-only paused 拓扑缺失、recovery retry 不闭包、双 restart timeout、release/recovery publish 竞态，以及 candidate helper 在 trust gate 前导入等问题。

## 主要变更

- 新增 `scripts/hf_space_llm_preflight.py`：隔离 runner environment，只允许受管 credential reference；使用 production runtime assembly 对 exact selected Provider 发起一次请求，不 retry、不换模型，错误输出脱敏。
- 新增 `recover-hf-space.yml`：要求 attempt 1、repository owner、current `main`、RC5 version、目标 tag/Release absent，并验证 failed release/recovery provenance。
- 在 mutation marker 前上传 immutable transaction intent；结合 primary/retry containment jobs 与 live paused topology，覆盖 `settings-only`、direct-parent `wrapper-advanced` 和 failed recovery retry。历史失败 run 仅接受一次性 exact legacy contract。
- Recovery 直接执行一次 `factory_reboot=True` 并等待 exact repo/runtime SHA；任一步失败继续自动 pause。
- 外部 deploy/publish run 与 recovery 共享完整 caller transaction concurrency；纯 evidence run 保留 per-candidate group。
- Reusable HFS workflow 独立验证 attempt、owner、GitHub current `main`、candidate/verifier/workflow SHA；所有 candidate execution job 都在该 gate 下游且 checkout 不持久化凭据。
- 增加 deterministic transition、trust ordering、rate-limit/single-attempt、credential-canary 和 workflow contract 测试，并同步发布/HFS 文档。

## 兼容性与非目标

- 不更改 OpenAPI、SDK、公共 API、Provider catalog 或 package version。
- 不引入 DeepSeek→Doubao runtime fallback；Provider 选择仍由受管配置显式决定。
- Recovery 没有 `contents: write`、tag、Release 或 attestation 权限；成功恢复 runtime 也不能替代正式 central release run。
- 不修改 branch protection、ruleset、tag signing、Release immutable policy，也不发布 PyPI。

## 验证

- `python3 -m pytest tests/ -q --tb=short`：`2799 passed, 2 skipped`（另有 2 个既有 websockets deprecation warnings）
- 定向 recovery/preflight/workflow/provider suite：`72 passed`
- `python3 -m ruff check src tests scripts`：PASS
- `python3 -m ruff format --check src tests scripts`：`913 files already formatted`
- `actionlint`（3 个变更 workflow）：PASS
- `sdk-contract`、`server-contract`、`provider-runtime`：PASS
- generated docs、Markdown links、legacy-term gate：PASS（legacy gate 仅有既有 allow-listed review warnings）
- Python 3.10 AST parse：4/4 新 Python 文件通过
- `git diff --check`：PASS
- staged diff `gitleaks`：no leaks found
- 只读 live contract：已知 failed run、primary containment、publish skipped、当前 paused wrapper/direct parent/source pins、RC5 tag/Release absent 均与一次性 legacy contract 匹配

## Review focus

1. Recovery helper import 是否始终位于 owner/current-main/version trust gates 之后。
2. Mutation marker 前 intent artifact、双 containment 路径和两种 paused topology 是否保持 fail-closed。
3. Shared concurrency 是否完整覆盖外部 HFS evidence、assemble 与 publish，同时不阻塞纯 evidence build。
4. Preflight 是否保持 exact Provider、single attempt、最小环境与 credential-safe error surface。
