### PR TITLE
fix(release): 修复 Windows preflight 隔离环境与临时目录清理

### DIFF
--- a/scripts/hf_space_llm_preflight.py
+++ b/scripts/hf_space_llm_preflight.py
@@ -112,20 +112,25 @@ def load_preflight_config(encoded: str, api_key: str) -> SouWenConfig:
             config_path.write_text(decoded, encoding="utf-8")
             config_path.chmod(0o600)
             os.chdir(tmpdir)
-            with _isolated_environment(
-                {
-                    "HOME": tmpdir,
-                    "UNIAPI_API_KEY": api_key,
-                }
-            ):
+            try:
+                with _isolated_environment(
+                    {
+                        "HOME": tmpdir,
+                        "USERPROFILE": tmpdir,
+                        "UNIAPI_API_KEY": api_key,
+                    }
+                ):
+                    get_config.cache_clear()
+                    config = reload_config()
+            finally:
+                os.chdir(original_cwd)
                 get_config.cache_clear()
-                return reload_config()
+            return config
     except PreflightFailure:
         raise
     except Exception as exc:  # noqa: BLE001 - raw config errors must not escape to CI logs.
         raise PreflightFailure("invalid HFS LLM Search configuration") from exc
     finally:
-        os.chdir(original_cwd)
         get_config.cache_clear()
 
 

--- a/tests/test_hf_space_llm_preflight.py
+++ b/tests/test_hf_space_llm_preflight.py
@@ -68,6 +68,58 @@ def test_load_preflight_config_resolves_exact_gateway_references_without_env_lea
         )
 
 
+def test_load_preflight_config_provides_cross_platform_home(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_expanduser = preflight.Path.expanduser
+    observed_home: dict[str, str | None] = {}
+
+    def require_windows_home(path: preflight.Path) -> preflight.Path:
+        if str(path).startswith("~"):
+            observed_home["HOME"] = preflight.os.environ.get("HOME")
+            observed_home["USERPROFILE"] = preflight.os.environ.get("USERPROFILE")
+            if not observed_home["USERPROFILE"]:
+                raise RuntimeError("Windows home is unavailable")
+        return original_expanduser(path)
+
+    monkeypatch.setattr(preflight.Path, "expanduser", require_windows_home)
+
+    config = preflight.load_preflight_config(
+        _encoded_config(deepseek=False, doubao=True),
+        "secret-canary",
+    )
+
+    assert config.enabled_uniapi_ark_source_ids() == (DOUBAO_ID,)
+    assert observed_home["HOME"] == observed_home["USERPROFILE"]
+
+
+def test_load_preflight_config_restores_cwd_before_temp_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: preflight.Path,
+) -> None:
+    temp_root = tmp_path / "preflight-temp"
+
+    class GuardedTemporaryDirectory:
+        def __init__(self, *, prefix: str) -> None:
+            assert prefix == "souwen-hfs-llm-preflight-"
+            temp_root.mkdir()
+
+        def __enter__(self) -> str:
+            return str(temp_root)
+
+        def __exit__(self, *_args: object) -> None:
+            assert preflight.Path.cwd() != temp_root
+
+    monkeypatch.setattr(preflight.tempfile, "TemporaryDirectory", GuardedTemporaryDirectory)
+
+    config = preflight.load_preflight_config(
+        _encoded_config(deepseek=False, doubao=True),
+        "secret-canary",
+    )
+
+    assert config.enabled_uniapi_ark_source_ids() == (DOUBAO_ID,)
+
+
 @pytest.mark.parametrize(
     ("api_key", "base_url"),
     [


### PR DESCRIPTION
## 结果与发布边界

修复 RC5 full-matrix 在 Windows runner 上唯一失败的 HFS LLM preflight 配置测试。隔离环境现在同时提供 POSIX `HOME` 与 Windows `USERPROFILE`，并在 `TemporaryDirectory` 清理前恢复原 cwd，避免 Windows 对当前目录的占用错误。

失败的 release run `30561579910` 不会 rerun，也没有创建 `v2.0.0rc5` tag 或 GitHub Release。当前 HFS 继续运行已验证的 `f06beeb6` source；本 PR 仅修复跨平台测试与 preflight 隔离，不触发 HFS mutation 或发布。

## 根因

两个独立 Windows 3.11 full-matrix job 都在同一测试失败：

- 清空 runner environment 后只设置 `HOME`，Windows `Path.expanduser()` 无法确定 home directory。
- 异常退出 `TemporaryDirectory` 时 cwd 仍位于该目录，Windows 随后因目录仍被进程占用而报 `WinError 32/5`。

Linux/macOS 允许 `HOME` 且可删除当前目录，因此 ordinary fast CI 未暴露这两个 Windows 语义差异。

## 变更

- `load_preflight_config()` 的最小隔离环境新增 `USERPROFILE=<temporary directory>`；不恢复其他 runner environment，也不放宽 unmanaged `${VAR}` 拒绝规则。
- 在临时目录 context 退出前恢复原 cwd，并保持 `get_config` cache 清理。
- 新增两个确定性回归测试，分别模拟 Windows home resolution 与禁止清理当前 cwd 的约束。

## 验证

修复前的新回归测试：`2 failed, 11 passed`，精确覆盖两个 Windows 症状。

本地修复后：

- `pytest tests/test_hf_space_llm_preflight.py -q --tb=short`：`13 passed`
- `pytest tests/ -q --tb=short`：`2801 passed, 2 skipped`
- `ruff check src tests scripts tools`：PASS
- `ruff format --check src tests scripts tools`：918 files already formatted
- `python3 -m compileall -q scripts/hf_space_llm_preflight.py tests/test_hf_space_llm_preflight.py`：PASS
- `git diff --check`：PASS
- staged `gitleaks`：no leaks found

Exact-head GitHub Actions：

- CI full dispatch `30562963514`：success；Windows `2801 passed, 2 skipped`
- V2 CI full dispatch `30562967537`：success；Windows `2801 passed, 2 skipped`
- Windows 上原失败测试和两个新增回归测试均 PASS
- ordinary PR CI、V2 CI、CodeQL 与 HF Space local gates：success

本 PR 尚未合并，也未重新 dispatch release；合并后仍需新的 exact-main Actions 与全新标准 release run。

## Review focus

1. `USERPROFILE` 是否仅用于跨平台 home resolution，且不会把 runner secrets/environment 带回配置解析。
2. cwd 是否在 `TemporaryDirectory.__exit__` 前恢复，且异常路径仍清理 config cache。
