### PR TITLE
fix(release): 在 factory rebuild 前显式解除 HFS pause

### DIFF
--- a/.github/workflows/deploy-hf-space.yml
+++ b/.github/workflows/deploy-hf-space.yml
@@ -1089,15 +1089,18 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_SPACE_ID: BlueSkyXN/SouWen
+          EXPECTED_SPACE_SHA: ${{ needs.sync-hfs-wrapper.outputs.space_commit_sha }}
           RECOVERY_FROM_RUN_ID: ${{ inputs.recovery_from_run_id }}
         run: |
           python -I - <<'PY'
           import os
+          import time
 
           from huggingface_hub import HfApi
 
           api = HfApi(token=os.environ["HF_TOKEN"])
           space_id = os.environ["HF_SPACE_ID"]
+          expected_sha = os.environ["EXPECTED_SPACE_SHA"]
           recovery = bool(os.environ.get("RECOVERY_FROM_RUN_ID"))
           if recovery:
               current = api.get_space_runtime(repo_id=space_id)
@@ -1106,6 +1109,28 @@ jobs:
                   raise SystemExit(
                       f"paused recovery must start from PAUSED; current stage={stage}"
                   )
+              resumed = api.restart_space(repo_id=space_id)
+              print(f"Requested paused Space resume for {space_id}; stage={resumed.stage}")
+              resume_deadline = time.monotonic() + 120
+              while time.monotonic() < resume_deadline:
+                  current = api.get_space_runtime(repo_id=space_id)
+                  stage = str(getattr(current.stage, "value", current.stage))
+                  repo_sha = str(api.repo_info(repo_id=space_id, repo_type="space").sha)
+                  print(
+                      f"recovery-resume stage={stage}, repo_sha={repo_sha}, "
+                      f"expected={expected_sha}"
+                  )
+                  if repo_sha != expected_sha:
+                      raise SystemExit("Space repository changed while leaving PAUSED")
+                  if stage.upper() != "PAUSED":
+                      if "ERROR" in stage.upper() or "STOPPED" in stage.upper():
+                          raise SystemExit(
+                              f"paused recovery resume failed before factory reboot: stage={stage}"
+                          )
+                      break
+                  time.sleep(5)
+              else:
+                  raise SystemExit("paused recovery did not leave PAUSED before factory reboot")
           runtime = api.restart_space(
               repo_id=space_id,
               factory_reboot=True,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,8 @@
   structured evidence 均在写入前失败，不 retry、不自动换 model，也不会 pause 原健康 Space。对已经
   containment 的 `PAUSED` transaction，新增 owner-only `recover-hf-space.yml`，精确绑定失败 run、
   paused/prior wrapper 与 source SHA，覆盖 settings-only、direct-parent wrapper advance 和 validated
-  recovery retry，完成 settings 重写、单次 factory reboot 和完整 smoke。Recovery 与 central release
+  recovery retry，完成 settings 重写、bounded resume barrier、单次 factory reboot 和完整 smoke。
+  Recovery 与 central release
   共用覆盖 assemble/publish 的全局 concurrency，并在 validate 与 mutation 前双重证明 RC5 tag/Release
   absent；新 transaction 在 mutation 前先持久化 machine intent，结合 primary/retry containment 与 live
   paused topology 绑定恢复状态，post outcome 仅作补充证据。Release/recovery 禁止 rerun，intent 上线前

--- a/docs/hf-space-cd.md
+++ b/docs/hf-space-cd.md
@@ -184,7 +184,9 @@ topology，因此 outcome runner/upload 失败不会锁死恢复入口。所有 
 Reusable HFS workflow 验证 Space 仍为 private/`PAUSED`，并只接受两个状态：Secret 写入后 wrapper 尚未
 前移的 `settings-only` 拓扑，或 paused wrapper **直接**继承 prior wrapper 且 pin failed candidate 的
 `wrapper-advanced` 拓扑。随后从获批 GitHub `hf` environment Secret source 重写完整 settings，以当前
-paused wrapper 为并发保护 parent 创建新 candidate wrapper，并直接执行一次 factory reboot，再完成完整
+paused wrapper 为并发保护 parent 创建新 candidate wrapper。Recovery 先用普通 restart 建立“已离开
+`PAUSED`”的有界 barrier，立即执行一次 factory reboot；它不等待第一次 build 完成，因此仍只有一次
+完整 900 秒 runtime takeover wait。之后再完成完整
 surface/capability/provenance smoke；任一步失败仍会重新 pause，且可用新失败 recovery receipt 再次前向
 恢复。`release-candidate.yml` 与 recovery 使用同一全局 concurrency group，锁覆盖标准 run 的 HFS、
 assemble 与 publish 全阶段，避免旧 evidence 与新 runtime 交叉发布。Recovery 成功只恢复到稳定 runtime，

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -1335,11 +1335,15 @@ def test_hfs_paused_recovery_is_owner_exact_state_and_action_driven() -> None:
     factory_restart = (
         "api.restart_space(\n              repo_id=space_id,\n              factory_reboot=True,"
     )
-    assert "api.restart_space(repo_id=space_id)" not in rebuild
+    normal_restart = "api.restart_space(repo_id=space_id)"
+    assert normal_restart in rebuild
     assert factory_restart in rebuild
-    assert rebuild.count("api.restart_space(") == 1
+    assert rebuild.index(normal_restart) < rebuild.index(factory_restart)
+    assert rebuild.count("api.restart_space(") == 2
+    assert rebuild.count("time.monotonic() + 120") == 1
     assert rebuild.count("time.monotonic() + 900") == 1
     assert "paused recovery must start from PAUSED" in rebuild
+    assert "paused recovery did not leave PAUSED before factory reboot" in rebuild
     assert "timeout-minutes: 25" in rebuild
 
     release = _workflow("release-candidate.yml")


### PR DESCRIPTION
## 结果与边界

为 paused recovery 增加一个 120 秒有界 resume barrier：先调用普通 `restart_space()` 并证明 Space 已离开 `PAUSED`、repo SHA 仍等于 promoted wrapper，随后立即调用一次 `factory_reboot=True`，最后只保留原有一次 900 秒 exact runtime takeover wait。

本 PR 尚未重新 dispatch recovery，也未手工修改 HF runtime。当前失败/运行中的 transaction 继续由原 Action fail-closed 处理。

## 真实问题

Recovery run `30559031605` 已证明以下步骤成功：owner/current-main provenance、selected Doubao live preflight、pre-mutation intent、Secret 同步和新 wrapper commit。随后 `factory_reboot=True` API step 成功返回，但 HF Space 持续保持 `PAUSED`，repo 已前移而 runtime 未启动；这说明仅依赖 factory 参数不能在当前平台状态下证明 pause 已解除。

## 变更

- paused recovery 先要求初始 stage 精确为 `PAUSED`。
- 普通 restart 后最多等待 120 秒，要求 stage 离开 `PAUSED`。
- barrier 期间持续验证 Space repo SHA 未被其他 writer 改变。
- `ERROR`/`STOPPED`、repo drift 或 barrier timeout 均 fail closed。
- 离开 pause 后立即 factory reboot，不等待第一次 build 完成；因此不是两个完整 build wait。
- 保留一个 900 秒 `RUNNING + repo SHA == runtime SHA == promoted wrapper` 终态 gate。

## 验证

- `pytest tests/test_release_candidate_workflows.py -q --tb=short`：`36 passed`
- `ruff check tests/test_release_candidate_workflows.py`：PASS
- `actionlint .github/workflows/deploy-hf-space.yml`：PASS
- `git diff --check`：PASS
- staged diff `gitleaks`：no leaks found

## Review focus

1. 普通 restart 是否只作为离开 `PAUSED` 的 barrier，而非第二次完整 build wait。
2. `repo_sha == expected_sha` 是否在 factory reboot 前持续保持。
3. 总预算是否仍受 `120s barrier + 900s takeover + setup` 约束并落在 25 分钟 job timeout 内。
