### PR TITLE
chore: retire stale automation docs and reduce Dependabot noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,12 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 3
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "dependencies"
       - "backend"
@@ -19,7 +24,12 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 3
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "dependencies"
       - "frontend"
@@ -32,7 +42,12 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 2
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "dependencies"
       - "ci"

--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -486,9 +486,10 @@ jobs:
           | Provider runtime profile | $PROVIDER_RUNTIME_RESULT | provider imports, doctor, fetch handlers, and browser variant declarations |
           | Panel build | $PANEL_RESULT | TypeScript, Vitest, single-file panel artifact |
 
-          External smoke, HF Space deploy, and binary build remain outside
-          automatic V2 CI. Run them manually or through tag/release workflows
-          before cutting a release candidate tag.
+          HF Space deploy and binary build remain outside automatic V2 CI.
+          Use the central release-candidate workflow for current release evidence.
+          External provider/runtime checks are separate, explicitly approved evidence
+          and are not part of automatic V2 CI or the current release contract.
           EOF
 
           if [ "$FULL_LANE" = "true" ]; then

--- a/docs/internal/development-branching.md
+++ b/docs/internal/development-branching.md
@@ -43,9 +43,9 @@ bottom of the remaining stack:
 2. Retarget the next Draft PR to `main` and verify that its head SHA and isolated
    diff are unchanged.
 3. After maintainer approval, mark that PR ready for review. Main-targeted CI,
-   V2 CI, HF Space local gates, and path-applicable External Smoke gates include
-   the `ready_for_review` activity so this transition creates fresh PR-context
-   evidence. Retargeting alone is not gate evidence.
+   V2 CI, and path-applicable HF Space local gates include the `ready_for_review`
+   activity so this transition creates fresh PR-context evidence. Retargeting alone
+   is not gate evidence.
 4. Require applicable checks and review on the exact head before selecting the
    merge-commit method. Read back the resulting `main` merge commit before
    continuing with the next layer.
@@ -104,10 +104,10 @@ Since 2026-07-26 both workflows run in two lanes (owner-approved CI slimming):
 - panel build: TypeScript check, Vitest, single-file panel build, and
   `src/souwen/server/panel.html` artifact validation.
 
-External smoke, HF Space local preflight, the RC5 Server bundle builder, and
-secret-backed checks keep their dedicated reusable/manual/schedule entrypoints.
-They should not be folded into every ordinary PR. Normal remote HFS promotion and
-GitHub publication are coordinated only by `release-candidate.yml`. The owner-only
+HF Space local preflight, the RC5 Server bundle builder, and secret-backed checks
+keep their dedicated workflow entrypoints. They should not be folded into every
+ordinary PR. Normal remote HFS promotion and GitHub publication are coordinated
+only by `release-candidate.yml`. The owner-only
 `recover-hf-space.yml` entrypoint may only forward-recover an exact, previously contained
 `PAUSED` transaction; it cannot publish and does not replace a fresh central release run.
 External transaction runs (`deploy_hfs=true` or `publish=true`) share

--- a/docs/internal/testing-playbook.md
+++ b/docs/internal/testing-playbook.md
@@ -45,8 +45,7 @@
 - [ ] `push.paths` 或 changes gate 覆盖相关源码、脚本、依赖文件和 workflow。
 - [ ] secret-backed job 挂 GitHub Environment。
 - [ ] fork PR 不运行 secret-backed job。
-- [ ] nightly / release gate 类 job 接入 `External Smoke Gate` 或说明为什么不接入。
-- [ ] nightly failure 能创建或更新带 `ci:external` / `smoke-failure` label 的 issue。
+- [ ] 外部 live 验证使用当前保留的 workflow 或经明确批准的手动路径。
 
 ## 4. 更新文档
 
@@ -64,38 +63,11 @@
 - [ ] 远端 PR checks 回读确认对应 job 通过。
 - [ ] 对 nightly / release gate，确认 schedule / tag / manual 入口不会静默遗忘。
 
-## 6. v2 release gate 证据
+## 6. 发布证据
 
-v2 release candidate 进入最终 tag 或发布前，必须手动触发一次 `External Smoke Gate`：
-
-- `workflow_dispatch` 选择 `suite=release`。
-- 触发 ref 必须是候选 head、release branch head 或最终 tag 对应 head。
-- `Scrapling release/nightly gate` 与 `Crawl4AI release/nightly gate` 均为
-  `success`。
-- 下载并保留 JSON + Markdown artifact；PR 或 release checklist 中记录 run URL、
-  head SHA、suite、结论和 artifact 名称。
-
-这项证据不替代 `V2 CI`，也不要求每个普通 PR 自动跑 release suite。
-它只用于证明发布候选头在真实外部 runtime gate 上可用。
-
-## 迁移示例：Scrapling
-
-Scrapling 属于 PR required functional check：
-
-- pytest 保留 provider 注册、配置和 mock 契约。
-- `scripts/scrapling_functional_check.py` 验证真实 `scrapling.fetchers` import、本地 fixture 抓取和 browser dynamic 抓取。
-- CI 显式执行 `scrapling install`。
-- CI 上传 `scrapling-functional.json` 和 `scrapling-functional.md`。
-
-## 迁移示例：Crawl4AI
-
-Crawl4AI 属于 PR required functional check：
-
-- pytest 保留 handler 注册、参数派发和错误聚合契约。
-- `scripts/crawl4ai_functional_check.py` 验证真实 `crawl4ai.AsyncWebCrawler` import 和本地 fixture browser 抓取。
-- 脚本本地默认允许缺 runtime 时 `SKIP`，CI 使用 `--require-runtime` 把缺 browser runtime 或启动失败提升为 `FAIL`。
-- CI 显式执行 `python -m playwright install --with-deps chromium`，不把 browser 安装隐藏在 Python 脚本里。
-- CI 上传 `crawl4ai-functional.json` 和 `crawl4ai-functional.md`。
+发布候选的正式门禁以 `.github/workflows/release-candidate.yml` 和
+`docs/internal/rc-readiness-gates.md` 为准。外部 provider/runtime 验证只在明确批准的环境中
+独立执行，不属于普通 PR 或当前发布 contract。
 
 ## 迁移示例：HF Space smoke
 
@@ -106,23 +78,3 @@ HF Space smoke 属于 deploy smoke / release gate：
 - `--json-report` / `--markdown-report` 作为统一 CLI alias，兼容原有 `--json-file` / `--report-file`。
 - 本地可用 `--mode offline` 验证 report 写入，不触碰真实 HF Space endpoint。
 - `HF Space CD` 上传 surface / capability 两类 JSON + Markdown artifact；JSON 是 source of truth，Markdown 只用于排障阅读。
-
-## 迁移示例：Zero-key live sources
-
-Zero-key live sources 属于 nightly / release gate：
-
-- pytest 保留 Google Patents / Wayback 的 parser、SSRF guard、registry 和 mock HTTP 契约。
-- `scripts/zero_key_functional_check.py` 在 `--mode live` 下真实探测 Google Patents search、Wayback Availability API 和 CDX API；当 Availability API 没有 closest 但同 URL 的 CDX 200 快照可证明有存档时，availability check 以 `cdx_fallback` 通过。
-- 本地默认 `--mode offline`，只验证 report 写入，不触碰真实外部服务。
-- live 模式默认把外部波动记录为 `WARN`；release / tag gate 使用 `--required` 把失败提升为 `FAIL`。
-- `External Smoke Gate` 在非 PR 事件运行该 job，避免高波动 live 源阻断普通 PR。
-
-## 迁移示例：External Smoke Gate
-
-`External Smoke Gate` 承担 nightly / release gate 治理：
-
-- `workflow_dispatch` 用于手动验证外部 gate。
-- `schedule` 每天 02:17 Asia/Shanghai 自动运行；失败时创建或更新 `ci:external` / `smoke-failure` issue，恢复后自动关闭。
-- tag `v*` 触发 release gate，发版前串行确认外部 runtime gate。
-- gate job 复用专项脚本，不在 workflow 中重新定义测试语义。
-- gate artifact 使用 `external-gate-*-report` 命名，保留 JSON + Markdown 报告 14 天。


### PR DESCRIPTION
## Summary

- remove retired External Smoke Gate and automated failure-Issue guidance from current internal documentation
- align the V2 CI summary with the current release contract without changing workflow behavior
- group minor and patch Dependabot updates and lower per-ecosystem open PR limits while retaining pip, npm, and GitHub Actions updates

## GitHub cleanup

- removed the unused ci:external and smoke-failure labels after confirming no open Issue or PR uses them
- reviewed all seven open Dependabot PRs; all remain open because they are distinct, current, and mergeable

## Validation

- git diff --check
- YAML parse for dependabot.yml and v2-ci.yml
- static Dependabot ecosystem, schedule, grouping, and limit assertions
- targeted retired-automation reference searches
- pytest tests/test_release_candidate_workflows.py::test_rc5_release_gate_contract_matches_control_plane -q

No business code changed. Database tests, full test suites, E2E, Docker, and external smoke were not run.